### PR TITLE
fix: pin mtp_gate=force on the two gate-backing recipes

### DIFF
--- a/recipes/qwen3.6/qwen3.6-27b-nvfp4-unsloth.yaml
+++ b/recipes/qwen3.6/qwen3.6-27b-nvfp4-unsloth.yaml
@@ -60,6 +60,13 @@ defaults:
   ssm_cache_slots: 128
   ssm_checkpoint_interval: 32
   speculative: true
+  # ★ DETERMINISM PIN. See qwen3.6-35b-a3b-fp8-bf16head for the full
+  # rationale. In `auto` the MTP gate switches MTP<->serial at runtime on
+  # wall-clock tok/s, and speculation is not output-neutral at temperature 0
+  # — so decode depends on box speed. This recipe backs Atlas's BFCL ACCURACY
+  # gates, which score at temp 0: an un-pinned arbiter moves the score itself,
+  # not merely the wall time.
+  mtp_gate: force
   num_drafts: 1
   mtp_quantization: bf16
   tool_call_parser: qwen3_coder

--- a/recipes/qwen3.6/qwen3.6-35b-a3b-fp8-bf16head.yaml
+++ b/recipes/qwen3.6/qwen3.6-35b-a3b-fp8-bf16head.yaml
@@ -39,6 +39,20 @@ defaults:
   scheduling_policy: slai
   speculative: true
   mtp_quantization: bf16
+  # ★ DETERMINISM PIN, not a performance knob. Without it the MTP gate runs in
+  # `auto`, where it is a bandit arbiter that switches MTP<->serial at runtime
+  # on WALL-CLOCK tok/s. Speculation is not output-neutral at temperature 0
+  # (rollback and SSM-conv restore are inexact; structural 4.1-nat margins
+  # measured 2026-07-22), so a throughput-timed path switch makes greedy decode
+  # depend on how fast the box happened to be that minute.
+  #
+  # This recipe backs Atlas's Gate A (agentic-webserver), whose client is pinned
+  # to the bone -- temperature 0.0, seed 0, constant prompt, normalised tool
+  # output -- and none of that helps while the SERVER picks numeric paths by
+  # stopwatch. Measured 2026-08-09: two runs of ONE binary on ONE box scored
+  # followed_directions 9/10 then 10/10, and iteration 9 of each built a
+  # different cargo profile from identical inputs.
+  mtp_gate: force
   enable_prefix_caching: true
   # bf16 lm-head: the 248K-vocab projection stays full-precision (the single
   # largest per-token weight read). Argmax over the vocab is exact — no flips.


### PR DESCRIPTION
Both recipes that back Atlas's benchmark gates serve with the MTP gate in `auto`, and that is the root cause of an intermittent gate failure.

## Why `auto` breaks a gate

In `auto`, `scheduler::mtp_gate` is a bandit arbiter that switches MTP↔serial **at runtime on wall-clock tok/s EWMAs**. Speculation is not output-neutral at temperature 0 — rollback and SSM-conv restore are inexact, measured at structural 4.1-nat margins on 2026-07-22 — so a throughput-timed path switch makes greedy decode depend on how fast the box happened to be that minute.

The 2026-07-22 campaign already declared this pin mandatory for gate runs. The recipes never adopted it.

## The measurement that forced this

Two runs of **one binary** on **one box**, back to back, scored `followed_directions` 9/10 then 10/10. Iteration 9 of each built a *different cargo profile* from identical inputs — `/tmp/agent_server.log` (`--release`) versus `/tmp/server.log` (dev).

The client side of that gate is pinned to the bone — temperature 0.0, seed 0, constant prompt, normalised tool output, all wire-asserted by test. None of it helps while the server is choosing numeric paths by stopwatch.

## What changes

| recipe | backs |
|---|---|
| `qwen3.6-35b-a3b-fp8-bf16head` | Gate A (agentic-webserver) |
| `qwen3.6-27b-nvfp4-unsloth` | the BFCL **accuracy** gates |

The second matters more, not less: those gates score at temperature 0, so an un-pinned arbiter moves the **score**, not merely the wall time.

## Scope — deliberately narrow

Eight other recipes also run `speculative: true` with no `mtp_gate`, and they are **left alone**. `auto` is the right choice for production serving: it is a throughput optimiser, and forcing it there would cost tok/s for a determinism property interactive serving does not need. Only recipes named by a `BENCH.toml` are pinned here.

## Verification

- `NOT_FLAGS` is empty and `schema::flag_for` renders `mtp_gate` → `--mtp-gate`, matching the clap flag (`serve_args.rs:236`, `Option<String>` with no default — so absent genuinely means `auto`, and this is not a no-op key).
- Both files parse as YAML with `mtp_gate: force` resolving under `defaults`.

**Not yet verified on hardware:** that the pin removes the flip. That needs repeat tiers under the pin and is tracked on the Atlas side — flagging rather than claiming it.

Co-Authored-By: Atlas <atlas@avarok.net>