### PR TITLE
qwen3.8: add the 27B unsloth NVFP4 recipe the agentic gate is measured under

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,20 +44,20 @@ The default 27B/35B NVFP4 recipes therefore now track the **`nvidia/*`** checkpo
 whose on-disk format has been stable since 2026-05-29. Those are verified end-to-end on a
 GB10 and are what you should use.
 
-There is deliberately **no `-unsloth` recipe yet**, though the engine now supports those
-checkpoints. Loading the mixed-precision layout took two fixes: atlas#300 (the layer
-weights) and atlas#301 (the FP8 `lm_head`, plus per-row weight scales that were being fed
-to a 128×128 block-scaled kernel — in-bounds, so no crash, just silently wrong logits).
-Both are on `main` and verified on a GB10:
+`-unsloth` recipes now exist, but only where a gate is actually measured on one — they
+are deliberately not the defaults. Loading the mixed-precision layout took two fixes:
+atlas#300 (the layer weights) and atlas#301 (the FP8 `lm_head`, plus per-row weight scales
+that were being fed to a 128×128 block-scaled kernel — in-bounds, so no crash, just
+silently wrong logits). Both are on `main` and verified on a GB10:
 
 | checkpoint | throughput | correctness |
 |---|---|---|
 | `unsloth/Qwen3.6-27B-NVFP4` | 14.0 tok/s | pass |
 | `unsloth/Qwen3.6-35B-A3B-NVFP4` | 123.4 tok/s | pass |
 
-The recipes land once an `avarok/atlas-gb10:dev` image **carrying atlas#301** is published.
-Until then a recipe pointing at those checkpoints would still fail on the image you'd
-actually pull, and shipping a recipe that does not serve is worse than shipping none.
+The two shipped so far are `qwen3.6-27b-nvfp4-unsloth` (the BFCL gate config) and
+`qwen3.8-27b-nvfp4-unsloth` (the agentic gate config). Both pin an image that can load the
+layout; on anything older they fail with `weight_global_scale not found`.
 
 If a model suddenly fails to build with a missing `weight_global_scale` or a
 `weight_scale` dtype error, you are almost certainly on a newer checkpoint than your Atlas
