### PR TITLE
recipe(nemotron): Nemotron-Labs-3-Puzzle-75B-A9B-NVFP4 reference config for GB10

### DIFF
--- a/recipes/nemotron-3-puzzle/nemotron-labs-3-puzzle-75b-a9b-nvfp4.yaml
+++ b/recipes/nemotron-3-puzzle/nemotron-labs-3-puzzle-75b-a9b-nvfp4.yaml
@@ -1,0 +1,109 @@
+recipe_version: "2"
+model: nvidia/NVIDIA-Nemotron-Labs-3-Puzzle-75B-A9B-NVFP4
+runtime: atlas
+container: avarok/atlas-gb10:latest
+max_nodes: 1
+
+metadata:
+  description: |
+    Nemotron-Labs-3-Puzzle-75B-A9B — NVIDIA hybrid Mamba-2 + LatentMoE +
+    Attention on a single GB10. 88 layers (8 attention, 40 SSM), 512
+    experts, latent MoE (moe_latent_size 4096 -> 1024), native-FP8 SSM
+    projections, NVFP4 MoE.
+
+    Measured on a GB10 (2026-08-13), 798 requests, zero errors / zero
+    warnings / zero panics in the server log:
+      boot          44.7 s   (168 kernel modules, 0 unresolved)
+      decode        21.7 tok/s single-stream
+      prefill     ~1540 tok/s at 25K context
+      needle       18/18 PASS, start/mid/end depths x 562 -> 25084 tokens
+      prefix cache 94.6% hit rate, 368829 tokens reused
+      agentic      3-step chained tool loop PASS (both sampling profiles)
+
+    ── REQUIRES AN IMAGE NEWER THAN :latest ──
+    As of 2026-08-13 this recipe does NOT serve correctly on the
+    published `avarok/atlas-gb10:latest`. Two engine fixes are required
+    and neither is on atlas `main` yet:
+
+      atlas#462  Nemotron-H is NoPE. Atlas applied rotary embedding to
+                 the whole family, which kills long-context retrieval
+                 above ~52 tokens. Boot MUST log `rotary_dim=0`; if it
+                 logs a non-zero rotary_dim, needle recall is dead and
+                 no serve flag can recover it.
+      atlas#462  MODEL.toml `[behavior].no_decode_graphs`. Decode-graph
+                 replay crashes this model with CUDA 700 at EXACTLY 64
+                 prompt tokens. Boot MUST log "Decode graphs disabled by
+                 MODEL.toml [behavior].no_decode_graphs".
+
+    Do not publish this recipe until an image carrying both is out —
+    a recipe that boots and then silently returns wrong long-context
+    answers is worse than no recipe. See the checkpoint note in the
+    repo README for the precedent.
+
+    ── KV MUST BE bf16, NOT fp8 ──
+    Served from the target's `[behavior].default_kv_dtype`, so the
+    recipe does not need to force it — but do not override it. fp8 KV
+    corrupts this thinking model's long reasoning context (hallucinated
+    tool schemas, non-sequiturs). This matches vLLM's own guidance for
+    the checkpoint. Verify: "KV cache dtype: bf16 (from MODEL.toml
+    default_kv_dtype)".
+
+    ── SSM PROJECTIONS MUST LOAD AS NATIVE FP8 ──
+    The checkpoint ships in_proj/out_proj as FP8. An earlier Atlas path
+    took FP8 -> BF16 -> NVFP4, double-quantizing already-quantized
+    weights and measurably degrading quality. Verify all 40 SSM layers
+    log `quant=Fp8 native_fp8=true native_bf16=false native_prefill=true`
+    and ZERO layers report the BF16 arm.
+
+    ── SAMPLING: use_sampling_presets_for_core IS LOAD-BEARING ──
+    This checkpoint's generation_config.json carries temperature=1.0,
+    an evaluation default rather than an agentic one. Without the
+    target's `use_sampling_presets_for_core` opt-in, core sampling falls
+    through to 1.0 and the 0.6/0.7 presets are silently ignored, so
+    agentic runs decode far hotter than intended. Measured on the Holo
+    sibling: opting in moved tool-call pass rate from 4/8 to 7/8 at C=8.
+
+    ── KNOWN: temp-0 output is not byte-reproducible under concurrency ──
+    Characterized 2026-08-13, reproducible across repeated trials:
+      C=1        deterministic (1 distinct output over 5 repeats)
+      C>=2       every reply differs from the C=1 baseline, while all
+                 peers within a batch agree
+      C>=5       peers split into 2 groups
+    This is FP accumulation order varying with batch shape, NOT a race
+    and NOT cross-request contamination — a 24-stream secret-leak probe
+    found 0 leaks, and 96 sessions under forced Marconi eviction found
+    0 contaminated. Short factual answers stay stable at C=8; long prose
+    drifts. Use C=1 if you require byte-identical greedy output.
+
+    ── SCOPE OF THESE NUMBERS ──
+    Measured with a locally built binary (atlas `main` + the Nemotron
+    stack: #462 NoPE/Lightning base, #467 batched decode, #475 milestone
+    B). What is documented here is the serve configuration; re-verify the
+    boot signal lines on whatever image you actually pull.
+  maintainer: avarok
+  category: agent
+  model_params: 75B
+  model_dtype: nvfp4
+  quantization: nvfp4
+  kv_dtype: bf16
+
+defaults:
+  port: 8888
+  host: 0.0.0.0
+  # 32K is the needle-VERIFIED regime (18/18 to 25084 tokens). The KV
+  # budget is not the constraint — with only 8 attention layers, util
+  # 0.80 leaves ~15.9 GB for KV = 130608 blocks = ~2.09M KV tokens — so
+  # this ceiling is set by what was measured, not by what fits. Raise it
+  # only alongside a needle run at the new length.
+  max_model_len: 32768
+  max_num_seqs: 8
+  # Inherited from MODEL.toml [behavior].default_kv_dtype. Stated here
+  # so an operator reading the recipe sees it; do NOT change to fp8.
+  kv_cache_dtype: bf16
+  gpu_memory_utilization: 0.80
+  scheduling_policy: slai
+  enable_prefix_caching: true
+  # Marconi SSM snapshots. 64 slots held 0 evictions across a 96-session
+  # forced-eviction probe (96 sessions against 64 slots, shuffled
+  # revisit) with 0 contaminated sessions and a 94.6% prefix hit rate.
+  ssm_cache_slots: 64

