### PR TITLE
fix(qwen3.5): cap batch so default NVFP4 35B recipe doesn't OOM

### DIFF
--- a/recipes/qwen3.5/qwen3.5-35b-a3b-nvfp4.yaml
+++ b/recipes/qwen3.5/qwen3.5-35b-a3b-nvfp4.yaml
@@ -20,9 +20,19 @@ defaults:
   port: 8888
   host: 0.0.0.0
   max_model_len: 8192
+  # Cap concurrent decode batch. Without this Atlas defaults to
+  # max_batch_size=8, and the inference-buffer + SSM-pool + GDN
+  # chunked-prefill preallocation scales with max_seq_len x batch
+  # (8192 x 8), needing ~9.35 GB before weights load — more than the
+  # free GPU slice at gpu_memory_utilization 0.88, so `sparkrun run
+  # @atlas/qwen3.5-35b-a3b-nvfp4` fails preflight out of the box.
+  # 8192 x 2 keeps the full context while fitting the budget.
+  max_batch_size: 2
+  max_num_seqs: 2
   kv_cache_dtype: fp8
   gpu_memory_utilization: 0.88
   scheduling_policy: slai
   speculative: true
   mtp_quantization: bf16
   enable_prefix_caching: true
+  oom_guard_mb: 1024


### PR DESCRIPTION
## Problem
`sparkrun run @atlas/qwen3.5-35b-a3b-nvfp4` — the **default** recipe with no overrides — fails preflight out of the box on a single GB10 (reported by a community user):

> Error: Preflight failed: inference buffers alone need 9.35 GB but only 6.92 GB is free on the GPU (before weights load). SSM pool + GDN chunked prefill scales with `--max-seq-len=8192 × --max-batch-size=8`.

## Root cause
The recipe set `max_model_len: 8192` but **no `max_batch_size`**, so Atlas fell back to its default `max_batch_size=8`. Inference-buffer + SSM-pool + GDN chunked-prefill preallocation scales with `max_seq_len × batch` (8192 × 8 = 65536 tokens), needing ~9.35 GB before weights load — more than the free slice at `gpu_memory_utilization 0.88`.

## Fix
Cap `max_batch_size`/`max_num_seqs` at 2 (a 4× reduction → ~2.3 GB buffers) while **preserving the full 8192 context**, and add `oom_guard_mb: 1024`. This mirrors the tight-budget convention already merged in `qwen3.5-122b-a10b-nvfp4-single.yaml` (`max_batch_size`, `max_num_seqs`, `oom_guard_mb`). YAML validated with PyYAML.

A default recipe should never OOM on its target hardware; this makes it serve out of the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)