### PR TITLE
recipes(qwen3.6-27b): BFCL-ST benchmark reference config (SSOT)

### DIFF
--- a/recipes/qwen3.6/qwen3.6-27b-benchmark-bfcl-st.yaml
+++ b/recipes/qwen3.6/qwen3.6-27b-benchmark-bfcl-st.yaml
@@ -1,0 +1,72 @@
+recipe_version: "2"
+model: unsloth/Qwen3.6-27B-NVFP4
+runtime: atlas
+container: avarok/atlas-gb10:latest
+max_nodes: 1
+
+metadata:
+  description: |
+    Qwen3.6-27B (unsloth uniform NVFP4) — reference serve config for the
+    BFCL v4 single-turn accuracy benchmark on a single GB10. This is the
+    SSOT for "what flags were the BFCL-ST numbers measured with" so it
+    never has to be reverse-engineered from session logs again.
+
+    TWO CONFIG LESSONS baked in (both learned the hard way, 2026-07-03):
+      1. tool_call_parser = qwen3_coder (auto-detected; DO NOT pass
+         --tool-call-parser hermes). Hermes' trigger never matches this
+         model's native XML tool-call format, so the XGrammar grammar
+         never engages and parallel/extraction collapses. Auto-selection
+         picks qwen3_coder, which engages constrained decoding.
+      2. Tool grammar ON (do NOT set --disable-tool-grammar). Grammar-off
+         emits only ONE call for a multi-call ("parallel") request.
+         Grammar-on emits all calls correctly — but is ONLY safe on a
+         build carrying Avarok-Cybersecurity/atlas #231 (b87bd483+),
+         which fixed the never-terminating-grammar EOS bug (pre-#231,
+         grammar-on tool turns ran on to 600-800 tokens / finish=length).
+      3. KV = BF16 (NOT fp8). FP8 KV degrades this NVFP4 model; BF16 gave
+         the best stable simple_python and is the safer default.
+
+    RESULTS (merged main b87bd483, seed 42, subset simple_python+parallel,
+    ~24/subset, this config):
+      simple_python 87.50   parallel 0.00*   overall 58.33
+    Historical full ST-995 reference (Jun 15, code 5838c8cf, OLD harness
+    4f2a21d): overall 89.04, simple_python 95.65, parallel 95.65.
+
+    *IMPORTANT — the parallel BFCL number is currently UNRELIABLE and is
+    NOT a model signal. A direct (non-harness) request on this exact
+    config emits 3 correct parallel calls (Paris/Berlin/Tokyo, indices
+    0/1/2, finish=tool_calls), but the harness scorer (endpoints
+    6a2894c "merge streaming tool-call deltas") mis-merges/rejects them
+    and captures markup (</parameters>) into argument values. Trust
+    simple_python; treat parallel as blocked on the harness scorer fix.
+    The Jun15->now drop is a harness/dataset confound (dataset re-hosted
+    to MLCommons R2 via endpoints cf1b932; scorer changed via 6a2894c;
+    harness 4f2a21d -> 8ba5298), NOT an Atlas code regression: the Jun15
+    binary under its own config scores parallel 0.00 today too.
+
+    Harness: inference-endpoint benchmark from-config
+      --config <edge-agentic>/bfcl_st_pr223.yaml --accuracy-only --seed 42
+    (full ST-995; use a subsets:[...] + sample_pct override for fast
+    config A/Bs per the benchmark-subset convention).
+  maintainer: avarok
+  category: agent
+  model_params: 27B
+  model_dtype: nvfp4
+  quantization: nvfp4
+  kv_dtype: bf16
+
+defaults:
+  port: 8903
+  host: 0.0.0.0
+  max_model_len: 32768
+  max_batch_size: 1
+  kv_cache_dtype: bf16
+  gpu_memory_utilization: 0.85
+  speculative: true
+  num_drafts: 1
+  mtp_quantization: bf16
+  enable_prefix_caching: true
+  ssm_cache_slots: 64
+  disable_thinking: true
+  # tool_call_parser: intentionally UNSET -> auto-detects qwen3_coder.
+  # tool grammar: intentionally left ON (do not disable).