--- a/recipes/nemotron-3.5-lightning/nemotron-3.5-lightning-30b-a3b-nvfp4.yaml
+++ b/recipes/nemotron-3.5-lightning/nemotron-3.5-lightning-30b-a3b-nvfp4.yaml
@@ -1,0 +1,125 @@
+recipe_version: "2"
+model: nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4
+runtime: atlas
+container: avarok/atlas-gb10:latest
+max_nodes: 1
+
+metadata:
+  description: |
+    Nemotron-3.5-Lightning-30B-A3B — NVIDIA hybrid Mamba-2 + MoE +
+    Attention on a single GB10. 52 layers (6 attention, 23 SSM), 128
+    experts top-6, hidden 2688. Dimensionally identical to the
+    Nemotron-3-Nano sibling; it differs by shipping a DeepSeek-style
+    1-step MTP draft head and by wanting the OPPOSITE thinking policy.
+
+    Boot-verified on a GB10 (2026-08-13):
+      kernel audit  154 lookups, 0 unresolved, 9 expected-absent, PASS
+      target        (sm_121, nemotron-3.5-lightning-30b-a3b, nvfp4)
+      config        52 layers, 6 attn, 23 SSM, 128 experts, rotary_dim=0
+
+    THROUGHPUT AND AGENTIC NUMBERS ARE NOT YET MEASURED for this
+    checkpoint and are deliberately omitted rather than copied from the
+    Nano sibling — the two share dimensions but not the sampling or
+    thinking policy, and MTP changes the decode path. This recipe
+    documents the serve CONFIGURATION only. Fill the table in before
+    undrafting.
+
+    ── REQUIRES AN IMAGE NEWER THAN :latest ──
+    As of 2026-08-13 this recipe cannot work on the published
+    `avarok/atlas-gb10:latest`. Neither prerequisite is on atlas `main`:
+
+      atlas#487  Lightning's OWN kernel target. Without it there is no
+                 `nemotron-3.5-lightning-30b-a3b` directory and the
+                 checkpoint silently resolves to the Nano target — same
+                 dimensions, so nothing errors — inheriting Nano's
+                 `thinking_default = false`. You get a working server
+                 running the WRONG policy. Boot MUST log
+                 "Selected kernel target: (sm_121,
+                 nemotron-3.5-lightning-30b-a3b, nvfp4)".
+      atlas#462  Nemotron-H is NoPE, plus the MODEL.toml
+                 `[behavior].no_decode_graphs` key. Atlas applied rotary
+                 embedding to the whole family, killing long-context
+                 retrieval above ~52 tokens; and decode-graph replay
+                 crashes this family with CUDA 716. Boot MUST log
+                 `rotary_dim=0` and "Decode graphs disabled by
+                 MODEL.toml [behavior].no_decode_graphs".
+
+    Recommended alongside: atlas#486, which fixes tool calls being
+    delivered with empty arguments when the model writes the
+    attribute dialect (`<parameter city="X">` rather than
+    `<parameter=city>`). Lightning emits the attribute form.
+
+    ── THINKING POLICY: THE REASON THIS TARGET IS SEPARATE ──
+    Served from the target's MODEL.toml, not from this recipe:
+      thinking_default  = true    # thinking is the quality path for chat
+      thinking_in_tools = false   # and the WRONG path for tool turns
+    With thinking on and tools armed, the model emits its `<tool_call>`
+    INSIDE `<think>`, so the turn depends on a `</think>` force-close
+    landing after the arguments rather than between the name and the
+    arguments. Measured at temperature 0, same build and prompt shape:
+    "Santiago" cut early and returned a name-only call; "Kyoto" cut late
+    and returned a good one. Not thinking at all on tool turns is both
+    correct and ~4x cheaper (23 completion tokens vs 89-97).
+
+    Do NOT try to reproduce this with
+    `--default-chat-template-kwargs '{"enable_thinking":true}'`. That is
+    an EXPLICIT directive and an explicit directive OUTRANKS
+    `thinking_in_tools`, so tool turns would think anyway. That
+    workaround is exactly what motivated splitting the target.
+
+    ── MTP: SHIPPED, BUT PARKED BY THE AUTO GATE ──
+    The checkpoint carries a 1-step draft head (`num_nextn_predict_layers
+    = 1`), which is also the discriminator that separates this target
+    from Nano's. Serve-validated 2026-08-11 (C=1, 400-token story, temp
+    0): the DRAFTS are good (K2 accept p1 = 0.49-0.65) but verify is NET
+    NEGATIVE — 55.0 tok/s forced-MTP against 70.1 tok/s serial — because
+    this target has no K-token batched verify kernels. The 23 Mamba-2
+    layers run K sequential recurrent decodes and the 23 MoE layers K
+    per-token expert GEMV sweeps, so a K=2 verify costs ~2x a decode in
+    weight reads for only ~1.55 tokens. The auto gate measures this and
+    parks speculation, so serving stays at the serial rate. Leave
+    `--speculative` OFF; it is not a win on this target today.
+
+    ── SAMPLING: use_sampling_presets_for_core IS LOAD-BEARING ──
+    generation_config.json carries temperature=1.0 / top_p=0.95, the HF
+    evaluation defaults rather than a serving recipe. Without the
+    target's opt-in, core sampling falls through to those values and
+    every preset is silently ignored for any client that does not send
+    its own sampling params (opencode does not).
+
+    ── AN EMPTY SYSTEM TURN DEGRADES THIS FAMILY ──
+    The chat template always emits a system block, rendering
+    `<|im_start|>system\n<|im_end|>` when the request carries no system
+    message. That exact shape was measured to degrade the Nano sibling
+    on 2026-07-28 — identical user text, only the system block
+    differing, correct with any system text and wrong with an empty one.
+    The target supplies a `default_system_prompt` so the empty turn
+    never renders; do not strip it.
+  maintainer: avarok
+  category: agent
+  model_params: 30B
+  model_dtype: nvfp4
+  quantization: nvfp4
+  kv_dtype: bf16
+
+defaults:
+  port: 8888
+  host: 0.0.0.0
+  # KV is not the binding constraint on this model: with only 6 attention
+  # layers, util 0.80 leaves room for millions of KV tokens (a util-0.90
+  # boot measured 1407573 blocks x 16 = ~22.5M). This ceiling is set by
+  # what has been exercised, not by what fits — raise it with a needle
+  # run at the new length, the same way the Puzzle sibling is bounded.
+  max_model_len: 32768
+  max_num_seqs: 8
+  # bf16 by choice. Not yet A/B'd ON THIS CHECKPOINT — it is the
+  # conservative setting carried over from the Puzzle sibling, whose
+  # target documents fp8 KV corrupting a thinking model's long reasoning
+  # context, and Lightning is thinking-first. Given the KV headroom
+  # above, bf16 costs nothing here. Revisit with a measurement, not a
+  # guess.
+  kv_cache_dtype: bf16
+  gpu_memory_utilization: 0.80
+  scheduling_policy: slai
+  enable_prefix_caching: true
+  ssm_cache_slots: 64


