### PR TITLE
feat(qwen3.6): FAST diet-8k and INTEL recipes for NVFP4 35B

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ image — pull a newer `avarok/atlas-gb10:dev`.
 | Recipe | Model | Topology | Notes |
 |---|---|---|---|
 | `qwen3.6-35b-a3b-nvfp4` | nvidia/Qwen3.6-35B-A3B-NVFP4 | single | **DEFAULT 35B** — MTP K=1 (pinned; 116.5 tok/s), calibrated fp8 KV (128K), qwen3_coder agentic stack; requires :dev ≥ 2026-07-10 (atlas#287) |
+| `qwen3.6-35b-a3b-nvfp4-diet-8k` | nvidia/Qwen3.6-35B-A3B-NVFP4 | single | **FAST** single-user memory diet (8k / gpu-mem 0.40) — ~112 tok/s no-think, ~40GB MemAvailable; MTP K=1 pinned |
+| `qwen3.6-35b-a3b-nvfp4-intel` | nvidia/Qwen3.6-35B-A3B-NVFP4 | single | **INTEL** — thinking on, tool parser on, 32k / gpu-mem 0.55; maximize explanation+result (25/32), not tok/s |
 | `qwen3.6-27b-nvfp4` | nvidia/Qwen3.6-27B-NVFP4 | single | **DEFAULT 27B** — dense hybrid SSM+Attn, MTP K=1 (pinned), bf16 KV, qwen3_coder agentic stack; requires :dev ≥ 2026-07-10 (atlas#287) |
 | `qwen3.8-27b-nvfp4-unsloth` | unsloth/Qwen3.8-27B-NVFP4 | single | Dense hybrid SSM+Attn — the AGENTIC gate config: thinking ON, bf16 head + bf16 KV, 32K, MTP K=4, slai. Architecturally identical to Qwen3.6-27B (all 1968 tensors match); only the weights differ |
 | `qwen3.6-35b-a3b-fp8-mtp` | Qwen/Qwen3.6-35B-A3B-FP8 | single | Flagship FP8 — native FP8, bf16 head + bf16 KV, 64K ctx, MTP K=2, live tool-call streaming |
@@ -92,6 +94,11 @@ image — pull a newer `avarok/atlas-gb10:dev`.
 
 ```
 recipes/
+├── qwen3.6/
+│   ├── qwen3.6-35b-a3b-nvfp4.yaml
+│   ├── qwen3.6-35b-a3b-nvfp4-diet-8k.yaml
+│   ├── qwen3.6-35b-a3b-nvfp4-intel.yaml
+│   └── …
 ├── qwen3.5/
 │   ├── qwen3.5-27b-dense-nvfp4.yaml
 │   ├── qwen3.5-35b-a3b-nvfp4.yaml

--- a/recipes/qwen3.6/NOTES-qwen3.6-35b-a3b-nvfp4-diet-8k.md
+++ b/recipes/qwen3.6/NOTES-qwen3.6-35b-a3b-nvfp4-diet-8k.md
@@ -1,0 +1,114 @@
+# NOTES: `qwen3.6-35b-a3b-nvfp4-diet-8k` (FAST)
+
+Single-user GB10 **fast** memory-diet recipe for `nvidia/Qwen3.6-35B-A3B-NVFP4`.
+Maximize **tok/s + host RAM**, not reasoning depth.
+
+Evidence: spark-9f9e serve-flag matrix **2026-08-11** (3-run medians,
+no-think short decode, ~256 completion tokens). Winner: `diet_40_8k`.
+
+Sibling INTEL recipe (`qwen3.6-35b-a3b-nvfp4-intel`) is a separate stem —
+do **not** collapse into one always-`--disable-thinking` doc.
+
+## TL;DR (must not regress)
+
+1. **Winner pins:** `--disable-thinking --gpu-memory-utilization 0.40
+   --max-seq-len 8192 --speculative --num-drafts 1 --kv-cache-dtype fp8
+   --kv-high-precision-layers auto --scheduling-policy slai
+   --enable-prefix-caching --tool-call-parser qwen3_coder`
+2. **Do NOT raise `--num-drafts`** on this MoE for single-user decode
+   (K=2 ~80, K=3 ~57, ngram ~89 vs K=1 ~112).
+3. **Nsight:** short decode is **MoE W4A16 expert GEMV-bound** (~66%
+   top-3), not attention/host. **Do not promise KV-dtype flips as a
+   short-decode tok/s win.**
+4. Client: `enable_thinking: false`.
+
+## Matrix leaderboard (spark-9f9e, 2026-08-11)
+
+| tag | decode tok/s median | TTFT ms median | MemAvailable GB |
+|---|---:|---:|---:|
+| **diet_40_8k (winner)** | **111.91** | **141.9** | **40.79** |
+| baseline_spec_k1 | 111.78 | 143.0 | 7.13 |
+| no_tool_parser | 111.77 | 143.1 | 7.14 |
+| mtp_vocab_100k | 111.5 | 144.0 | 7.16 |
+| diet_55_32k | 111.13 | 142.9 | 31.1 |
+| ngram_spec | 89.47 | 160.9 | 7.4 |
+| spec_k2 (num-drafts 2) | 79.86 | 175.0 | 7.07 |
+| spec_k3 (num-drafts 3) | 56.94 | 215.2 | 6.96 |
+
+`diet_40_8k` runs: `[98.95, 113.36, 111.91]` → median ~112 tok/s.
+Same speed as high-context baseline, ~6× more free host RAM.
+
+## Do not raise `--num-drafts` on this MoE for single-user decode
+
+Raising num-drafts hurt hard on this hybrid SSM model:
+
+| drafts | decode tok/s median |
+|---|---:|
+| K=1 (pinned) | ~111.9 |
+| K=2 | ~79.9 |
+| K=3 | ~56.9 |
+| ngram | ~89.5 |
+
+Pin `num_drafts: 1`. MTP gate "ENABLED" is not evidence a deeper draft
+is profitable — only a no-spec A/B is.
+
+## Winner flags (parked Cmd)
+
+```bash
+spark serve nvidia/Qwen3.6-35B-A3B-NVFP4 \
+  --port 8888 \
+  --kv-cache-dtype fp8 --kv-high-precision-layers auto \
+  --scheduling-policy slai --enable-prefix-caching --disable-thinking \
+  --gpu-memory-utilization 0.40 --max-seq-len 8192 \
+  --speculative --num-drafts 1 --tool-call-parser qwen3_coder
+```
+
+## Nsight short-decode (diet_40_8k) — GEMV wall
+
+Sources (spark-9f9e):
+- `~/atlas-perf/nsys/decode-diet40-wrap-20260812-024656.nsys-rep`
+- `~/atlas-perf/nsys/FINDINGS.md`
+- `~/atlas-perf/nsys/ncu/COMPUTE_FINDINGS.md` (ncu **blocked** —
+  `ERR_NVGPUCTRPERM` / RmProfilingAdminOnly; Systems FINDINGS still valid)
+
+**Verdict:** GPU/kernel-bound on MoE W4A16 expert GEMV — **not**
+attention, **not** host. Profiler tax ~91 tok/s under nsys vs ~112
+baseline.
+
+| % GPU time | kernel |
+|---:|---|
+| 28.3 | `w4a16_gemv_batch2` |
+| 24.4 | `moe_expert_gate_up_shared_batch2` |
+| 13.8 | `moe_expert_silu_down_shared_batch2` |
+| **~66** | **top-3 MoE/W4A16 combined** |
+| 6.8 | `dense_gemv_bf16` |
+| 4.2 | `gated_delta_rule_wy2` |
+| **&lt;2** | **`paged_decode_attn_fp8` / `paged_decode_attn`** |
+
+Supporting API profile: `cuStreamSynchronize` ~51% → waiting on GPU,
+not launch-starved CPU. DtoH async API time notable but secondary.
+
+**Recipe implications (do not soften):**
+- Round-2 `--kv-cache-dtype nvfp4` may still free KV memory; it is **not**
+  a promised short-decode tok/s win (attention ≪ 2% of kernel time).
+- Real speed follow-up is **kernel** work on expert GEMV path (ncu
+  roofline when privilege unlocked; fuse/retune gate_up+silu_down) —
+  Sparker owns that lane, not this recipe PR.
+
+## Prefill profile
+
+One-liner: `~/atlas-perf/nsys/FINDINGS-prefill4k.md` — GEMM+GDN hot set, TTFT ~2.56s @ ~6.7k prompt (diet_40 cold prefill). Prefill ≠ decode GEMV wall; do not promise decode-kernel fixes for TTFT.
+
+## Round-2 follow-ups for FAST (stubs only — unmeasured)
+
+- `--max-batch-size 1` / `--max-num-seqs 1`
+- `--kv-cache-dtype nvfp4` (memory experiment; see Nsight caveat)
+- `--ssm-cache-slots 0`
+- `--disable-tool-grammar true` / omit tool parser
+- DFlash alt (`--dflash` + `z-lab/Qwen3.6-35B-A3B-DFlash`)
+
+## Repro (after merge)
+
+```bash
+sparkrun run @atlas/qwen3.6-35b-a3b-nvfp4-diet-8k
+```

--- a/recipes/qwen3.6/NOTES-qwen3.6-35b-a3b-nvfp4-intel.md
+++ b/recipes/qwen3.6/NOTES-qwen3.6-35b-a3b-nvfp4-intel.md
@@ -1,0 +1,86 @@
+# NOTES: `qwen3.6-35b-a3b-nvfp4-intel` (INTEL)
+
+Sibling of the **fast** `qwen3.6-35b-a3b-nvfp4-diet-8k` recipe.
+Maximize **intelligence**: (1) ability to explain itself and
+(2) superhuman-quality results — vs the fast disable-thinking lane.
+
+**Tok/s is not the success metric.** Canary pass/fail alone is not enough.
+
+Measured on spark-9f9e **2026-08-11/12**. Canonical score sheet:
+`~/atlas-intel-eval/out/SCORED.md` (scored 2026-08-12 03:09 UTC).
+
+## Two-track layout
+
+| stem | goal | thinking | tools | mem/seq |
+|---|---|---|---|---|
+| `…-diet-8k` | tok/s + host RAM | off | parser on | 8k / 0.40 |
+| `…-intel` (this) | explanation + answer caliber | **on** | parser **on** | **32k / 0.55** |
+
+Do not merge into one always-disable-thinking document.
+
+## Locked serve flags (measured park)
+
+```bash
+spark serve nvidia/Qwen3.6-35B-A3B-NVFP4 \
+  --port 8888 \
+  --kv-cache-dtype fp8 --kv-high-precision-layers auto \
+  --scheduling-policy slai --enable-prefix-caching \
+  --gpu-memory-utilization 0.55 --max-seq-len 32768 \
+  --speculative --num-drafts 1 \
+  --tool-call-parser qwen3_coder
+  # thinking ON: omit --disable-thinking
+```
+
+Client: `enable_thinking: true`.
+
+Still pin `--num-drafts 1` (FAST Round-1: K=2/3 regress on this MoE).
+
+**32k / 0.55 is locked for now.** Higher `max-seq-len` remains
+**optional** later for long agent threads — **not** required by this
+eval (needle ~3.3k worked).
+
+## Success metrics (from SCORED.md)
+
+| axis | score |
+|---|---:|
+| Explanation | **13/16** |
+| Result (answer caliber) | **12/16** |
+| Combined | **25/32** |
+| Pass bar (≥3, neither axis 0) | **5/8 pass** (3/8 soft-fail at 2) |
+| Thinking present | **8/8** (`reasoning_tokens` ~256–273) |
+
+### Per-item
+
+| id | expl | result | sum | finish | note |
+|---|---:|---:|---:|---|---|
+| math_hard_explain_01 | 2 | 1 | 3 | stop | theory OK; missed ANSWER_* lines |
+| math_constraint_explain_02 | 2 | 2 | 4 | stop | full pass |
+| code_subtle_bug_01 | 2 | 2 | 4 | stop | full pass |
+| tool_json_plan_01 | 2 | 2 | 4 | stop | clean JSON / allowlisted tools |
+| needle_recall_explain_01 | 2 | 2 | 4 | stop | strong needle @ ~3.3k |
+| adversarial_ambiguous_01 | 1 | 1 | 2 | length | runaway content |
+| expert_synthesis_01 | 1 | 1 | 2 | stop | soft dual-resident flirt |
+| code_algo_invariant_01 | 1 | 1 | 2 | length | runaway / meta loop |
+
+Hard human-trap fails: **none**. Soft miss on `expert_synthesis_01`.
+Delivery failures (not KV): length-cap on adversarial + binary-search.
+
+Secondary tok/s in SCORED.md is informational only — do not cite as
+the reason to ship or reject this recipe.
+
+## Binding limiter (not 32k KV headroom)
+
+The binding failure mode is **max_tokens / runaway content after short
+~256-token thinking**, not context window:
+
+- `adversarial_ambiguous_01` and `code_algo_invariant_01` hit
+  `finish_reason=length` with process text leaking into `content`
+- One format omission (`ANSWER_*`) on doors math
+- Next knobs: clearer stop after final answer / selective max_tokens —
+  **not** raising max-seq first
+
+## Repro (after merge)
+
+```bash
+sparkrun run @atlas/qwen3.6-35b-a3b-nvfp4-intel
+```

--- a/recipes/qwen3.6/qwen3.6-35b-a3b-nvfp4-diet-8k.yaml
+++ b/recipes/qwen3.6/qwen3.6-35b-a3b-nvfp4-diet-8k.yaml
@@ -1,0 +1,65 @@
+recipe_version: "2"
+model: nvidia/Qwen3.6-35B-A3B-NVFP4
+runtime: atlas
+container: avarok/atlas-gb10:dev
+max_nodes: 1
+
+metadata:
+  description: |
+    Qwen3.6-35B-A3B (nvidia modelopt NVFP4) — FAST single-user
+    memory-diet profile for one GB10 (maximize tok/s + host RAM, not
+    reasoning depth). Same short-decode speed as the high-context
+    default (~112 tok/s no-think) but frees host RAM (~40 GB MemAvailable
+    vs ~7 GB at max-seq 131k / gpu-mem 0.92).
+
+    Sibling INTEL recipe (thinking on, tool parser/grammar on, higher
+    mem/seq) is tracked separately — do not collapse into this stem.
+
+    Winner of the 2026-08-11 spark-9f9e serve-flag matrix (`diet_40_8k`):
+    --gpu-memory-utilization 0.40 --max-seq-len 8192 with MTP K=1,
+    calibrated fp8 KV, slai, prefix caching, qwen3_coder parser,
+    --disable-thinking. 3-run median decode 111.91 tok/s
+    (runs 98.95 / 113.36 / 111.91); TTFT median 141.9 ms;
+    MemAvailable 40.79 GB. See NOTES-qwen3.6-35b-a3b-nvfp4-diet-8k.md
+    for the full leaderboard.
+
+    num_drafts is pinned to 1. Do NOT raise num-drafts on this MoE for
+    single-user decode: the same matrix measured K=2 ~79.9 tok/s and
+    K=3 ~56.9 tok/s (regressions), ngram ~89.5. "ENABLED" in the MTP
+    gate log is not evidence a deeper draft is profitable.
+
+    This is intentionally NOT the default 35B recipe — keep
+    qwen3.6-35b-a3b-nvfp4.yaml for high-context agentic work. Use this
+    diet stem when you want single-user decode headroom on the host.
+
+    Round-2 follow-ups (stubs only, not measured; see NOTES):
+    max-batch/seqs 1, kv nvfp4, ssm-cache-slots 0,
+    disable-tool-grammar, omit tool parser, DFlash alt.
+    Nsight (diet_40_8k short decode): MoE W4A16 expert GEMV-bound
+    (~66% top-3); do not promise KV-dtype as a short-decode win.
+  maintainer: avarok
+  category: agent
+  model_params: 35B
+  model_dtype: nvfp4
+  quantization: nvfp4
+  kv_dtype: fp8
+
+defaults:
+  port: 8888
+  host: 0.0.0.0
+  # Memory diet: 8k ctx + low gpu-mem keeps ~112 tok/s while freeing
+  # ~40 GB host RAM vs the 131k/0.92 baseline (~7 GB available).
+  max_model_len: 8192
+  kv_cache_dtype: fp8
+  gpu_memory_utilization: 0.40
+  scheduling_policy: slai
+  speculative: true
+  # Do not raise on this MoE for single-user decode (K=2/3 regress).
+  num_drafts: 1
+  mtp_quantization: bf16
+  enable_prefix_caching: true
+  # fp8 KV requires online K/V scale calibration on this checkpoint.
+  fp8_kv_calibration_tokens: 256
+  kv_high_precision_layers: auto
+  tool_call_parser: qwen3_coder
+  disable_thinking: true

--- a/recipes/qwen3.6/qwen3.6-35b-a3b-nvfp4-intel.yaml
+++ b/recipes/qwen3.6/qwen3.6-35b-a3b-nvfp4-intel.yaml
@@ -1,0 +1,51 @@
+recipe_version: "2"
+model: nvidia/Qwen3.6-35B-A3B-NVFP4
+runtime: atlas
+container: avarok/atlas-gb10:dev
+max_nodes: 1
+
+metadata:
+  description: |
+    Qwen3.6-35B-A3B (nvidia modelopt NVFP4) — INTEL single-user profile
+    for one GB10. Maximize explanation quality + answer caliber
+    (superhuman-quality results), not tok/s.
+
+    Measured 2026-08-11/12 on spark-9f9e (thinking-on park). Eval
+    ~/atlas-intel-eval/out/SCORED.md: explanation 13/16, result 12/16,
+    combined 25/32; 5/8 cleared the >=3 pass bar; thinking present on
+    all 8. Needle/tool JSON strong. Failures were length-cap / soft
+    traps, not 32k headroom.
+
+    Sibling FAST recipe is qwen3.6-35b-a3b-nvfp4-diet-8k (disable-thinking
+    memory diet). Keep these as separate stems — do not collapse into
+    one always-disable-thinking doc.
+
+    Locked serve shape: thinking enabled, MTP drafts=1, qwen3_coder
+    tool parser, gpu-mem 0.55, max-seq 32768, fp8 KV. Higher max-seq
+    is optional later for long agent threads, not required by this eval.
+    See NOTES-qwen3.6-35b-a3b-nvfp4-intel.md.
+  maintainer: avarok
+  category: agent
+  model_params: 35B
+  model_dtype: nvfp4
+  quantization: nvfp4
+  kv_dtype: fp8
+
+defaults:
+  port: 8888
+  host: 0.0.0.0
+  # Locked from measured intel park (spark-9f9e, 2026-08-11/12).
+  max_model_len: 32768
+  kv_cache_dtype: fp8
+  gpu_memory_utilization: 0.55
+  scheduling_policy: slai
+  speculative: true
+  # Same MTP pin as FAST: deeper drafts still hurt this MoE decode.
+  num_drafts: 1
+  mtp_quantization: bf16
+  enable_prefix_caching: true
+  fp8_kv_calibration_tokens: 256
+  kv_high_precision_layers: auto
+  tool_call_parser: qwen3_coder
+  # Thinking ON — omit --disable-thinking / leave false.
+  disable_thinking: false


### PR DESCRIPTION
## Summary

One PR for both measured sibling stems of `nvidia/Qwen3.6-35B-A3B-NVFP4`. Same YAML + NOTES already vendored on `facepunch47/atlas` (PR #6) as spark-server fixtures. This is the public sparkrun `@atlas/` catalogue landing.

Fork PR (do not merge that one first unless you prefer the fork path): https://github.com/facepunch47/atlas-recipes/pull/1

- Add `qwen3.6-35b-a3b-nvfp4-diet-8k` — **FAST** single-user GB10 memory-diet profile (maximize tok/s + host RAM).
- Pins from spark-9f9e matrix winner `diet_40_8k` (2026-08-11):
  `--disable-thinking --gpu-memory-utilization 0.40 --max-seq-len 8192
  --speculative --num-drafts 1 --kv-cache-dtype fp8 …`
- Median short no-think decode **~112 tok/s** with **~41 GB** MemAvailable
  (vs ~7 GB on high-context baseline at same speed).
- NOTES: full leaderboard, **do not raise num-drafts** (K=2/3 regress),
  Nsight GEMV wall (MoE W4A16 ~66% top-3; attn <2%) — **do not promise
  KV-dtype as a short-decode tok/s win**.
- Add `qwen3.6-35b-a3b-nvfp4-intel` — **INTEL** single-user GB10 profile
  (maximize explanation quality + answer caliber, **not** tok/s).
- Locked pins from measured thinking-on park (spark-9f9e, 2026-08-11/12):
  omit `--disable-thinking`, `--gpu-memory-utilization 0.55`,
  `--max-seq-len 32768`, `--speculative --num-drafts 1`, fp8 KV,
  `--tool-call-parser qwen3_coder`.
- Eval: **expl 13/16**, **result 12/16**, **combined 25/32**, **5/8** pass bar; thinking on all 8.
- Binding limiter was **max_tokens / runaway content** after short
  thinking — **not** 32k KV headroom.
- Does **not** change the default high-context `qwen3.6-35b-a3b-nvfp4`
  recipe. Stems stay separate — do not collapse into one always-disable-thinking doc.

YAML is faithful to the measured park: FAST 8k / 0.40 thinking off; INTEL 32k / 0.55 thinking on. Recipe-only extras inherited from the sibling nvfp4 recipe (not contradictory): `mtp_quantization: bf16`, `fp8_kv_calibration_tokens: 256`.

## Evidence

| source | path / note |
|---|---|
| FAST matrix | spark-9f9e `/tmp/atlas-matrix` — winner `diet_40_8k` 111.91 tok/s, 40.79 GB |
| FAST Nsight | `~/atlas-perf/nsys/decode-diet40-wrap-20260812-024656.nsys-rep` + `FINDINGS.md` |
| FAST ncu | blocked `ERR_NVGPUCTRPERM` — see `~/atlas-perf/nsys/ncu/COMPUTE_FINDINGS.md` |
| INTEL scores | expl 13/16, result 12/16, combined 25/32, pass 5/8 |

## Files

- `recipes/qwen3.6/qwen3.6-35b-a3b-nvfp4-diet-8k.yaml`
- `recipes/qwen3.6/NOTES-qwen3.6-35b-a3b-nvfp4-diet-8k.md`
- `recipes/qwen3.6/qwen3.6-35b-a3b-nvfp4-intel.yaml`
- `recipes/qwen3.6/NOTES-qwen3.6-35b-a3b-nvfp4-intel.md`
- `README.md` (catalogue rows + qwen3.6 layout)

## Test plan

- [x] YAML matches sibling `recipe_version: "2"` schema
- [x] FAST pins: `disable_thinking: true`, `gpu_memory_utilization: 0.40`, `max_model_len: 8192`, `num_drafts: 1`
- [x] INTEL pins: `disable_thinking: false`, `gpu_memory_utilization: 0.55`, `max_model_len: 32768`, `num_drafts: 1`
- [x] Shared: fp8 KV, speculative, `qwen3_coder`, slai, prefix cache
- [ ] Default `qwen3.6-35b-a3b-nvfp4.yaml` unchanged
- [ ] Live `:8888` was **not** bounced for this docs PR
- [ ] `sparkrun recipe show @atlas/qwen3.6-35b-a3b-nvfp4-diet-8k` / `…-intel` after merge

## Notes for reviewers

- Round-2 stubs (max-batch/seqs 1, kv nvfp4, …) are documented as unmeasured.
- Kernel speedups belong to Sparker’s lane (expert GEMV), not this PR.
- Do not judge INTEL on decode tok/s. Next quality knobs: stop-after-final / selective max_tokens, not context.