### PR TITLE
recipes: add Laguna S 2.1 NVFP4 profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ image — pull a newer `avarok/atlas-gb10:dev`.
 
 | Recipe | Model | Topology | Notes |
 |---|---|---|---|
+| `laguna-s-2.1-nvfp4` | poolside/Laguna-S-2.1-NVFP4 | single | 200K context, FP8 KV, 16K prefill, NFS-aware load, no DFlash; requires Atlas PR #350 |
 | `qwen3.6-35b-a3b-nvfp4` | nvidia/Qwen3.6-35B-A3B-NVFP4 | single | **DEFAULT 35B** — MTP K=1 (pinned; 116.5 tok/s), calibrated fp8 KV (128K), qwen3_coder agentic stack; requires :dev ≥ 2026-07-10 (atlas#287) |
 | `qwen3.6-27b-nvfp4` | nvidia/Qwen3.6-27B-NVFP4 | single | **DEFAULT 27B** — dense hybrid SSM+Attn, MTP K=1 (pinned), bf16 KV, qwen3_coder agentic stack; requires :dev ≥ 2026-07-10 (atlas#287) |
 | `qwen3.6-35b-a3b-fp8-mtp` | Qwen/Qwen3.6-35B-A3B-FP8 | single | Flagship FP8 — native FP8, bf16 head + bf16 KV, 64K ctx, MTP K=2, live tool-call streaming |

--- a/recipes/laguna-s-2.1/laguna-s-2.1-nvfp4.yaml
+++ b/recipes/laguna-s-2.1/laguna-s-2.1-nvfp4.yaml
@@ -13,8 +13,9 @@ metadata:
     FP8 KV scheme, keeps the BF16 lm-head, and exposes 200K logical context via
     KV overcommit while limiting Atlas's physical allocation to 80% of unified
     memory. Prefix caching is enabled for agentic loops; SSM snapshot storage is
-    explicitly disabled because Laguna has no SSM state. The checkpoint's Jinja
-    template defaults `enable_thinking` to false and permits per-request opt-in.
+    explicitly disabled because Laguna has no SSM state. Thinking is enabled by
+    default for agentic coding, as recommended by Poolside, and clients can
+    still disable it per request through the Jinja `enable_thinking` control.
 
     The 16K prefill chunk is the measured balanced setting. Exact MoE tiles
     improved cold 8K TTFT by 3.7%. The NFS prefetch flag is intentional: Laguna's

--- a/recipes/laguna-s-2.1/laguna-s-2.1-nvfp4.yaml
+++ b/recipes/laguna-s-2.1/laguna-s-2.1-nvfp4.yaml
@@ -1,0 +1,69 @@
+recipe_version: "2"
+model: poolside/Laguna-S-2.1-NVFP4
+runtime: atlas
+container: avarok/atlas-gb10:dev
+max_nodes: 1
+
+metadata:
+  description: |
+    Poolside Laguna S 2.1 NVFP4 on one GB10, without DFlash. Laguna is a
+    117.6B-total / 8.5B-active MoE with 48 attention layers and no SSM layers.
+
+    This profile is measured on Atlas PR #350. It uses the checkpoint's native
+    FP8 KV scheme, keeps the BF16 lm-head, and exposes 200K logical context via
+    KV overcommit while limiting Atlas's physical allocation to 80% of unified
+    memory. Prefix caching is enabled for agentic loops; SSM snapshot storage is
+    explicitly disabled because Laguna has no SSM state. The checkpoint's Jinja
+    template defaults `enable_thinking` to false and permits per-request opt-in.
+
+    The 16K prefill chunk is the measured balanced setting. Exact MoE tiles
+    improved cold 8K TTFT by 3.7%. The NFS prefetch flag is intentional: Laguna's
+    14 checkpoint shards are commonly served from an NFS-backed Hugging Face
+    cache. DFlash is deliberately omitted until its separate correctness and
+    quality gate is complete.
+  maintainer: monumental-systems
+  category: agent
+  model_params: 117.6B
+  model_dtype: nvfp4
+  quantization: nvfp4
+  kv_dtype: fp8
+
+defaults:
+  port: 8888
+  host: 0.0.0.0
+  max_model_len: 200000
+  max_num_seqs: 4
+  max_batch_size: 4
+  max_prefill_tokens: 16384
+  kv_cache_dtype: fp8
+  lm_head_dtype: bf16
+  gpu_memory_utilization: 0.80
+  swap_space_gb: 4
+  ssm_cache_slots: 0
+  max_thinking_budget: 1024
+  scheduling_policy: slai
+
+env:
+  ATLAS_KV_OVERCOMMIT: "1"
+  ATLAS_MOE_PREFILL_EXACT_TILES: "1"
+
+# Explicit command until sparkrun's Atlas runtime exposes structured mappings
+# for swap_space_gb and fast_load_prefetch_shards. Keep this in lockstep with
+# the defaults above so CLI overrides for the standard keys still render.
+command: |
+  spark serve poolside/Laguna-S-2.1-NVFP4 \
+    --port {port} \
+    --host {host} \
+    --max-seq-len {max_model_len} \
+    --max-num-seqs {max_num_seqs} \
+    --max-batch-size {max_batch_size} \
+    --max-prefill-tokens {max_prefill_tokens} \
+    --kv-cache-dtype {kv_cache_dtype} \
+    --lm-head-dtype {lm_head_dtype} \
+    --gpu-memory-utilization {gpu_memory_utilization} \
+    --swap-space-gb {swap_space_gb} \
+    --fast-load-prefetch-shards \
+    --enable-prefix-caching \
+    --ssm-cache-slots {ssm_cache_slots} \
+    --max-thinking-budget {max_thinking_budget} \
+    --scheduling-policy {scheduling_policy}

--- a/recipes/laguna-s-2.1/laguna-s-2.1-nvfp4.yaml
+++ b/recipes/laguna-s-2.1/laguna-s-2.1-nvfp4.yaml
@@ -42,6 +42,7 @@ defaults:
   ssm_cache_slots: 0
   max_thinking_budget: 1024
   scheduling_policy: slai
+  tbt_deadline_ms: 100
 
 env:
   ATLAS_KV_OVERCOMMIT: "1"
@@ -66,4 +67,5 @@ command: |
     --enable-prefix-caching \
     --ssm-cache-slots {ssm_cache_slots} \
     --max-thinking-budget {max_thinking_budget} \
-    --scheduling-policy {scheduling_policy}
+    --scheduling-policy {scheduling_policy} \
+    --tbt-deadline-ms {tbt_deadline_ms}


### PR DESCRIPTION
Adds the measured single-GB10 Atlas profile for poolside/Laguna-S-2.1-NVFP4, without DFlash.\n\nConfiguration: 200K logical context with KV overcommit, FP8 KV, BF16 lm-head, 16K prefill, max C=4, 0.80 GPU memory utilization, 4 GiB swap, NFS shard prefetch, prefix caching, SSM cache disabled, Poolside per-request thinking control, slai scheduling, and exact MoE prefill tiles.\n\nValidated with sparkrun recipe show and a full sparkrun dry-run; the rendered serve command contains the intended flags and both environment variables.\n\nDepends on Avarok-Cybersecurity/atlas#350.