### PR DESCRIPTION
Adds a reference recipe for **Nemotron-Labs-3-Puzzle-75B-A9B-NVFP4** on a single GB10. There's no Puzzle recipe in the registry today.

Measured on a GB10, 2026-08-13 — **798 requests, zero errors, zero warnings, zero panics** in the server log:

| | |
|---|---|
| boot | 44.7 s, 168 kernel modules, **0 unresolved** |
| decode | 21.7 tok/s single-stream |
| prefill | ~1540 tok/s at 25K context |
| needle | **18/18** PASS, start/mid/end depths × 562 → 25 084 tokens |
| prefix cache | 94.6% hit rate, 368 829 tokens reused |
| agentic | 3-step chained tool loop PASS, both sampling profiles |
| SSM | 40/40 layers `native_fp8=true` |

## Draft because it does not serve correctly on `:latest`

This is the part worth reviewing. Puzzle needs two engine fixes, neither of which is on atlas `main`:

- **atlas#462 — Nemotron-H is NoPE.** Atlas applied rotary embedding to the whole family, which kills long-context retrieval above ~52 tokens. The recipe documents the boot line to check: `rotary_dim=0`. If it's non-zero, needle recall is dead and no serve flag recovers it.
- **atlas#462 — `[behavior].no_decode_graphs`.** Decode-graph replay crashes this model with **CUDA 700 at exactly 64 prompt tokens**. Verified fixed by sweeping 92 distinct prompt lengths including 64 and 128, plus 400-token decodes pinned at ptok 63/64/65/127/128/129.

