### PR TITLE
feat(qwen3.6): add Qwen3.6-35B-A3B-NVFP4 + MTP Atlas recipe

### DIFF
--- a/recipes/qwen3.6/qwen3.6-35b-a3b-nvfp4-atlas.yaml
+++ b/recipes/qwen3.6/qwen3.6-35b-a3b-nvfp4-atlas.yaml
@@ -1,0 +1,29 @@
+recipe_version: "2"
+model: RedHatAI/Qwen3.6-35B-A3B-NVFP4
+runtime: atlas
+container: avarok/atlas-gb10:latest
+max_nodes: 1
+
+metadata:
+  description: |
+    Qwen3.6-35B-A3B (RedHatAI NVFP4) with MTP K=2 on the Atlas runtime.
+    Mirrors the qwen3.5-35b-a3b-nvfp4 recipe but uses the qwen3_5_moe
+    architecture from Qwen3.6, served on a single GB10. NVFP4 weights +
+    NVFP4 KV cache + NVFP4 MTP-quantized draft head.
+  maintainer: avarok
+  category: agent
+  model_params: 35B
+  model_dtype: nvfp4
+  quantization: nvfp4
+  kv_dtype: nvfp4
+
+defaults:
+  port: 8888
+  host: 0.0.0.0
+  max_model_len: 131072
+  kv_cache_dtype: nvfp4
+  gpu_memory_utilization: 0.88
+  scheduling_policy: slai
+  speculative: true
+  mtp_quantization: nvfp4
+  enable_prefix_caching: true


### PR DESCRIPTION
## Summary

Adds the Atlas recipe for `RedHatAI/Qwen3.6-35B-A3B-NVFP4` with the upstream-bundled MTP K=2 draft head. Mirrors the existing `qwen3.5-35b-a3b-nvfp4` recipe; only the model id changes (`qwen3_5_moe` arch is identical) and `max_model_len` is bumped to 131072 so the full `spark-arena-v2` depth sweep up to 100k fits.

## Result (live-validated on a single GB10)

`sparkrun benchmark run recipes/qwen3.6/qwen3.6-35b-a3b-nvfp4-atlas.yaml --profile spark-arena-v2 --port 8888`

- **Decode @ tg=128, pp=2048, depth=0, concurrency=1: 214.59 tok/s (4.66 ms TPOT)**
- **vs current Spark Arena leaderboard #6 (Qwen3.6-35B-A3B-NVFP4 on vLLM): 77.07 tok/s → 2.78× speedup**
- 25/28 cells in the heat-aware schedule produced clean arena-valid run JSONs
- 3 cells (d=4096,c=1 etc.) hit an Atlas-side hang on \`avarok/atlas-gb10:latest\`; recoverable via \`sparkrun benchmark resume bench_b9efdca5fa68\`

## Reproducibility

- Image: \`avarok/atlas-gb10:latest\` (stock public)
- Model: \`RedHatAI/Qwen3.6-35B-A3B-NVFP4\` (stock public)
- Sparkrun: v0.2.31 (PyPI)
- No engine patches required

## Test plan
- [x] \`sparkrun show recipes/qwen3.6/qwen3.6-35b-a3b-nvfp4-atlas.yaml\` parses
- [x] \`sparkrun benchmark run … --profile spark-arena-v2\` produces consolidated.json with 25 cells
- [x] Result beats every NVFP4 entry on the current Spark Arena leaderboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)