### PR TITLE
qwen3-vl: enable prefix caching so a warm gate can be warm

### DIFF
--- a/recipes/qwen3-vl/qwen3-vl-30b-a3b-nvfp4.yaml
+++ b/recipes/qwen3-vl/qwen3-vl-30b-a3b-nvfp4.yaml
@@ -25,3 +25,9 @@ defaults:
   kv_cache_dtype: fp8
   gpu_memory_utilization: 0.88
   scheduling_policy: slai
+  # Without this the ttft-warm-gate has nothing to be warm ABOUT: it serves this
+  # recipe, every warm leg reports `cached 0 tok`, and it re-measures cold
+  # prefill under a warm label. Observed on dgx1 at 546.1 ms warm vs 549.1 ms
+  # cold — the two are within 0.5% because they are the same work. The sibling
+  # qwen3.6-35b-a3b-nvfp4 recipe has carried this since it gained a warm gate.
+  enable_prefix_caching: true


### PR DESCRIPTION
Without `enable_prefix_caching`, `ttft-warm-gate` has nothing to be warm **about**.
The gate serves this recipe under `--pull-request-gate`, every warm leg returns
`cached 0 tok`, and it re-measures cold prefill under a warm label.

Measured on dgx1, `ig1/Qwen3-VL-30B-A3B-Instruct-NVFP4`:

| leg | median | cached |
|---|---:|---:|
| warm 256 tok | 224.1 ms | **0 tok** |
| warm 1024 tok | 546.1 ms | **0 tok** |
| warm 4096 tok | 2191.8 ms | **0 tok** |
| *cold* 1024 tok | 549.1 ms | 0 tok |

Warm and cold agree to **0.5%** because they are the same work. With the flag, the
same box measures warm 1024 tok at **21.8 ms** with **1136 tokens cached** — 25×
apart.

The sibling `qwen3.6/qwen3.6-35b-a3b-nvfp4.yaml` has carried
`enable_prefix_caching: true` since it gained a warm gate; this one was never
updated, because nothing gated it.

**Prerequisite** for the `ttft-warm-gate` entry in the atlas repo's
`kernels/gb10/qwen3-vl-30b-a3b/BENCH.toml`. That gate is being added because
Qwen3-VL's cold TTFT just improved 45.3% (1797 → 983 ms) and nothing held it in
place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01456mJyNZ1EMJAmeQYSMxA1