Both failure modes are quiet in different ways — one returns wrong answers, the other crashes only at one specific length — so the recipe quotes the exact boot lines rather than describing them. Following the checkpoint precedent in the README: a recipe that doesn't serve is worse than no recipe.

## Three ways to silently get a worse model

**1. KV must be `bf16`.** Served from the target's `default_kv_dtype`, so the recipe doesn't force it — but don't override it. fp8 KV corrupts this thinking model's long reasoning context (hallucinated tool schemas, non-sequiturs). Matches vLLM's guidance for the checkpoint.

**2. SSM projections must load as native FP8.** The checkpoint ships `in_proj`/`out_proj` as FP8. An earlier Atlas path took FP8 → BF16 → NVFP4, double-quantizing already-quantized weights. Verify all 40 SSM layers log `quant=Fp8 native_fp8=true native_bf16=false`.

**3. `use_sampling_presets_for_core` is load-bearing.** `generation_config.json` carries `temperature=1.0` — an evaluation default, not an agentic one. Without the opt-in, core sampling falls through to 1.0 and the 0.6/0.7 presets are silently ignored. Measured on the Holo sibling, opting in moved tool-call pass rate from 4/8 to 7/8 at C=8.

## Known limitation: temp-0 is not byte-reproducible under concurrency

Characterized on the same run, reproducible across repeated trials:

| C | behaviour |
|---|---|
| 1 | deterministic — 1 distinct output over 5 repeats |
| ≥2 | every reply differs from the C=1 baseline; peers within a batch agree |
| ≥5 | peers split into 2 groups |

Identical across trials, so this is FP accumulation order varying with batch shape — **not a race, and not contamination**: a 24-stream secret-leak probe found 0 leaks, and 96 sessions under forced Marconi eviction (96 sessions against 64 slots, shuffled revisit) found 0 contaminated, with the cache genuinely exercised at a 94.6% hit rate. Short factual answers stay stable at C=8; long prose drifts. The recipe says to use C=1 if you need byte-identical greedy output.

## Scope

- Numbers come from a **locally built binary** (atlas `main` + the Nemotron stack: #462, #467, #475). What's documented is the serve configuration; re-verify the boot signal lines on whatever image you actually pull.
- `max_model_len: 32768` is set by **what was needle-verified**, not by what fits — the KV budget is nowhere near binding (only 8 attention layers; util 0.80 leaves ~2.09M KV tokens). Raise it alongside a needle run at the new length.
- Not added to the README catalogue while draft, matching #13 — a catalogue entry would advertise a recipe that can't serve yet. Happy to add it on undraft.
