### PR TITLE
recipes: enable video_allow_ffmpeg on the video-fidelity gate serves

### DIFF
--- a/recipes/qwen3.6/qwen3.6-27b-nvfp4-unsloth.yaml
+++ b/recipes/qwen3.6/qwen3.6-27b-nvfp4-unsloth.yaml
@@ -47,7 +47,7 @@ metadata:
   model_params: 27B dense hybrid (48 GDN linear-attn + 16 softmax-attn layers)
   quantization: NVFP4 (mixed precision above layer 55)
   kv_dtype: bf16
-  updated: "2026-08-06"
+  updated: "2026-08-15"
 
 defaults:
   host: 0.0.0.0
@@ -65,3 +65,10 @@ defaults:
   tool_call_parser: qwen3_coder
   disable_tool_grammar: true
   disable_thinking: true
+  # video-fidelity gate — this recipe is that gate's default serve (added
+  # 2026-08-15). The MP4/MOV legs are decoded by the server shelling out to
+  # ffmpeg, which stays OFF unless the serve pins it, and the certified
+  # self-start refuses --serve-override for keys absent from these defaults —
+  # so without this line every MP4 leg 400s and the gate goes red. Inert for
+  # bfcl-subset and agentic, which send no video.
+  video_allow_ffmpeg: true

--- a/recipes/qwen3.6/qwen3.6-35b-a3b-fp8-bf16head.yaml
+++ b/recipes/qwen3.6/qwen3.6-35b-a3b-fp8-bf16head.yaml
@@ -44,3 +44,7 @@ defaults:
   # largest per-token weight read). Argmax over the vocab is exact — no flips.
   lm_head_dtype: bf16
   kv_high_precision_layers: auto
+  # video-fidelity (non-default subject, runnable on demand): MP4/MOV legs
+  # need the server's ffmpeg subprocess decoder, which is off unless the
+  # recipe pins it. Inert for every gate that sends no video.
+  video_allow_ffmpeg: true

--- a/recipes/qwen3.8/qwen3.8-27b-nvfp4-unsloth.yaml
+++ b/recipes/qwen3.8/qwen3.8-27b-nvfp4-unsloth.yaml
@@ -127,7 +127,7 @@ metadata:
   model_dtype: nvfp4
   quantization: NVFP4 (mixed precision above layer 55, FP8 linear_attn projections)
   kv_dtype: bf16
-  updated: "2026-08-14"
+  updated: "2026-08-15"
 
 defaults:
   host: 0.0.0.0
@@ -156,3 +156,7 @@ defaults:
   # both before and after the --num-drafts precedence fix.
   num_drafts: 3
   mtp_quantization: bf16
+  # video-fidelity (non-default subject, runnable on demand): MP4/MOV legs
+  # need the server's ffmpeg subprocess decoder, which is off unless the
+  # recipe pins it. Inert for the agentic/BFCL gates — they send no video.
+  video_allow_ffmpeg: true


### PR DESCRIPTION
The `video-fidelity` certified gate self-starts its server from these recipes and sends MP4/MOV video probes. The server only decodes those containers when ffmpeg is enabled (OFF by default), and `--serve-override` refuses a key absent from recipe defaults — so without this line every MP4 leg returns HTTP 400, the run ends Failed, and no gate record is written. The 13/13 reference run (2026-08-14) was a manual serve with the flag.

Adds `video_allow_ffmpeg: true` to the three recipes named by a video-fidelity BENCH.toml entry (27B default subject, 35B, 3.8 dense). Inert for the bfcl-subset and agentic gates sharing these recipes — no video parts, no subprocess, no effect on model math/memory/scheduling.

Pairs with the atlas-repo change (video/driver.rs skip-path fix) on PR #519.

🤖 Generated with [Claude Code](https://claude.com/claude-code)