### PR TITLE
Add DFlash speculative-decode recipes for Qwen3.6-27B-NVFP4

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ image — pull a newer `avarok/atlas-gb10:dev`.
 |---|---|---|---|
 | `qwen3.6-35b-a3b-nvfp4` | nvidia/Qwen3.6-35B-A3B-NVFP4 | single | **DEFAULT 35B** — MTP K=1 (pinned; 116.5 tok/s), calibrated fp8 KV (128K), qwen3_coder agentic stack; requires :dev ≥ 2026-07-10 (atlas#287) |
 | `qwen3.6-27b-nvfp4` | nvidia/Qwen3.6-27B-NVFP4 | single | **DEFAULT 27B** — dense hybrid SSM+Attn, MTP K=1 (pinned), bf16 KV, qwen3_coder agentic stack; requires :dev ≥ 2026-07-10 (atlas#287) |
+| `qwen3.6-27b-nvfp4-dflash` | nvidia/Qwen3.6-27B-NVFP4 | single | **DFlash - balanced (default).** EAGLE drafter + fused GDN verify, spec-through-think + adaptive. ~20-25 code / ~15 prose parity. Approx-lossless (NOSPEC for byte-exact). Requires a DFlash-carrying image. |
+| `qwen3.6-27b-nvfp4-dflash-safe` | nvidia/Qwen3.6-27B-NVFP4 | single | **DFlash - conservative.** Answer-body spec only, adaptive on. ~20 code / ~15.4 prose parity, no coherence risk, never below serial. |
+| `qwen3.6-27b-nvfp4-dflash-code` | nvidia/Qwen3.6-27B-NVFP4 | single | **DFlash - code peak.** Spec-through-think, adaptive off (no serial fallback). ~29.9 code; prose net-negative. Code-heavy only. |
 | `qwen3.6-35b-a3b-fp8-mtp` | Qwen/Qwen3.6-35B-A3B-FP8 | single | Flagship FP8 — native FP8, bf16 head + bf16 KV, 64K ctx, MTP K=2, live tool-call streaming |
 | `qwen3.6-35b-a3b-fp8-bf16head` | Qwen/Qwen3.6-35B-A3B-FP8 | single | 32K safe profile of the FP8 flagship (same bf16 head/KV) |
 | `qwen3.6-35b-a3b-fp8-nvfp4head` | Qwen/Qwen3.6-35B-A3B-FP8 | single | nvfp4 lm-head sibling — near-neutral wall, lower VRAM |

--- a/recipes/qwen3.6/qwen3.6-27b-nvfp4-dflash-code.yaml
+++ b/recipes/qwen3.6/qwen3.6-27b-nvfp4-dflash-code.yaml
@@ -51,6 +51,9 @@ defaults:
   kv_cache_dtype: bf16
   gpu_memory_utilization: 0.85
   enable_prefix_caching: true
+  # tool_call_parser / disable_tool_grammar inherited from the qwen3.6-27b-nvfp4
+  # default; NOT independently validated with DFlash (spec-decode benches use no
+  # tool calls). Note atlas #231 may favor grammar-on for parallel calls.
   tool_call_parser: qwen3_coder
   disable_tool_grammar: true
 

--- a/recipes/qwen3.6/qwen3.6-27b-nvfp4-dflash-code.yaml
+++ b/recipes/qwen3.6/qwen3.6-27b-nvfp4-dflash-code.yaml
@@ -1,0 +1,68 @@
+# CONFIRM before publish: the container tag that carries the DFlash binary + drafter.
+# Schema VERIFIED 2026-07-13 vs sparkrun runtimes/atlas.py: dflash (bool flag),
+# draft_model + dflash_gamma (flag map), and the env: block are all supported keys.
+recipe_version: "2"
+model: nvidia/Qwen3.6-27B-NVFP4
+runtime: atlas
+container: avarok/atlas-gb10:dev        # CONFIRM: tag that actually carries DFlash
+max_nodes: 1
+
+metadata:
+  description: |
+    Qwen3.6-27B (nvidia modelopt NVFP4, dense hybrid SSM+Attn) with DFlash
+    speculative decoding - BOUTIQUE / code-peak. WICKED FAST on code, MOST caveats.
+    EAGLE-style external drafter with fused GDN K=gamma verify. Spec-through-think
+    ON and adaptive suspend OFF: forces the spec path with NO serial fallback.
+    Optimal for code-heavy workloads ONLY.
+
+    Measured - GB10 single-user, temp=0, MinHeap code / Volvo prose:
+    - Code:  ~29.9 tok/s (fastest; reproduced r1/r2, tau ~7-8)
+    - Prose: ~12.9 tok/s (NET-NEGATIVE vs serial 15.3 - no safety net)
+
+    Output fidelity (applies to ALL DFlash profiles):
+    - DFlash is a legitimate SAMPLING speculative decoder; this build's fused GDN
+      verify has a small numerics gap -> APPROXIMATELY, not exactly, distribution-
+      preserving.
+    - At temp=0, NOT byte-exact vs base-model greedy - with spec-through-think ON,
+      an early low-margin flip compounds into a different but valid/coherent
+      trajectory. Use NOSPEC (or -safe) for byte-exact output.
+    - At temp>0, divergence is ordinary sampling variance; quality unaffected.
+
+    max_tokens: caps CONTENT (enforced on the spec path); thinking tokens are free,
+    so total completion exceeds max_tokens (standard for reasoning models, not
+    runaway generation).
+
+    WHY "MOST caveats" - carries all of -dflash's caveats PLUS the adaptive-off cost:
+    - ADAPTIVE OFF = NO serial fallback. On prose / low-accept prompts it goes
+      net-negative (12.9 < 15.3 serial) and has no suspend to rescue it. Do NOT use
+      as a general-purpose default. Code-heavy workloads only.
+  maintainer: rstesiak
+  category: agent
+  model_params: 27B
+  model_dtype: nvfp4
+  quantization: nvfp4
+  kv_dtype: bf16
+
+defaults:
+  port: 8888
+  host: 0.0.0.0
+  max_model_len: 32768
+  max_batch_size: 1
+  kv_cache_dtype: bf16
+  gpu_memory_utilization: 0.85
+  enable_prefix_caching: true
+  tool_call_parser: qwen3_coder
+  disable_tool_grammar: true
+
+  # DFlash speculative (NOT MTP) - keys verified vs sparkrun runtimes/atlas.py
+  dflash: true
+  draft_model: z-lab/Qwen3.6-27B-DFlash
+  dflash_gamma: 17                       # FLAG value = literature gamma 16; fused GDN verify
+  env:
+    ATLAS_DFLASH_SPEC_THINK: "1"         # ON = spec through <think>
+    ATLAS_DFLASH_ADAPTIVE: "0"           # OFF = no serial fallback (code peak; erodes prose)
+    ATLAS_DFLASH_SEAM_SERIAL: "1"        # T=0 spec-entry flip fix
+    ATLAS_DFLASH_MASKED_VERIFY: "1"      # special-token leak fix (~free)
+    ATLAS_DFLASH_DRAFTER_FP8: "1"
+    ATLAS_DFLASH_OPTION_B: "1"
+    ATLAS_DFLASH_EAGLE_FIX: "1"

--- a/recipes/qwen3.6/qwen3.6-27b-nvfp4-dflash-code.yaml
+++ b/recipes/qwen3.6/qwen3.6-27b-nvfp4-dflash-code.yaml
@@ -49,7 +49,7 @@ defaults:
   max_model_len: 32768
   max_batch_size: 1
   kv_cache_dtype: bf16
-  gpu_memory_utilization: 0.85
+  gpu_memory_utilization: 0.55
   enable_prefix_caching: true
   # tool_call_parser / disable_tool_grammar inherited from the qwen3.6-27b-nvfp4
   # default; NOT independently validated with DFlash (spec-decode benches use no

--- a/recipes/qwen3.6/qwen3.6-27b-nvfp4-dflash-safe.yaml
+++ b/recipes/qwen3.6/qwen3.6-27b-nvfp4-dflash-safe.yaml
@@ -51,7 +51,7 @@ defaults:
   max_model_len: 32768
   max_batch_size: 1
   kv_cache_dtype: bf16
-  gpu_memory_utilization: 0.85
+  gpu_memory_utilization: 0.55
   enable_prefix_caching: true
   # tool_call_parser / disable_tool_grammar inherited from the qwen3.6-27b-nvfp4
   # default; NOT independently validated with DFlash (spec-decode benches use no

--- a/recipes/qwen3.6/qwen3.6-27b-nvfp4-dflash-safe.yaml
+++ b/recipes/qwen3.6/qwen3.6-27b-nvfp4-dflash-safe.yaml
@@ -1,0 +1,70 @@
+# CONFIRM before publish: the container tag that carries the DFlash binary + drafter.
+# Schema VERIFIED 2026-07-13 vs sparkrun runtimes/atlas.py: dflash (bool flag),
+# draft_model + dflash_gamma (flag map), and the env: block are all supported keys.
+recipe_version: "2"
+model: nvidia/Qwen3.6-27B-NVFP4
+runtime: atlas
+container: avarok/atlas-gb10:dev        # CONFIRM: tag that actually carries DFlash
+max_nodes: 1
+
+metadata:
+  description: |
+    Qwen3.6-27B (nvidia modelopt NVFP4, dense hybrid SSM+Attn) with DFlash
+    speculative decoding - CONSERVATIVE / safe profile. EAGLE-style external
+    drafter (z-lab/Qwen3.6-27B-DFlash) with fused GDN K=gamma verify. Speculates
+    the ANSWER BODY only (spec-through-think OFF); adaptive suspend ON so prose
+    falls back to serial pace rather than going net-negative.
+
+    Measured - GB10 single-user, temp=0, MinHeap code / Volvo prose:
+    - Code:  ~20 tok/s
+    - Prose: ~15.4 tok/s (serial parity; NOSPEC serial reference = 15.3)
+
+    Output fidelity (applies to ALL DFlash profiles):
+    - DFlash is a legitimate SAMPLING speculative decoder (accept/reject verify
+      is distribution-preserving in principle). This build's fused GDN verify has
+      a small numerics gap, so it is APPROXIMATELY - not exactly - distribution-
+      preserving.
+    - At temp=0 the output is NOT byte-exact vs the base model's greedy output
+      (answer-body speculation diverges at low-margin tokens). This profile
+      diverges LESS than -dflash/-dflash-code (no think-block speculation), but it
+      is still not bit-exact. For strictly reference-reproducible output at temp=0,
+      use NOSPEC (no DFlash).
+    - At temp>0 (sampling) the difference is ordinary sampling variance; output
+      quality is unaffected.
+
+    max_tokens: caps CONTENT tokens and IS enforced on the spec path (budget +
+    rollback). Thinking tokens are free (standard reasoning-model behavior), so
+    total completion_tokens can exceed max_tokens - NOT runaway generation.
+
+    Why this profile: no known coherence risk, closest DFlash profile to the base
+    model, and it never underperforms serial. Slower than -dflash; zero asterisks.
+  maintainer: rstesiak
+  category: agent
+  model_params: 27B
+  model_dtype: nvfp4
+  quantization: nvfp4
+  kv_dtype: bf16
+
+defaults:
+  port: 8888
+  host: 0.0.0.0
+  max_model_len: 32768
+  max_batch_size: 1
+  kv_cache_dtype: bf16
+  gpu_memory_utilization: 0.85
+  enable_prefix_caching: true
+  tool_call_parser: qwen3_coder
+  disable_tool_grammar: true
+
+  # DFlash speculative (NOT MTP) - keys verified vs sparkrun runtimes/atlas.py
+  dflash: true
+  draft_model: z-lab/Qwen3.6-27B-DFlash
+  dflash_gamma: 17                       # FLAG value = literature gamma 16; fused GDN verify
+  env:
+    ATLAS_DFLASH_SPEC_THINK: "0"         # OFF = conservative (answer-body spec only)
+    ATLAS_DFLASH_ADAPTIVE: "1"           # suspend->serial on low accept (prose safety)
+    ATLAS_DFLASH_SEAM_SERIAL: "1"        # T=0 spec-entry flip fix
+    ATLAS_DFLASH_MASKED_VERIFY: "1"      # special-token leak fix (~free)
+    ATLAS_DFLASH_DRAFTER_FP8: "1"
+    ATLAS_DFLASH_OPTION_B: "1"
+    ATLAS_DFLASH_EAGLE_FIX: "1"

--- a/recipes/qwen3.6/qwen3.6-27b-nvfp4-dflash-safe.yaml
+++ b/recipes/qwen3.6/qwen3.6-27b-nvfp4-dflash-safe.yaml
@@ -53,6 +53,9 @@ defaults:
   kv_cache_dtype: bf16
   gpu_memory_utilization: 0.85
   enable_prefix_caching: true
+  # tool_call_parser / disable_tool_grammar inherited from the qwen3.6-27b-nvfp4
+  # default; NOT independently validated with DFlash (spec-decode benches use no
+  # tool calls). Note atlas #231 may favor grammar-on for parallel calls.
   tool_call_parser: qwen3_coder
   disable_tool_grammar: true
 

--- a/recipes/qwen3.6/qwen3.6-27b-nvfp4-dflash.yaml
+++ b/recipes/qwen3.6/qwen3.6-27b-nvfp4-dflash.yaml
@@ -1,0 +1,81 @@
+# CONFIRM before publish: the container tag that carries the DFlash binary + drafter.
+# Schema VERIFIED 2026-07-13 vs sparkrun runtimes/atlas.py: dflash (bool flag),
+# draft_model + dflash_gamma (flag map), and the env: block are all supported keys.
+recipe_version: "2"
+model: nvidia/Qwen3.6-27B-NVFP4
+runtime: atlas
+container: avarok/atlas-gb10:dev        # CONFIRM: tag that actually carries DFlash
+max_nodes: 1
+
+metadata:
+  description: |
+    Qwen3.6-27B (nvidia modelopt NVFP4, dense hybrid SSM+Attn) with DFlash
+    speculative decoding - MID / balanced (recommended default). EAGLE-style
+    external drafter (z-lab/Qwen3.6-27B-DFlash) with fused GDN K=gamma verify.
+    Speculates THROUGH the <think> reasoning phase (spec-through-think ON) with
+    adaptive suspend ON so prose stays at serial parity.
+
+    Measured - GB10 single-user, MinHeap code / Volvo prose. A gradient by
+    workload, not one number:
+    - Code (temp=0):      ~24-25 tok/s typical, up to ~28; tau ~7 (accept ~6-7/16)
+    - Math (temp=0):      ~21 tok/s
+    - Logic/reasoning:    ~20 tok/s
+    - Open prose (temp=0):~15 tok/s (serial parity floor; adaptive suspends)
+    - Code (temp=0.7):    ~24 tok/s, output quality clean
+    So ~20-25 across real reasoning/code traffic; open prose is the ~15 floor,
+    never worse. (NOSPEC serial reference = 15.3.)
+
+    Output fidelity (applies to ALL DFlash profiles):
+    - DFlash is a legitimate SAMPLING speculative decoder; this build's fused GDN
+      verify has a small numerics gap -> APPROXIMATELY, not exactly, distribution-
+      preserving.
+    - At temp=0 the output is NOT byte-exact vs base-model greedy. Because
+      spec-through-think is ON, an early low-margin flip in the reasoning phase
+      compounds: DFlash tracks greedy briefly, then diverges to a DIFFERENT but
+      equally valid/coherent trajectory (measured: different reasoning + code, both
+      correct). It does not re-sync to the greedy path. For byte-exact / reference-
+      reproducible output at temp=0, use NOSPEC (or the -safe profile for a smaller
+      divergence).
+    - At temp>0 (sampling) the divergence is ordinary sampling variance - the same
+      you'd get from the base model - and the numerics gap is an invisible sub-
+      distributional shift. Output quality is unaffected.
+
+    max_tokens: caps CONTENT tokens and IS enforced on the spec path (budget +
+    rollback). Thinking tokens are free (standard reasoning-model behavior), so
+    total completion_tokens exceeds max_tokens (e.g. ~1500 content + ~1300-1600
+    thinking). NOT runaway generation. Only gap: max_thinking_budget is not
+    force-enforced on the spec path (default: none, thinking ends naturally).
+
+    Known residual caveat (UNDER RE-VERIFICATION): on a prior binary, dense
+    TECHNICAL prose (e.g. ZKP / SQL-injection explainers) occasionally derailed at
+    the </think> seam (5/7 clean). Not re-confirmed on the current binary.
+  maintainer: rstesiak
+  category: agent
+  model_params: 27B
+  model_dtype: nvfp4
+  quantization: nvfp4
+  kv_dtype: bf16
+
+defaults:
+  port: 8888
+  host: 0.0.0.0
+  max_model_len: 32768
+  max_batch_size: 1
+  kv_cache_dtype: bf16
+  gpu_memory_utilization: 0.85
+  enable_prefix_caching: true
+  tool_call_parser: qwen3_coder
+  disable_tool_grammar: true
+
+  # DFlash speculative (NOT MTP) - keys verified vs sparkrun runtimes/atlas.py
+  dflash: true
+  draft_model: z-lab/Qwen3.6-27B-DFlash
+  dflash_gamma: 17                       # FLAG value = literature gamma 16; fused GDN verify
+  env:
+    ATLAS_DFLASH_SPEC_THINK: "1"         # ON = spec through <think> (the code win)
+    ATLAS_DFLASH_ADAPTIVE: "1"           # suspend->serial on low accept (prose parity)
+    ATLAS_DFLASH_SEAM_SERIAL: "1"        # T=0 spec-entry flip fix
+    ATLAS_DFLASH_MASKED_VERIFY: "1"      # special-token leak fix (~free)
+    ATLAS_DFLASH_DRAFTER_FP8: "1"
+    ATLAS_DFLASH_OPTION_B: "1"
+    ATLAS_DFLASH_EAGLE_FIX: "1"

--- a/recipes/qwen3.6/qwen3.6-27b-nvfp4-dflash.yaml
+++ b/recipes/qwen3.6/qwen3.6-27b-nvfp4-dflash.yaml
@@ -62,7 +62,7 @@ defaults:
   max_model_len: 32768
   max_batch_size: 1
   kv_cache_dtype: bf16
-  gpu_memory_utilization: 0.85
+  gpu_memory_utilization: 0.55
   enable_prefix_caching: true
   # tool_call_parser / disable_tool_grammar inherited from the qwen3.6-27b-nvfp4
   # default; NOT independently validated with DFlash (spec-decode benches use no

--- a/recipes/qwen3.6/qwen3.6-27b-nvfp4-dflash.yaml
+++ b/recipes/qwen3.6/qwen3.6-27b-nvfp4-dflash.yaml
@@ -64,6 +64,9 @@ defaults:
   kv_cache_dtype: bf16
   gpu_memory_utilization: 0.85
   enable_prefix_caching: true
+  # tool_call_parser / disable_tool_grammar inherited from the qwen3.6-27b-nvfp4
+  # default; NOT independently validated with DFlash (spec-decode benches use no
+  # tool calls). Note atlas #231 may favor grammar-on for parallel calls.
   tool_call_parser: qwen3_coder
   disable_tool_grammar: true
 


### PR DESCRIPTION
## Add DFlash speculative-decode recipes for Qwen3.6-27B-NVFP4

Adds three DFlash spec-decode recipes for Qwen3.6-27B-NVFP4 (GB10, single-node),
using an EAGLE-style external drafter (`z-lab/Qwen3.6-27B-DFlash`) with fused GDN
K=gamma verify. They form a speed/fidelity ladder; pick by workload.

| Recipe | Config | Code | Prose | Use |
|---|---|---|---|---|
| `qwen3.6-27b-nvfp4-dflash` (default) | spec-through-think, adaptive on | ~20-25 | ~15 (parity) | balanced |
| `qwen3.6-27b-nvfp4-dflash-safe` | answer-body spec only, adaptive on | ~20 | ~15.4 (parity) | conservative, no asterisks |
| `qwen3.6-27b-nvfp4-dflash-code` | spec-through-think, adaptive off | ~29.9 | ~12.9 (net-neg) | code-heavy only |

Measured on a GB10, temp=0, MinHeap code / Volvo prose. NOSPEC serial reference = 15.3.
The default is a gradient by workload: code ~25, math ~21, logic ~20, prose ~15 floor;
at temp=0.7 it holds ~24 tok/s with clean output.

### Schema

Verified against sparkrun `runtimes/atlas.py`: `dflash` (bool flag), `draft_model`,
`dflash_gamma`, and the `env:` block are all supported recipe keys. No changes to the
runner needed.

### Constraints (documented in each recipe's description)

- **Output fidelity.** DFlash is a legitimate sampling speculative decoder; this build's
  fused verify has a small numerics gap, so it is approximately (not exactly)
  distribution-preserving. At temp=0 the output is not byte-exact vs the base model's
  greedy output (a valid, different trajectory). At temp>0 the difference is ordinary
  sampling variance and quality is unaffected. Use NOSPEC (DFlash off) for byte-exact
  output. Making the verify bit-exact is a follow-up.
- **max_tokens.** Caps content tokens and is enforced on the spec path. Thinking tokens
  are free (standard reasoning-model behavior), so total completion_tokens exceeds
  max_tokens. This is not runaway generation.
- **`-dflash-code` is code-only.** Adaptive-off removes the serial fallback, so prose and
  low-accept prompts go net-negative. Not a general-purpose default.

### Open items

`container:` currently points at `avarok/atlas-gb10:dev` as a placeholder. It needs to
target the tag that carries the DFlash binary + drafter. Flagging for confirmation before
these are treated as live.

There is also the option of using only one recipe; with the other two configurations achievable via launch parametrers/flags/switches.