@@ -69,6 +69,7 @@ image — pull a newer `avarok/atlas-gb10:dev`.
 |---|---|---|---|
 | `qwen3.6-35b-a3b-nvfp4` | nvidia/Qwen3.6-35B-A3B-NVFP4 | single | **DEFAULT 35B** — MTP K=1 (pinned; 116.5 tok/s), calibrated fp8 KV (128K), qwen3_coder agentic stack; requires :dev ≥ 2026-07-10 (atlas#287) |
 | `qwen3.6-27b-nvfp4` | nvidia/Qwen3.6-27B-NVFP4 | single | **DEFAULT 27B** — dense hybrid SSM+Attn, MTP K=1 (pinned), bf16 KV, qwen3_coder agentic stack; requires :dev ≥ 2026-07-10 (atlas#287) |
+| `qwen3.8-27b-nvfp4-unsloth` | unsloth/Qwen3.8-27B-NVFP4 | single | Dense hybrid SSM+Attn — the AGENTIC gate config: thinking ON, bf16 head + bf16 KV, 32K, MTP K=4, slai. Architecturally identical to Qwen3.6-27B (all 1968 tensors match); only the weights differ |
 | `qwen3.6-35b-a3b-fp8-mtp` | Qwen/Qwen3.6-35B-A3B-FP8 | single | Flagship FP8 — native FP8, bf16 head + bf16 KV, 64K ctx, MTP K=2, live tool-call streaming |
 | `qwen3.6-35b-a3b-fp8-bf16head` | Qwen/Qwen3.6-35B-A3B-FP8 | single | 32K safe profile of the FP8 flagship (same bf16 head/KV) |
 | `qwen3.6-35b-a3b-fp8-nvfp4head` | Qwen/Qwen3.6-35B-A3B-FP8 | single | nvfp4 lm-head sibling — near-neutral wall, lower VRAM |

--- a/recipes/qwen3.8/qwen3.8-27b-nvfp4-unsloth.yaml
+++ b/recipes/qwen3.8/qwen3.8-27b-nvfp4-unsloth.yaml
@@ -1,0 +1,114 @@
+recipe_version: "2"
+model: unsloth/Qwen3.8-27B-NVFP4
+runtime: atlas
+container: avarok/atlas-gb10:latest
+max_nodes: 1
+
+metadata:
+  description: |
+    Qwen3.8-27B (unsloth NVFP4, dense hybrid SSM+Attn) — the AGENTIC profile,
+    and the config the `agentic-webserver` gate's dense variant is measured
+    under.
+
+    Qwen3.8-27B is ARCHITECTURALLY IDENTICAL to Qwen3.6-27B: all 1968 tensors
+    match in name, shape and dtype; the compressed-tensors quantization config
+    differs only by a version string (0.17.2.a20260707 → a20260716); the
+    tokenizer vocab (248044), merges (247587) and 33 added_tokens hash
+    identically. Verified 2026-08-14. Only the WEIGHTS differ. Practical
+    consequences: the kernel path, serve flags and BFCL draw all carry over
+    unchanged — but no score baseline does, because scores are a property of
+    weights.
+
+    ⚠ THIS IS THE AGENTIC PROFILE, NOT THE BFCL ONE. Thinking is ON and there
+    is no tool-call parser pinned here. The 27B sibling recipe
+    qwen3.6-27b-nvfp4-unsloth.yaml is the BFCL/tool-calling config (thinking
+    OFF, qwen3_coder parser, grammar disabled) and is measured on a completely
+    different gate. Do not cross-use them: the two differ in thinking, KV/head
+    precision, scheduler, SSM cache geometry AND memory budget.
+
+    PROVENANCE OF THE FLAGS BELOW — read before changing any of them.
+
+    Every value here is pinned to ONE measured run, not to prose:
+    2026-08-14, dgx2 (GB10), binary main 680b3a568 — which is exactly what
+    `avarok/atlas-gb10:latest` resolved to on that date — agentic-webserver
+    N=10: webserver_ok 10/10, followed_directions 10/10, Σwall 1925.1 s,
+    per-run walls 156.0 / 187.3 / 274.2 / 144.7 / 230.5 / 243.3 / 205.2 /
+    117.3 / 185.2 / 181.4 s (117–274 s, 2.3× min-to-max).
+
+    1. `gpu_memory_utilization: 0.85` + `max_batch_size: 1` are REQUIRED, not
+       preferences. The 35B flagship's agentic profile (0.70 util, batch 2)
+       CANNOT serve this model at all — it dies at boot with
+       "No memory left for KV cache: total GPU = 121.7 GB, budget 85.2 GB, but
+       57.4 GB already consumed + 44.0 GB inference reserve = 101.4 GB
+       committed." A dense 27B commits 57.4 GB where the 35B MoE commits ~35.
+       Lowering util or raising batch size here reproduces that boot failure.
+
+    2. `lm_head_dtype: bf16` is a correctness pin, not a tuning knob. The
+       248K-vocab projection stays full precision so argmax over the vocab is
+       exact. Reducing it below bf16 is measured-catastrophic on long
+       structured agentic generation for this family (low-margin argmax flips
+       compound over a trajectory) even when short-prompt coherence looks
+       clean — so it cannot be validated by a smoke test.
+
+    3. `num_drafts: 3` (MTP K=4 verify) is EXPLICIT on purpose, and is the K
+       the reference run actually executed. Two reasons it must be written out
+       rather than left to default:
+         - On images at/older than 680b3a568, `--num-drafts` was silently
+           discarded (it carried a clap default of 1 which the MODEL.toml merge
+           also used as its "flag not passed" sentinel), and this checkpoint
+           resolved to the qwen3.6-27b kernel target whose
+           `default_num_drafts = 3` then won. So the reference tier ran at K=4
+           whatever the recipe said.
+         - On images carrying the fix plus the dedicated qwen3.8-27b target,
+           that target deliberately omits `default_num_drafts`, so an OMITTED
+           value would resolve to the engine default of 1 (K=2) — a different
+           config from the one measured.
+       Writing `3` yields K=4 on both sides of that change, which is the only
+       value that keeps this recipe reproducing its own reference run.
+       ★ K=2 is UNTESTED on these weights. If a future tier A/Bs it and wins,
+       change this — but do not assume it, and do not "tidy" it away.
+
+    4. `kv_cache_dtype: bf16` at the 32K agentic operating point: bf16 KV is
+       both faster and higher quality than calibrated fp8 KV at ≤32K for this
+       family; fp8 KV is a memory lever for ~128K, which this profile is not.
+
+    5. `ssm_cache_slots: 256` / `ssm_checkpoint_interval: 16` is the agentic
+       (multi-turn, long-prefix) geometry, deliberately denser than the
+       128/32 the BFCL sibling uses — agentic trajectories re-enter long
+       shared prefixes far more often.
+
+    WHAT THIS RECIPE DOES NOT CLAIM: a wall-time band. Σwall 1925 s is ONE
+    tier. The gate entry that consumes this recipe
+    (kernels/gb10/qwen3.8-27b/BENCH.toml) carries an explicitly PROVISIONAL
+    2500 s ceiling for exactly that reason. Do not read 1925 s as a target.
+
+  maintainer: Atlas
+  category: agent
+  model_params: 27B dense hybrid (48 GDN linear-attn + 16 softmax-attn layers)
+  model_dtype: nvfp4
+  quantization: NVFP4 (mixed precision above layer 55, FP8 linear_attn projections)
+  kv_dtype: bf16
+  updated: "2026-08-14"
+
+defaults:
+  host: 0.0.0.0
+  port: 8888
+  # 32K agentic operating point — matches the reference run exactly.
+  max_model_len: 32768
+  # See provenance note 1: 0.85/1 is the only combination that boots.
+  max_batch_size: 1
+  gpu_memory_utilization: 0.85
+  kv_cache_dtype: bf16
+  # See provenance note 2 — correctness pin, do not lower.
+  lm_head_dtype: bf16
+  kv_high_precision_layers: auto
+  scheduling_policy: slai
+  enable_prefix_caching: true
+  # See provenance note 5 — agentic geometry, denser than the BFCL sibling's.
+  ssm_cache_slots: 256
+  ssm_checkpoint_interval: 16
+  speculative: true
+  # See provenance note 3 — explicit K, reproduces the reference run on images
+  # both before and after the --num-drafts precedence fix.
+  num_drafts: 3
+  mtp_quantization: bf16

--- a/recipes/qwen3.8/qwen3.8-27b-nvfp4-unsloth.yaml
+++ b/recipes/qwen3.8/qwen3.8-27b-nvfp4-unsloth.yaml
@@ -82,6 +82,45 @@ metadata:
     (kernels/gb10/qwen3.8-27b/BENCH.toml) carries an explicitly PROVISIONAL
     2500 s ceiling for exactly that reason. Do not read 1925 s as a target.
 
+    ★ RAISE `max_model_len` FOR REAL AGENTIC CODING — 32768 IS A GATE VALUE,
+      NOT A RECOMMENDATION.
+
+    32K is here because it is the operating point the reference run was
+    measured at, and a gate config must be reproducible. It is NOT the right
+    context for day-to-day agentic coding: a coding session that reads a few
+    files, holds a diff and keeps tool history will exhaust 32K quickly, and
+    once it does you lose the earliest turns — usually the task statement.
+    The checkpoint supports 262144 natively and extends to ~1M with YaRN.
+
+    To raise it, override `max_model_len` at run time rather than editing this
+    file, so the gate config stays reproducible:
+
+        sparkrun run @atlas/qwen3.8-27b-nvfp4-unsloth --max-model-len 131072
+
+    Two honest constraints before you do:
+
+    1. QUALITY IS NOT CHARACTERIZED ABOVE ~24K. The kernel target declares
+       `effective_context = 24576` for this model — an empirical bound carried
+       over from Qwen3.6-27B and explicitly UNMEASURED on 3.8 weights. So even
+       the 32K default already sits above the bound anyone has evidence for,
+       and a larger window is extrapolating twice. Longer context will not
+       error; it may quietly get worse. Treat a big window as "more room
+       before truncation", not as "more usable reasoning".
+
+    2. KV MEMORY IS THE BINDING CONSTRAINT, and this profile has little slack.
+       Weights alone commit 57.4 GB of a 121.7 GB board, and 0.85 util is
+       already near the top (see note 1 — the boot failure is real and easy to
+       reproduce). Raising context without freeing KV bytes will fail at boot
+       the same way. The lever is `kv_cache_dtype: fp8`, which roughly halves
+       KV bytes and is what this model's own MODEL.toml carries as its
+       default; the bf16-KV preference in note 4 is specific to <=32K, so it
+       is the right trade to make when you leave that regime. Keep
+       `max_batch_size: 1`.
+
+    In short: 32K + bf16 KV for reproducing the gate; larger context + fp8 KV
+    for actually working in the model, accepting that quality past ~24K is
+    uncharacterized on these weights.
+
   maintainer: Atlas
   category: agent
   model_params: 27B dense hybrid (48 GDN linear-attn + 16 softmax-attn layers)
@@ -93,7 +132,12 @@ metadata:
 defaults:
   host: 0.0.0.0
   port: 8888
-  # 32K agentic operating point — matches the reference run exactly.
+  # 32K is the GATE operating point — it matches the reference run exactly and
+  # exists to be reproducible, not because it is the right context for real
+  # work. ★ For agentic coding, RAISE THIS at run time (e.g.
+  # `--max-model-len 131072`) and pair it with `kv_cache_dtype: fp8`; see the
+  # "RAISE max_model_len" section above for the two constraints that come with
+  # it (quality is uncharacterized above ~24K, and KV memory is the binder).
   max_model_len: 32768
   # See provenance note 1: 0.85/1 is the only combination that boots.
   max_batch_size: 1


### PR DESCRIPTION
Adds `qwen3.8/qwen3.8-27b-nvfp4-unsloth`, the recipe the dense variant of Atlas's
`agentic-webserver` gate references. Without it that variant cannot self-start under
`--pull-request-gate` (Avarok-Cybersecurity/atlas#513 lands the variant; this is its missing
dependency).

## What this checkpoint is

`unsloth/Qwen3.8-27B-NVFP4` is **architecturally identical** to `unsloth/Qwen3.6-27B-NVFP4`:
all 1968 tensors match in name, shape and dtype; the compressed-tensors quantization config
differs only by a version string (`0.17.2.a20260707` → `a20260716`); the tokenizer vocab
(248044), merges (247587) and 33 added_tokens hash identically. Verified 2026-08-14.

Only the **weights** differ. So the kernel path and serve flags carry over unchanged — and no
score baseline does, because scores are a property of weights.

## Agentic, not BFCL

This is deliberately the *agentic* profile — thinking ON, no tool-call parser pinned. The
existing `qwen3.6-27b-nvfp4-unsloth` is the BFCL/tool-calling config (thinking OFF,
`qwen3_coder`, grammar disabled), measured on a different gate. The two differ in thinking,
head/KV precision, scheduler, SSM cache geometry **and** memory budget, so they are not
interchangeable; the recipe says so explicitly.

## Provenance

Every value pins one measured run: 2026-08-14, dgx2 (GB10), binary main `680b3a568` — which is
what `avarok/atlas-gb10:latest` resolved to that day — `agentic-webserver` N=10:

```
webserver_ok          10/10
followed_directions   10/10
Σ wall                1925.1 s
per-run               156.0 187.3 274.2 144.7 230.5 243.3 205.2 117.3 185.2 181.4  (117–274 s)
```

Three flags are load-bearing rather than tuned:

**`gpu_memory_utilization: 0.85` + `max_batch_size: 1`** — the only combination that boots. The
35B flagship's agentic profile (0.70 util, batch 2) cannot serve this model at all:

```
No memory left for KV cache: total GPU = 121.7 GB, --gpu-memory-utilization 70% → budget 85.2 GB,
but 57.4 GB already consumed + 44.0 GB inference reserve = 101.4 GB committed.
```

A dense 27B commits 57.4 GB where the 35B MoE commits ~35 GB. This was hit for real before the
reference run, not reasoned about.

**`lm_head_dtype: bf16`** — a correctness pin. The 248K-vocab projection stays full precision so
argmax is exact. Reducing it is measured-catastrophic on long structured agentic generation for
this family (low-margin argmax flips compound over a trajectory) even when short-prompt coherence
looks clean, so it cannot be validated by a smoke test.

**`num_drafts: 3`** (MTP K=4) — explicit because omitting it is *not stable across images*. On
images at/older than `680b3a568`, `--num-drafts` was silently discarded (a clap default of 1
doubled as the MODEL.toml merge's "flag not passed" sentinel) and this checkpoint resolved to the
`qwen3.6-27b` kernel target, whose `default_num_drafts = 3` then won — so the reference tier ran
at K=4 regardless. On images carrying the fix plus the dedicated `qwen3.8-27b` target, that target
omits `default_num_drafts`, so an omitted value would resolve to K=2. Writing `3` reproduces the
reference run on both sides of that change. **K=2 is untested on these weights** — noted in the
recipe so nobody "tidies" it away.

## What this does not claim

A wall-time band. Σwall 1925 s is **one tier**. The gate entry consuming this recipe carries an
explicitly provisional 2500 s ceiling for that reason; 1925 s is not a target.

## Also

Refreshes the README's `-unsloth` note, which still said "there is deliberately no `-unsloth`
recipe yet" after #15 shipped one, and adds the catalogue row.

All 15 `defaults` keys were checked against the keys existing recipes already use — no new or
misspelled keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
