### PR TITLE
feat(qwen3.6): add 27B dense FP8 recipes (no-MTP and MTP variants)

### DIFF
--- a/recipes/qwen3.6/qwen3.6-27b-dense-fp8-atlas.yaml
+++ b/recipes/qwen3.6/qwen3.6-27b-dense-fp8-atlas.yaml
@@ -1,0 +1,31 @@
+recipe_version: "2"
+model: Qwen/Qwen3.6-27B-FP8
+runtime: atlas
+container: avarok/atlas-gb10:latest
+max_nodes: 1
+
+metadata:
+  description: |
+    Qwen3.6-27B (dense, native FP8) on the Atlas runtime. FP8 weights
+    paired with BF16 KV — FP8/NVFP4 KV breaks dense attention here
+    (request timeouts, CUDA graph thrash). max_model_len capped at
+    60_000 so the full spark-arena-v2 concurrency=10 sweep fits in the
+    KV pool on a single GB10; cells at depth=65535/100000 in
+    spark-arena-v2 will be skipped because they exceed max_model_len.
+    Use --tp 2 / EP=2 to get the full long-context sweep. No MTP.
+  maintainer: avarok
+  category: chat
+  model_params: 27B
+  model_dtype: fp8
+  quantization: fp8
+  kv_dtype: bf16
+
+defaults:
+  port: 8888
+  host: 0.0.0.0
+  max_model_len: 60000
+  kv_cache_dtype: bf16
+  gpu_memory_utilization: 0.88
+  scheduling_policy: slai
+  speculative: false
+  enable_prefix_caching: true

--- a/recipes/qwen3.6/qwen3.6-27b-dense-fp8-mtp-atlas.yaml
+++ b/recipes/qwen3.6/qwen3.6-27b-dense-fp8-mtp-atlas.yaml
@@ -1,0 +1,34 @@
+recipe_version: "2"
+model: Qwen/Qwen3.6-27B-FP8
+runtime: atlas
+container: avarok/atlas-gb10:latest
+max_nodes: 1
+
+metadata:
+  description: |
+    Qwen3.6-27B (dense, native FP8) on the Atlas runtime, with the
+    upstream-bundled MTP draft head (mtp.safetensors, FP8 e4m3 linear +
+    BF16 norms) enabled for K=2 speculative decoding. KV stays BF16
+    (FP8/NVFP4 KV breaks dense attention — request timeouts + CUDA
+    graph thrash). max_model_len capped at 60_000 so the full
+    spark-arena-v2 concurrency=10 sweep fits in the KV pool on a
+    single GB10; cells at depth=65535/100000 in spark-arena-v2 will be
+    skipped because they exceed max_model_len. Use --tp 2 / EP=2 to
+    get the full long-context sweep.
+  maintainer: avarok
+  category: chat
+  model_params: 27B
+  model_dtype: fp8
+  quantization: fp8
+  kv_dtype: bf16
+
+defaults:
+  port: 8888
+  host: 0.0.0.0
+  max_model_len: 60000
+  kv_cache_dtype: bf16
+  gpu_memory_utilization: 0.88
+  scheduling_policy: slai
+  speculative: true
+  mtp_quantization: fp8
+  enable_prefix_caching: true


### PR DESCRIPTION
## Summary
- Add `qwen3.6-27b-dense-fp8-atlas.yaml` — native FP8 weights, BF16 KV, 60K context, no speculative decoding.
- Add `qwen3.6-27b-dense-fp8-mtp-atlas.yaml` — same base config plus the upstream-bundled MTP head (`mtp.safetensors`, FP8 e4m3 linear + BF16 norms) for K=2 speculative decoding.

The MTP recipe depends on Atlas runtime support for **dense** MTP heads (i.e. non-MoE FFN inside the MTP layer). That support is added in companion Atlas PR `feat/qwen35-dense-mtp` — until that lands and a new alpha image is published, the MTP recipe will just silently fall back to greedy decoding (the runtime warns when `--speculative` is set without loadable MTP weights).

Both recipes deliberately pin BF16 KV: FP8/NVFP4 KV breaks Qwen3.6 dense attention on Atlas (request timeouts + CUDA graph thrash). Long-context beyond 60K still requires `--tp 2` / EP=2.

## Test plan
- [ ] Atlas PR `feat/qwen35-dense-mtp` lands and ships in next alpha.
- [ ] `sparkrun benchmark run recipes/qwen3.6/qwen3.6-27b-dense-fp8-atlas.yaml --profile spark-arena-v2` baseline (no MTP) — already running on dgx2.
- [ ] `sparkrun benchmark run recipes/qwen3.6/qwen3.6-27b-dense-fp8-mtp-atlas.yaml --profile spark-arena-v2` head-to-head — pending Atlas-side merge.