--- a/recipes/qwen3.6/qwen3.6-27b-nvfp4-prefill-record.yaml
+++ b/recipes/qwen3.6/qwen3.6-27b-nvfp4-prefill-record.yaml
@@ -1,0 +1,60 @@
+recipe_version: "2"
+model: nvidia/Qwen3.6-27B-NVFP4
+runtime: atlas
+container: avarok/atlas-gb10:latest
+max_nodes: 1
+
+metadata:
+  description: |
+    Qwen3.6-27B (dense, NVIDIA mixed-precision NVFP4: MLP W4A16_NVFP4 gs16,
+    attn/GDN projections FP8) with the 2026-07-02 prefill record stack.
+    Cold prefill measured on a single GB10, solo, coherence 10/10:
+      2k 1088 / 4k 1077 / 8k 1057 / 16k 982 / 29k 911 tok/s
+    (1.24-1.75x llama.cpp Q4_K_M on identical prompts/probes; 16k TTFT
+    28.6s -> 16.3s vs the pre-record baseline). Warm multi-turn TTFT
+    median 2217-2253 ms via tail SSM checkpoints (beats llama.cpp's 2401
+    on the identical 22-turn driver).
+
+    REQUIRES a build carrying Avarok-Cybersecurity/atlas PR #223
+    (perf/qwen36-27b-prefill-nvfp4: attn transposed-NVFP4 routing,
+    ATLAS_FFN_NVFP4_MMQ, FlashInfer-GDN AOT bridge, tail SSM
+    checkpoints). Not yet in a tagged container release — until then,
+    build the branch with ATLAS_TARGET_MODEL=qwen3.6-27b
+    ATLAS_TARGET_QUANT=nvfp4.
+
+    Env stack (the record configuration; each flag is opt-in and
+    independently coherence-gated 10/10):
+      ATLAS_FFN_NVFP4_MMQ=1     # vendored llama Blackwell FP4 block-scale
+                                # MMQ for FFN gate/up (80 TFLOP/s vs 51)
+      ATLAS_GDN_REGRESIDENT=1   # register-resident GDN warm replay
+      ATLAS_GDN_FLASHINFER=1    # FlashInfer GDN chunked prefill (+17-20%)
+      ATLAS_GDN_LIB=<repo>/3rdparty_patches/gdn_aot/libatlasgdn.so
+      CUTE_DSL_ARCH=sm_121a
+      LD_LIBRARY_PATH must include the cute-dsl runtime
+      (nvidia_cutlass_dsl/lib) and the CUDA libs.
+
+    Checkpoint-interval note: with the tail-SSM-checkpoint fix, prefill
+    chunks stay full-size at EVERY interval (the old interval=16
+    256-token micro-chunking is gone) and warm restores work even at
+    interval 0; 16 remains a good default for branchy/partial-prefix
+    reuse.
+  maintainer: avarok
+  category: agent
+  model_params: 27B
+  model_dtype: nvfp4
+  quantization: nvfp4
+  kv_dtype: fp8
+
+defaults:
+  port: 8888
+  host: 0.0.0.0
+  max_model_len: 36864
+  max_batch_size: 1
+  kv_cache_dtype: fp8
+  kv_high_precision_layers: auto
+  gpu_memory_utilization: 0.72
+  enable_prefix_caching: true
+  ssm_cache_slots: 256
+  ssm_checkpoint_interval: 16
+  tool_call_parser: hermes
+  disable_thinking: true

--- a/recipes/qwen3.6/qwen3.6-35b-a3b-fp8-mtp.yaml
+++ b/recipes/qwen3.6/qwen3.6-35b-a3b-fp8-mtp.yaml
@@ -55,6 +55,13 @@ defaults:
   # Gate 2026-06-11: webserver_ok 10/10, zero path-drift, median run
   # ~125s with caching ON + MTP K=2 (image digest 637e7b32).
   enable_prefix_caching: true
+  # ssm_cache_slots MUST be pinned: the Marconi slot pool is an LRU region and
+  # the built-in default (16) churns under multi-turn agentic load (~4-6 snapshot
+  # saves/turn at 17k ctx) — the fresh tail/leaf checkpoint gets evicted before the
+  # next turn's lookup ("Prefix cache hit: N tokens but no SSM snapshot" → full SSM
+  # recompute, warm TTFT 15s+). Diagnosed 2026-07-02 (webserver_ok gate, snapshot-id
+  # recycling 10/13/13/10 in the serve log). 256 holds a full session comfortably.
+  ssm_cache_slots: 256
   # bf16 lm-head: the 248K-vocab projection stays full-precision (the
   # single largest per-token weight read). Argmax over the vocab is exact.
   lm_head_dtype: bf16


### PR DESCRIPTION
Adds `qwen3.6-27b-benchmark-bfcl-st.yaml` — the validated serve config for the BFCL v4 single-turn benchmark, so we never reverse-engineer the flags from session logs again (this is exactly the gap that caused the #238 confound: the Jun-15 89.04 config was never in a recipe).

Encodes the two hard-won config lessons from the #238 bisect:
- **qwen3_coder parser** (auto-detected; do NOT pass `--tool-call-parser hermes` — hermes never engages the grammar on this model's native format).
- **tool grammar ON** (grammar-off emits only 1 call for parallel requests) — safe only on builds with atlas #231.
- **BF16 KV** (fp8 KV degrades this NVFP4 model).

Results + the harness/scorer confound (dataset re-host + streaming-delta scorer change making the parallel number unreliable) are documented inline in the recipe description. Full bisect writeup in Avarok-Cybersecurity/atlas#238.