### PR TITLE
atlasctl-agent: the local agent, end to end

### DIFF
--- a/.github/workflows/bootstrap-publish.yml
+++ b/.github/workflows/bootstrap-publish.yml
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+name: Bootstrap crates.io publish
+
+# A one-off, run by hand.
+#
+# crates.io has no pending-publisher mechanism: a crate must already exist
+# before a Trusted Publisher can be attached to it. So the very first publish
+# of each crate cannot use OIDC and has to present a token. Every release after
+# this one goes through release.yml, which uses Trusted Publishing and stores no
+# token at all.
+#
+# Delete this workflow once the five crates exist and their publishers are
+# configured. It is kept deliberately awkward to run — a typed confirmation, and
+# no automatic trigger — because publishing to crates.io is irreversible.
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type "publish" to confirm. Versions on crates.io are permanent.'
+        required: true
+        type: string
+      dry_run:
+        description: "Package and verify without uploading"
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bootstrap-publish
+
+jobs:
+  publish:
+    name: publish in dependency order
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check the confirmation
+        if: inputs.confirm != 'publish'
+        run: |
+          echo "::error::confirmation not given; nothing was published"
+          exit 1
+
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Test before publishing anything
+        run: cargo test --workspace --locked
+
+      - name: Publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -eu
+          # Order matters: a crate cannot be published until everything it
+          # depends on is already on the registry.
+          for crate in atlas-recipes-data atlasctl-protocol atlasctl-core atlasctl-agent atlasctl; do
+            version=$(cargo metadata --no-deps --format-version 1 \
+              | python3 -c "import json,sys;print(next(p['version'] for p in json.load(sys.stdin)['packages'] if p['name']=='$crate'))")
+
+            # Idempotent: re-running after a partial failure must not trip over
+            # the crates that already went out.
+            if curl -fsSL "https://crates.io/api/v1/crates/$crate/$version" >/dev/null 2>&1; then
+              echo "$crate $version is already published, skipping"
+              continue
+            fi
+
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "would publish $crate $version"
+              continue
+            fi
+
+            echo "publishing $crate $version"
+            cargo publish -p "$crate" --locked
+            # crates.io indexes asynchronously; the next crate depends on this
+            # one resolving, so wait for the index rather than racing it.
+            for _ in $(seq 1 60); do
+              if curl -fsSL "https://crates.io/api/v1/crates/$crate/$version" >/dev/null 2>&1; then
+                echo "  indexed"; break
+              fi
+              sleep 5
+            done
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,13 +91,26 @@ jobs:
           set -eu
           # File list comes from git, not a shell glob: a glob that fails to
           # expand would make this check pass without inspecting anything.
-          files=$(git ls-files 'crates/*/src/*.rs' 'crates/*/src/**/*.rs' \
+          # `git ls-files` skips untracked files, which is fine in CI (the tree
+          # is committed) but silently under-scans when run locally. `find` does
+          # not, so the local and CI runs agree.
+          #
+          # Provider modules are where vendor specifics belong: profile.rs
+          # (device flags), collective.rs (fabric env), telemetry/nvidia.rs and
+          # telemetry/rocm.rs (per-vendor readings).
+          files=$(find crates/*/src -name '*.rs' \
             | grep -vE '(profile|collective)\.rs' \
+            | grep -vE 'telemetry/(nvidia|rocm)\.rs' \
             | grep -vE 'tests\.rs|/tests/')
           [ -n "$files" ] || { echo "no files to scan - the lint is not working"; exit 1; }
           echo "scanning $(echo "$files" | wc -l) files"
+          # Comments are excluded: the point is to keep vendor *behaviour* out
+          # of neutral modules, not to ban the word from prose explaining why
+          # the abstraction exists. A doc comment saying nvidia-smi reports N/A
+          # on unified-memory parts is exactly the note a reader wants.
           # shellcheck disable=SC2086
-          hits=$(grep -nE -- '--gpus|/dev/kfd|/dev/dri|nvidia-smi|rocm-smi|NCCL_' $files || true)
+          hits=$(grep -nE -- '--gpus|/dev/kfd|/dev/dri|nvidia-smi|rocm-smi|NCCL_' $files \
+            | grep -vE ':[0-9]+: *(//|/\*|\*)' || true)
           if [ -n "$hits" ]; then
             echo "vendor-specific literals outside a provider module:"; echo "$hits"; exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,7 +201,7 @@ jobs:
       # A statically-linked musl binary satisfies the manylinux policy trivially,
       # so each Linux target is emitted twice from one build: manylinux for glibc
       # hosts and musllinux for Alpine. The binary is identical; only the tag
-      # differs, which is what makes `uvx atlas-ctl` resolve on both.
+      # differs, which is what makes `uvx pyatlasctl` resolve on both.
       - name: build wheel (manylinux)
         if: contains(matrix.target, 'linux-musl')
         uses: PyO3/maturin-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,6 +178,99 @@ jobs:
             cargo publish -p "$crate" --locked
           done
 
+  wheels:
+    name: wheel ${{ matrix.target }}
+    needs: [preflight]
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { target: aarch64-unknown-linux-musl, runner: ubuntu-24.04-arm }
+          - { target: x86_64-unknown-linux-musl,  runner: ubuntu-24.04 }
+          - { target: aarch64-apple-darwin,       runner: macos-14 }
+          - { target: x86_64-apple-darwin,        runner: macos-14 }
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name || inputs.tag }}
+      # A statically-linked musl binary satisfies the manylinux policy trivially,
+      # so each Linux target is emitted twice from one build: manylinux for glibc
+      # hosts and musllinux for Alpine. The binary is identical; only the tag
+      # differs, which is what makes `uvx atlas-ctl` resolve on both.
+      - name: build wheel (manylinux)
+        if: contains(matrix.target, 'linux-musl')
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist --manifest-path crates/atlasctl/Cargo.toml
+          manylinux: "2_17"
+      - name: build wheel (musllinux)
+        if: contains(matrix.target, 'linux-musl')
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist --manifest-path crates/atlasctl/Cargo.toml
+          manylinux: musllinux_1_2
+      - name: build wheel (macos)
+        if: contains(matrix.target, 'apple-darwin')
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist --manifest-path crates/atlasctl/Cargo.toml
+      - uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: dist/*.whl
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.target }}
+          path: dist/*.whl
+
+  sdist:
+    name: sdist
+    needs: [preflight]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name || inputs.tag }}
+      # Published for source availability under the AGPL, and for platforms the
+      # wheel matrix does not cover. Building it needs a Rust toolchain, which
+      # the project README says.
+      - uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: --out dist --manifest-path crates/atlasctl/Cargo.toml
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-sdist
+          path: dist/*.tar.gz
+
+  publish-pypi:
+    name: PyPI
+    needs: [release-please, github-release, wheels, sdist]
+    runs-on: ubuntu-24.04
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          path: dist
+          merge-multiple: true
+      # Trusted publishing, so no PyPI API token is stored in this repository.
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist
+          # Re-running a partially-failed release must not fail on files that
+          # already went out.
+          skip-existing: true
+
   smoke-install:
     name: smoke ${{ matrix.runner }}
     needs: [github-release]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,13 +77,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "atlasctl-agent"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "atlasctl-core",
+ "atlasctl-protocol",
+ "serde",
+ "serde_json",
+ "subtle",
+ "thiserror",
+]
+
+[[package]]
 name = "atlasctl-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "atlas-recipes-data",
+ "atlasctl-protocol",
  "serde",
  "serde_yaml_ng",
+ "thiserror",
+]
+
+[[package]]
+name = "atlasctl-protocol"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
  "thiserror",
 ]
 
@@ -221,6 +244,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,6 +323,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "serde_yaml_ng"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,6 +353,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -375,3 +423,9 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,10 +70,12 @@ name = "atlasctl"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "atlasctl-agent",
  "atlasctl-core",
  "clap",
  "rustix",
  "serde_yaml_ng",
+ "tokio",
 ]
 
 [[package]]
@@ -83,10 +85,12 @@ dependencies = [
  "anyhow",
  "atlasctl-core",
  "atlasctl-protocol",
+ "axum",
  "serde",
  "serde_json",
  "subtle",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -111,10 +115,98 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "base64",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1",
+ "sync_wrapper",
+ "tokio",
+ "tokio-tungstenite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
@@ -147,7 +239,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -161,6 +253,41 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "equivalent"
@@ -179,6 +306,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-util"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,6 +387,86 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
 
 [[package]]
 name = "include_dir"
@@ -244,16 +522,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "log"
+version = "0.4.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -271,6 +605,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -319,7 +688,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -336,6 +705,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml_ng"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,6 +738,49 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys",
 ]
 
 [[package]]
@@ -362,6 +797,17 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "2.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
@@ -370,6 +816,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "thiserror"
@@ -388,8 +840,117 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.4",
 ]
+
+[[package]]
+name = "tokio"
+version = "1.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -410,6 +971,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,6 +1004,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@
 
 [workspace]
 resolver = "3"
-members = ["crates/atlasctl-core", "crates/atlasctl"]
+members = ["crates/atlasctl-core", "crates/atlasctl", "crates/atlasctl-protocol", "crates/atlasctl-agent"]
 
 [workspace.package]
 version = "0.1.0"
@@ -22,6 +22,8 @@ authors = ["Avarok Cybersecurity"]
 [workspace.dependencies]
 atlas-recipes-data = { path = ".", version = "0.1.0" }
 atlasctl-core = { path = "crates/atlasctl-core", version = "0.1.0" }
+atlasctl-protocol = { path = "crates/atlasctl-protocol", version = "0.1.0" }
+atlasctl-agent = { path = "crates/atlasctl-agent", version = "0.1.0" }
 anyhow = "1"
 include_dir = "0.7"
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Or, if you already have the toolchains:
 
 ```sh
 cargo install atlasctl        # from crates.io
-uvx atlas-ctl list            # from PyPI, no install step
+uvx pyatlasctl list            # from PyPI, no install step
 ```
 
 The installer downloads a prebuilt binary, verifies its SHA-256 against the

--- a/crates/atlasctl-agent/Cargo.toml
+++ b/crates/atlasctl-agent/Cargo.toml
@@ -15,8 +15,14 @@ atlasctl-protocol.workspace = true
 anyhow.workspace = true
 serde.workspace = true
 serde_json = "1"
+axum = { version = "0.8", features = ["ws"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal"] }
 subtle = "2"
 thiserror.workspace = true
+
+[dev-dependencies]
+# The recording mocks are feature-gated so they never ship in a release build.
+atlasctl-core = { workspace = true, features = ["test-mocks"] }
 
 [features]
 test-mocks = []

--- a/crates/atlasctl-agent/Cargo.toml
+++ b/crates/atlasctl-agent/Cargo.toml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 [package]
-name = "atlasctl-core"
-description = "Recipe model and deterministic recipe-to-docker translation for atlasctl."
+name = "atlasctl-agent"
+description = "Local agent that lets the Atlas website launch recipes on this machine."
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -10,15 +10,15 @@ repository.workspace = true
 authors.workspace = true
 
 [dependencies]
-atlas-recipes-data.workspace = true
+atlasctl-core.workspace = true
 atlasctl-protocol.workspace = true
 anyhow.workspace = true
 serde.workspace = true
-serde_yaml_ng.workspace = true
+serde_json = "1"
+subtle = "2"
 thiserror.workspace = true
 
 [features]
-# Exposes the recording mocks to downstream test suites (the agent crate).
 test-mocks = []
 
 [lints]

--- a/crates/atlasctl-agent/src/guard.rs
+++ b/crates/atlasctl-agent/src/guard.rs
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Deciding whether a browser connection may proceed.
+//!
+//! A loopback port is reachable by every page the user visits: browsers permit
+//! cross-origin WebSocket connections to `127.0.0.1`, and the handshake is not
+//! subject to a CORS preflight. So the drive-by page — not a network attacker —
+//! is the threat this port actually adds, and `Origin` is what defeats it,
+//! because browsers set that header from the page's true origin and page script
+//! cannot alter it.
+//!
+//! Everything here is a pure function over headers, so the whole decision is
+//! testable without a socket.
+
+/// Origins allowed to drive this agent.
+pub const ALLOWED_ORIGINS: &[&str] = &["https://atlasinference.io"];
+
+/// Additional origins for local development, enabled explicitly.
+pub const DEV_ORIGINS: &[&str] = &[
+    "http://localhost:5173",
+    "http://127.0.0.1:5173",
+    "http://localhost:4173",
+    "http://127.0.0.1:4173",
+];
+
+/// Host values a loopback connection may legitimately carry.
+///
+/// This is the anti-DNS-rebinding control. Rebinding changes what a name
+/// *resolves to*, not what the browser puts in `Host`, so a page served from
+/// `attacker.com` still sends `Host: attacker.com:34333` and is refused here
+/// even if its name now points at 127.0.0.1.
+fn host_allowed(host: &str, port: u16) -> bool {
+    let expected = [
+        format!("127.0.0.1:{port}"),
+        format!("localhost:{port}"),
+        format!("[::1]:{port}"),
+    ];
+    expected.iter().any(|e| e == host)
+}
+
+/// Why a connection was refused.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum Refusal {
+    /// No `Origin` header at all.
+    #[error("no Origin header; refusing a connection whose origin cannot be established")]
+    MissingOrigin,
+
+    /// An origin outside the allowlist.
+    #[error("origin `{0}` is not allowed to drive this agent")]
+    ForeignOrigin(String),
+
+    /// No `Host` header.
+    #[error("no Host header")]
+    MissingHost,
+
+    /// A `Host` that is not this loopback listener.
+    #[error("host `{0}` is not this agent's loopback address (possible DNS rebinding)")]
+    ForeignHost(String),
+}
+
+/// Decide whether a connection may upgrade.
+///
+/// Matching is exact string equality. Prefix or substring matching would accept
+/// `https://atlasinference.io.evil.com`, and a scheme-insensitive match would
+/// accept plain `http://atlasinference.io`; neither is our origin.
+pub fn check(
+    origin: Option<&str>,
+    host: Option<&str>,
+    port: u16,
+    allow_dev: bool,
+) -> Result<(), Refusal> {
+    let host = host.ok_or(Refusal::MissingHost)?;
+    if !host_allowed(host, port) {
+        return Err(Refusal::ForeignHost(host.to_string()));
+    }
+
+    // A missing Origin is refused rather than trusted. Browsers always send one
+    // for a WebSocket handshake, so its absence means the peer is not the thing
+    // this port exists to serve.
+    let origin = origin.ok_or(Refusal::MissingOrigin)?;
+    let allowed = ALLOWED_ORIGINS.iter().chain(if allow_dev {
+        DEV_ORIGINS.iter()
+    } else {
+        [].iter()
+    });
+    if allowed.into_iter().any(|a| *a == origin) {
+        Ok(())
+    } else {
+        Err(Refusal::ForeignOrigin(origin.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PORT: u16 = 34333;
+
+    fn ok(origin: &str) -> Result<(), Refusal> {
+        check(
+            Some(origin),
+            Some(&format!("127.0.0.1:{PORT}")),
+            PORT,
+            false,
+        )
+    }
+
+    #[test]
+    fn the_real_site_is_allowed() {
+        assert!(ok("https://atlasinference.io").is_ok());
+    }
+
+    #[test]
+    fn a_lookalike_origin_is_refused() {
+        // Substring or prefix matching would accept every one of these.
+        for evil in [
+            "https://atlasinference.io.evil.com",
+            "https://evil.com/atlasinference.io",
+            "https://atlasinference.io.",
+            "https://notatlasinference.io",
+            "https://sub.atlasinference.io",
+        ] {
+            assert!(ok(evil).is_err(), "{evil} must be refused");
+        }
+    }
+
+    #[test]
+    fn the_scheme_and_port_must_match_exactly() {
+        assert!(
+            ok("http://atlasinference.io").is_err(),
+            "plain http is not our origin"
+        );
+        assert!(
+            ok("https://atlasinference.io:8443").is_err(),
+            "a different port is a different origin"
+        );
+    }
+
+    #[test]
+    fn a_missing_or_null_origin_is_refused() {
+        assert_eq!(
+            check(None, Some(&format!("127.0.0.1:{PORT}")), PORT, false),
+            Err(Refusal::MissingOrigin)
+        );
+        // `null` is what a sandboxed iframe or a file:// page sends.
+        assert!(ok("null").is_err());
+    }
+
+    #[test]
+    fn dns_rebinding_is_refused_on_the_host_header() {
+        // The attacker's page keeps its own Origin *and* its own Host, so this
+        // fails twice over; assert the Host check specifically.
+        let r = check(
+            Some("https://atlasinference.io"),
+            Some("attacker.com:34333"),
+            PORT,
+            false,
+        );
+        assert_eq!(r, Err(Refusal::ForeignHost("attacker.com:34333".into())));
+    }
+
+    #[test]
+    fn every_loopback_spelling_of_host_is_accepted() {
+        for h in ["127.0.0.1:34333", "localhost:34333", "[::1]:34333"] {
+            assert!(
+                check(Some("https://atlasinference.io"), Some(h), PORT, false).is_ok(),
+                "{h} should be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn a_host_on_the_wrong_port_is_refused() {
+        assert!(
+            check(
+                Some("https://atlasinference.io"),
+                Some("127.0.0.1:1234"),
+                PORT,
+                false
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn dev_origins_are_off_unless_asked_for() {
+        let host = format!("127.0.0.1:{PORT}");
+        assert!(check(Some("http://localhost:5173"), Some(&host), PORT, false).is_err());
+        assert!(check(Some("http://localhost:5173"), Some(&host), PORT, true).is_ok());
+        // Even with dev origins on, an unrelated origin stays refused.
+        assert!(check(Some("https://evil.com"), Some(&host), PORT, true).is_err());
+    }
+
+    #[test]
+    fn a_missing_host_is_refused() {
+        assert_eq!(
+            check(Some("https://atlasinference.io"), None, PORT, false),
+            Err(Refusal::MissingHost)
+        );
+    }
+}

--- a/crates/atlasctl-agent/src/launcher.rs
+++ b/crates/atlasctl-agent/src/launcher.rs
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! How a session actually starts, stops, and inspects launches.
+//!
+//! Behind a trait so the session's decisions — which are the security-relevant
+//! part — are tested against a recording mock rather than a docker daemon.
+
+use atlasctl_core::{Recipe, ScalarValue};
+use atlasctl_protocol::msg::{AgentError, RunningLaunch};
+use std::collections::BTreeMap;
+
+/// A rendered command, for the client to inspect before committing.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Preview {
+    /// The command, shell-quoted for display.
+    pub command: String,
+    /// Recipe settings this agent version does not understand.
+    pub unapplied: Vec<String>,
+}
+
+/// A launch that started.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Started {
+    /// Container name.
+    pub container: String,
+    /// Where the model is served, when it serves.
+    pub endpoint: Option<String>,
+}
+
+/// Runs launches.
+pub trait Launcher: Send + Sync {
+    /// Render the command without running it.
+    fn preview(
+        &self,
+        recipe: &Recipe,
+        overrides: &BTreeMap<String, ScalarValue>,
+    ) -> Result<Preview, AgentError>;
+
+    /// Start a recipe.
+    fn launch(
+        &self,
+        recipe: &Recipe,
+        overrides: &BTreeMap<String, ScalarValue>,
+    ) -> Result<Started, AgentError>;
+
+    /// Stop a recipe by name.
+    fn stop(&self, recipe: &str) -> Result<(), AgentError>;
+
+    /// What is currently running.
+    fn running(&self) -> Result<Vec<RunningLaunch>, AgentError>;
+}
+
+#[cfg(any(test, feature = "test-mocks"))]
+mod mock {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// What a mock launcher was asked to do.
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum Call {
+        /// A preview was rendered.
+        Preview(String),
+        /// A launch was started.
+        Launch(String, BTreeMap<String, ScalarValue>),
+        /// A launch was stopped.
+        Stop(String),
+        /// Running launches were listed.
+        Running,
+    }
+
+    /// Records what the session asked for, and answers as scripted.
+    #[derive(Debug, Default)]
+    pub struct RecordingLauncher {
+        calls: Mutex<Vec<Call>>,
+        fail_launch: Mutex<Option<AgentError>>,
+    }
+
+    impl RecordingLauncher {
+        /// A launcher that succeeds at everything.
+        pub fn new() -> Self {
+            Self::default()
+        }
+
+        /// Make the next launch fail.
+        pub fn failing(error: AgentError) -> Self {
+            Self {
+                calls: Mutex::new(Vec::new()),
+                fail_launch: Mutex::new(Some(error)),
+            }
+        }
+
+        /// Everything it was asked to do, in order.
+        pub fn calls(&self) -> Vec<Call> {
+            self.calls.lock().expect("lock").clone()
+        }
+
+        /// Whether it was asked to launch anything at all.
+        pub fn launched_anything(&self) -> bool {
+            self.calls().iter().any(|c| matches!(c, Call::Launch(..)))
+        }
+
+        fn record(&self, c: Call) {
+            self.calls.lock().expect("lock").push(c);
+        }
+    }
+
+    impl Launcher for RecordingLauncher {
+        fn preview(
+            &self,
+            recipe: &Recipe,
+            _o: &BTreeMap<String, ScalarValue>,
+        ) -> Result<Preview, AgentError> {
+            self.record(Call::Preview(recipe.name.clone()));
+            Ok(Preview {
+                command: format!("docker run … {}", recipe.model),
+                unapplied: vec![],
+            })
+        }
+
+        fn launch(
+            &self,
+            recipe: &Recipe,
+            o: &BTreeMap<String, ScalarValue>,
+        ) -> Result<Started, AgentError> {
+            self.record(Call::Launch(recipe.name.clone(), o.clone()));
+            if let Some(e) = self.fail_launch.lock().expect("lock").take() {
+                return Err(e);
+            }
+            Ok(Started {
+                container: format!("atlas-{}", recipe.name),
+                endpoint: Some("http://localhost:8888/v1".into()),
+            })
+        }
+
+        fn stop(&self, recipe: &str) -> Result<(), AgentError> {
+            self.record(Call::Stop(recipe.to_string()));
+            Ok(())
+        }
+
+        fn running(&self) -> Result<Vec<RunningLaunch>, AgentError> {
+            self.record(Call::Running);
+            Ok(Vec::new())
+        }
+    }
+}
+
+#[cfg(any(test, feature = "test-mocks"))]
+pub use mock::{Call, RecordingLauncher};

--- a/crates/atlasctl-agent/src/launcher.rs
+++ b/crates/atlasctl-agent/src/launcher.rs
@@ -27,6 +27,10 @@ pub struct Started {
     pub endpoint: Option<String>,
 }
 
+pub mod docker;
+
+pub use docker::DockerLauncher;
+
 /// Runs launches.
 pub trait Launcher: Send + Sync {
     /// Render the command without running it.

--- a/crates/atlasctl-agent/src/launcher/docker.rs
+++ b/crates/atlasctl-agent/src/launcher/docker.rs
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The production launcher: translate a recipe, then run the command.
+
+use super::{Launcher, Preview, Started};
+use atlasctl_core::chain::UserConfig;
+use atlasctl_core::docker::collective::NcclRoce;
+use atlasctl_core::docker::profile::{DeviceProfile, LaunchProfile};
+use atlasctl_core::docker::translate::{LABEL_MANAGED, LaunchContext, Placement, translate};
+use atlasctl_core::host::HostSnapshot;
+use atlasctl_core::io::ProcessRunner;
+use atlasctl_core::{Recipe, ScalarValue};
+use atlasctl_protocol::RecipeId;
+use atlasctl_protocol::msg::{AgentError, RunningLaunch};
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+/// Launches recipes through the docker CLI.
+pub struct DockerLauncher {
+    runner: Arc<dyn ProcessRunner>,
+    host: HostSnapshot,
+    profile: &'static LaunchProfile,
+    devices: Box<dyn DeviceProfile>,
+}
+
+impl DockerLauncher {
+    /// Build a launcher.
+    pub fn new(
+        runner: Arc<dyn ProcessRunner>,
+        host: HostSnapshot,
+        profile: &'static LaunchProfile,
+        devices: Box<dyn DeviceProfile>,
+    ) -> Self {
+        Self {
+            runner,
+            host,
+            profile,
+            devices,
+        }
+    }
+
+    fn plan(
+        &self,
+        recipe: &Recipe,
+        overrides: &BTreeMap<String, ScalarValue>,
+    ) -> Result<atlasctl_core::docker::LaunchPlan, AgentError> {
+        // A browser launch is always single-node. Multi-node needs a rank per
+        // machine, which is a fleet decision rather than something one page
+        // should be able to assert on its own.
+        let ctx = LaunchContext {
+            profile: self.profile,
+            devices: self.devices.as_ref(),
+            collective: &NcclRoce,
+        };
+        translate(
+            recipe,
+            overrides,
+            &UserConfig::new(),
+            &self.host,
+            &Placement::Solo,
+            &ctx,
+        )
+        .map_err(|e| AgentError::NotLaunchable {
+            recipe: RecipeId::parse(&recipe.name)
+                .unwrap_or_else(|_| RecipeId::parse("unknown").expect("literal is a valid id")),
+            reason: e.to_string(),
+        })
+    }
+}
+
+impl Launcher for DockerLauncher {
+    fn preview(
+        &self,
+        recipe: &Recipe,
+        overrides: &BTreeMap<String, ScalarValue>,
+    ) -> Result<Preview, AgentError> {
+        let plan = self.plan(recipe, overrides)?;
+        Ok(Preview {
+            command: plan.docker.to_string(),
+            // Settings the recipe carries that this build does not understand.
+            // Reported so the client can show them: the tool this replaces
+            // discarded them silently.
+            unapplied: plan.unmapped.into_iter().map(|u| u.key).collect(),
+        })
+    }
+
+    fn launch(
+        &self,
+        recipe: &Recipe,
+        overrides: &BTreeMap<String, ScalarValue>,
+    ) -> Result<Started, AgentError> {
+        let plan = self.plan(recipe, overrides)?;
+        let name = plan.docker.name.clone();
+
+        // Clear a previous container of the same name. Failure is expected when
+        // nothing is there; the launch below is what has to succeed.
+        let _ = self
+            .runner
+            .run(&["docker".into(), "rm".into(), "-f".into(), name.clone()]);
+
+        let out =
+            self.runner
+                .run(&plan.docker.to_argv())
+                .map_err(|e| AgentError::LaunchFailed {
+                    detail: e.to_string(),
+                })?;
+        if !out.success() {
+            return Err(AgentError::LaunchFailed {
+                detail: format!("docker run exited {}: {}", out.status, out.stderr.trim()),
+            });
+        }
+
+        let port = plan
+            .docker
+            .command
+            .windows(2)
+            .find(|w| w[0] == "--port")
+            .map(|w| w[1].clone());
+        let endpoint = match port.as_deref() {
+            // A worker rank is bound to port 0 and serves nothing.
+            Some("0") | None => None,
+            Some(p) => Some(format!("http://localhost:{p}/v1")),
+        };
+
+        Ok(Started {
+            container: name,
+            endpoint,
+        })
+    }
+
+    fn stop(&self, recipe: &str) -> Result<(), AgentError> {
+        let out = self
+            .runner
+            .run(&["docker".into(), "stop".into(), format!("atlas-{recipe}")])
+            .map_err(|e| AgentError::LaunchFailed {
+                detail: e.to_string(),
+            })?;
+        if out.success() {
+            Ok(())
+        } else {
+            Err(AgentError::LaunchFailed {
+                detail: out.stderr.trim().to_string(),
+            })
+        }
+    }
+
+    fn running(&self) -> Result<Vec<RunningLaunch>, AgentError> {
+        let out = self
+            .runner
+            .run(&[
+                "docker".into(),
+                "ps".into(),
+                "--filter".into(),
+                format!("label={LABEL_MANAGED}=1"),
+                "--format".into(),
+                "{{.Names}}\t{{.Status}}".into(),
+            ])
+            .map_err(|e| AgentError::DockerUnavailable {
+                detail: e.to_string(),
+            })?;
+        if !out.success() {
+            return Err(AgentError::DockerUnavailable {
+                detail: out.stderr.trim().to_string(),
+            });
+        }
+        Ok(out
+            .stdout
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|line| {
+                let mut parts = line.split('\t');
+                let container = parts.next().unwrap_or_default().to_string();
+                let status = parts.next().unwrap_or_default().to_string();
+                // Recover the recipe from the container name, which we control.
+                let recipe = container
+                    .strip_prefix("atlas-")
+                    .and_then(|s| RecipeId::parse(s).ok());
+                RunningLaunch {
+                    container,
+                    recipe,
+                    status,
+                }
+            })
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/atlasctl-agent/src/launcher/docker/tests.rs
+++ b/crates/atlasctl-agent/src/launcher/docker/tests.rs
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use super::*;
+use atlasctl_core::docker::profile::{NvidiaDevices, ROOTLESS_V1};
+use atlasctl_core::io::RecordingRunner;
+use atlasctl_core::io::process::Output;
+use atlasctl_core::recipe::Provenance;
+
+fn host() -> HostSnapshot {
+    HostSnapshot {
+        uid: 1000,
+        gid: 1000,
+        home: "/home/spark".into(),
+        hf_cache_dir: "/home/spark/.cache/huggingface".into(),
+        env: BTreeMap::new(),
+    }
+}
+
+fn recipe() -> Recipe {
+    Recipe::parse(
+        "r",
+        "model: org/m\ncontainer: img:tag\nruntime: atlas\ndefaults:\n  port: 8888\n",
+        Provenance::Builtin {
+            path: "r.yaml".into(),
+        },
+    )
+    .expect("fixture parses")
+}
+
+fn launcher(runner: Arc<RecordingRunner>) -> DockerLauncher {
+    DockerLauncher::new(runner, host(), &ROOTLESS_V1, Box::new(NvidiaDevices))
+}
+
+#[test]
+fn preview_renders_the_command_without_running_anything() {
+    let runner = Arc::new(RecordingRunner::new());
+    let p = launcher(runner.clone())
+        .preview(&recipe(), &BTreeMap::new())
+        .expect("previews");
+    assert!(p.command.starts_with("docker run"), "{}", p.command);
+    assert!(p.command.contains("spark serve org/m"));
+    assert_eq!(
+        runner.call_count(),
+        0,
+        "preview must not execute anything at all"
+    );
+}
+
+#[test]
+fn preview_and_launch_render_the_same_command() {
+    // What the client is shown must be what runs, or inspection is theatre.
+    let runner = Arc::new(RecordingRunner::new());
+    let l = launcher(runner.clone());
+    let previewed = l.preview(&recipe(), &BTreeMap::new()).unwrap().command;
+    l.launch(&recipe(), &BTreeMap::new()).unwrap();
+
+    let run_call = runner
+        .calls()
+        .into_iter()
+        .find(|c| {
+            c.first().map(String::as_str) == Some("docker")
+                && c.get(1).map(String::as_str) == Some("run")
+        })
+        .expect("a docker run happened");
+    // The preview is shell-quoted; compare the meaningful tail.
+    assert!(previewed.contains("spark serve org/m"));
+    assert!(
+        run_call
+            .windows(3)
+            .any(|w| w == ["spark", "serve", "org/m"])
+    );
+}
+
+#[test]
+fn launching_removes_a_stale_container_first_then_runs() {
+    let runner = Arc::new(RecordingRunner::new());
+    launcher(runner.clone())
+        .launch(&recipe(), &BTreeMap::new())
+        .expect("launches");
+    let calls = runner.calls();
+    assert_eq!(
+        calls[0][..3],
+        ["docker", "rm", "-f"],
+        "stale container is cleared first"
+    );
+    assert_eq!(calls[0][3], "atlas-r");
+    assert_eq!(calls[1][..2], ["docker", "run"]);
+}
+
+#[test]
+fn a_failed_docker_run_is_reported_with_its_stderr() {
+    let runner = Arc::new(RecordingRunner::new());
+    runner.push_result(Output {
+        status: 0,
+        stdout: String::new(),
+        stderr: String::new(),
+    }); // rm
+    runner.push_result(Output {
+        status: 125,
+        stdout: String::new(),
+        stderr: "no such image".into(),
+    });
+    let err = launcher(runner)
+        .launch(&recipe(), &BTreeMap::new())
+        .expect_err("must fail");
+    let msg = err.to_string();
+    assert!(msg.contains("125"), "{msg}");
+    assert!(msg.contains("no such image"), "{msg}");
+}
+
+#[test]
+fn the_endpoint_reflects_the_resolved_port() {
+    let runner = Arc::new(RecordingRunner::new());
+    let started = launcher(runner)
+        .launch(&recipe(), &BTreeMap::new())
+        .expect("launches");
+    assert_eq!(started.container, "atlas-r");
+    assert_eq!(
+        started.endpoint.as_deref(),
+        Some("http://localhost:8888/v1")
+    );
+}
+
+#[test]
+fn an_override_reaches_the_executed_command() {
+    let runner = Arc::new(RecordingRunner::new());
+    let overrides = BTreeMap::from([("port".to_string(), ScalarValue::Int(9100))]);
+    let started = launcher(runner.clone())
+        .launch(&recipe(), &overrides)
+        .expect("launches");
+    assert_eq!(
+        started.endpoint.as_deref(),
+        Some("http://localhost:9100/v1")
+    );
+    let run = runner
+        .calls()
+        .into_iter()
+        .find(|c| c.get(1).map(String::as_str) == Some("run"))
+        .unwrap();
+    assert!(run.windows(2).any(|w| w == ["--port", "9100"]));
+}
+
+#[test]
+fn stop_targets_only_our_own_container_name() {
+    let runner = Arc::new(RecordingRunner::new());
+    launcher(runner.clone()).stop("r").expect("stops");
+    assert_eq!(runner.calls(), [["docker", "stop", "atlas-r"]]);
+}
+
+#[test]
+fn running_launches_are_found_by_label_and_mapped_back_to_recipes() {
+    let runner = Arc::new(RecordingRunner::new());
+    runner.push_result(Output {
+        status: 0,
+        stdout: "atlas-qwen3.6-27b-fp8\tUp 3 minutes\nsomeone-elses-container\tUp 1 hour\n".into(),
+        stderr: String::new(),
+    });
+    let running = launcher(runner.clone()).running().expect("lists");
+
+    // The docker query must filter by our label, so an unrelated container is
+    // never a candidate for us to stop.
+    assert!(
+        runner.calls()[0]
+            .iter()
+            .any(|a| a.contains("io.atlasctl.managed=1"))
+    );
+
+    assert_eq!(
+        running[0].recipe.as_ref().map(|r| r.as_str()),
+        Some("qwen3.6-27b-fp8")
+    );
+    assert_eq!(running[0].status, "Up 3 minutes");
+    // A container that is not ours by naming convention still lists, with no
+    // recipe attached, rather than being silently dropped.
+    assert_eq!(running[1].recipe, None);
+}
+
+#[test]
+fn docker_being_unavailable_is_reported_as_such() {
+    let runner = Arc::new(RecordingRunner::new());
+    runner.push_result(Output {
+        status: 1,
+        stdout: String::new(),
+        stderr: "cannot connect to the docker daemon".into(),
+    });
+    let err = launcher(runner).running().expect_err("must fail");
+    assert!(
+        matches!(err, AgentError::DockerUnavailable { .. }),
+        "{err:?}"
+    );
+}

--- a/crates/atlasctl-agent/src/lib.rs
+++ b/crates/atlasctl-agent/src/lib.rs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+#![deny(warnings)]
+#![deny(clippy::all)]
+
+//! The local agent: lets the Atlas website launch recipes on this machine.
+
+pub mod guard;
+pub mod launcher;
+pub mod session;
+pub mod token;
+
+/// Port the browser control channel listens on.
+pub const DEFAULT_PORT: u16 = 34333;

--- a/crates/atlasctl-agent/src/lib.rs
+++ b/crates/atlasctl-agent/src/lib.rs
@@ -8,6 +8,7 @@ pub mod guard;
 pub mod launcher;
 pub mod server;
 pub mod session;
+pub mod telemetry;
 pub mod token;
 
 /// Port the browser control channel listens on.

--- a/crates/atlasctl-agent/src/lib.rs
+++ b/crates/atlasctl-agent/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod guard;
 pub mod launcher;
+pub mod server;
 pub mod session;
 pub mod token;
 

--- a/crates/atlasctl-agent/src/server.rs
+++ b/crates/atlasctl-agent/src/server.rs
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The loopback websocket listener.
+//!
+//! This layer makes no decisions. It binds loopback, applies the guard before
+//! the upgrade completes, decodes frames, and hands them to a [`Session`].
+//! Everything that could be got wrong lives in modules that are testable
+//! without a socket; keeping the transport thin is what makes that true.
+
+use crate::guard;
+use crate::launcher::Launcher;
+use crate::session::{Session, SessionDeps};
+use anyhow::{Context, Result};
+use atlasctl_core::registry::RegistrySet;
+use atlasctl_protocol::msg::{ClientMsg, ServerMsg};
+use axum::Router;
+use axum::extract::{ConnectInfo, State, WebSocketUpgrade, ws};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+
+/// Largest frame we will decode.
+///
+/// Every legitimate message is small. A cap means a client cannot make the
+/// agent allocate on its say-so.
+const MAX_FRAME_BYTES: usize = 64 * 1024;
+
+/// Shared state for the listener.
+pub struct AgentState {
+    /// The recipe inventory.
+    pub registry: RegistrySet,
+    /// How launches happen.
+    pub launcher: Box<dyn Launcher>,
+    /// The expected pairing token.
+    pub token: String,
+    /// Whether this machine can run a recipe, and why not if it cannot.
+    pub can_launch: Result<(), String>,
+    /// Port we are listening on, for the Host check.
+    pub port: u16,
+    /// Whether development origins are accepted.
+    pub allow_dev_origins: bool,
+}
+
+/// Build the router.
+pub fn router(state: Arc<AgentState>) -> Router {
+    Router::new().route("/ws", get(upgrade)).with_state(state)
+}
+
+/// Bind loopback and serve until the process is asked to stop.
+///
+/// The bind address is a literal, never a hostname: resolving a name could
+/// yield something that is not loopback, and this listener must never be
+/// reachable from the network.
+pub async fn serve(state: Arc<AgentState>, port: u16) -> Result<()> {
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .with_context(|| format!("could not bind {addr} — is another agent already running?"))?;
+
+    let bound = listener.local_addr()?;
+    debug_assert!(
+        bound.ip().is_loopback(),
+        "the browser listener must be loopback-only"
+    );
+
+    axum::serve(
+        listener,
+        router(state).into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .with_graceful_shutdown(shutdown())
+    .await
+    .context("the agent listener stopped unexpectedly")
+}
+
+async fn shutdown() {
+    let _ = tokio::signal::ctrl_c().await;
+}
+
+/// Decide whether a connection may upgrade, then run a session on it.
+async fn upgrade(
+    State(state): State<Arc<AgentState>>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    upgrade: WebSocketUpgrade,
+) -> Response {
+    // Belt and braces: the socket is bound to loopback, so a non-loopback peer
+    // should be impossible. If one appears, something is wrong enough to refuse.
+    if !peer.ip().is_loopback() {
+        return (StatusCode::FORBIDDEN, "not a loopback connection").into_response();
+    }
+
+    let header = |name: &str| headers.get(name).and_then(|v| v.to_str().ok());
+    if let Err(refusal) = guard::check(
+        header("origin"),
+        header("host"),
+        state.port,
+        state.allow_dev_origins,
+    ) {
+        // Refused before the upgrade completes, so a rejected page never gets a
+        // websocket at all.
+        return (StatusCode::FORBIDDEN, refusal.to_string()).into_response();
+    }
+
+    upgrade
+        .max_message_size(MAX_FRAME_BYTES)
+        .on_upgrade(move |socket| run_session(socket, state))
+}
+
+async fn run_session(mut socket: ws::WebSocket, state: Arc<AgentState>) {
+    let (mut session, welcome) = Session::new(SessionDeps {
+        registry: &state.registry,
+        launcher: state.launcher.as_ref(),
+        token: &state.token,
+        can_launch: state.can_launch.clone(),
+    });
+
+    if send(&mut socket, &welcome).await.is_err() {
+        return;
+    }
+
+    while let Some(Ok(frame)) = socket.recv().await {
+        let text = match frame {
+            ws::Message::Text(t) => t,
+            // Binary frames are not part of this protocol. Accepting them would
+            // widen the surface for nothing.
+            ws::Message::Binary(_) => {
+                let _ = send(
+                    &mut socket,
+                    &session.on_malformed("binary frames are not accepted".into()),
+                )
+                .await;
+                break;
+            }
+            ws::Message::Close(_) => break,
+            _ => continue,
+        };
+
+        let replies = match serde_json::from_str::<ClientMsg>(&text) {
+            Ok(msg) => session.handle(msg),
+            Err(e) => vec![session.on_malformed(e.to_string())],
+        };
+
+        for reply in replies {
+            if send(&mut socket, &reply).await.is_err() {
+                return;
+            }
+        }
+
+        // Denied keys are logged rather than merely refused: nothing in a real
+        // client offers one, so an attempt says something about the caller.
+        for key in session.denied_attempts.drain(..) {
+            eprintln!("atlasctl agent: client attempted to set the denied key `{key}`");
+        }
+
+        if session.is_closed() {
+            break;
+        }
+    }
+
+    // Dropping the socket closes it; axum's WebSocket has no explicit close.
+    let _ = socket.send(ws::Message::Close(None)).await;
+}
+
+async fn send(socket: &mut ws::WebSocket, msg: &ServerMsg) -> Result<()> {
+    let text = serde_json::to_string(msg).context("encoding a reply")?;
+    socket
+        .send(ws::Message::Text(text.into()))
+        .await
+        .context("sending a reply")
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/atlasctl-agent/src/server/tests.rs
+++ b/crates/atlasctl-agent/src/server/tests.rs
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Transport-level tests, over a real socket on an ephemeral loopback port.
+
+use super::*;
+use crate::launcher::RecordingLauncher;
+use std::sync::Arc;
+
+const TOKEN: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+fn state(port: u16) -> Arc<AgentState> {
+    Arc::new(AgentState {
+        registry: RegistrySet::builtin_only(),
+        launcher: Box::new(RecordingLauncher::new()),
+        token: TOKEN.to_string(),
+        can_launch: Ok(()),
+        port,
+        allow_dev_origins: false,
+    })
+}
+
+/// Start the listener on an ephemeral port and return its address.
+async fn spawn() -> SocketAddr {
+    let listener =
+        tokio::net::TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
+            .await
+            .expect("bind loopback");
+    let addr = listener.local_addr().expect("local addr");
+    let app = router(state(addr.port()));
+    tokio::spawn(async move {
+        let _ = axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .await;
+    });
+    // Let the accept loop start.
+    tokio::task::yield_now().await;
+    addr
+}
+
+/// Perform the HTTP upgrade by hand, so the response to a refused handshake can
+/// be inspected — a websocket client library would just report a failure.
+async fn handshake(addr: SocketAddr, origin: Option<&str>, host: Option<&str>) -> String {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    let mut stream = tokio::net::TcpStream::connect(addr).await.expect("connect");
+    let host = host
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("127.0.0.1:{}", addr.port()));
+
+    let mut req = format!(
+        "GET /ws HTTP/1.1\r\nHost: {host}\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\
+         Sec-WebSocket-Version: 13\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+    );
+    if let Some(o) = origin {
+        req.push_str(&format!("Origin: {o}\r\n"));
+    }
+    req.push_str("\r\n");
+
+    stream.write_all(req.as_bytes()).await.expect("write");
+    let mut buf = vec![0u8; 1024];
+    let n = stream.read(&mut buf).await.unwrap_or(0);
+    String::from_utf8_lossy(&buf[..n]).to_string()
+}
+
+#[tokio::test]
+async fn the_listener_binds_loopback_only() {
+    let addr = spawn().await;
+    assert!(
+        addr.ip().is_loopback(),
+        "the browser channel must never be network-reachable"
+    );
+}
+
+#[tokio::test]
+async fn the_real_site_completes_the_upgrade() {
+    let addr = spawn().await;
+    let resp = handshake(addr, Some("https://atlasinference.io"), None).await;
+    assert!(
+        resp.starts_with("HTTP/1.1 101"),
+        "expected an upgrade, got: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn a_hostile_origin_is_refused_before_any_websocket_exists() {
+    let addr = spawn().await;
+    for evil in [
+        "https://evil.com",
+        "https://atlasinference.io.evil.com",
+        "http://atlasinference.io",
+        "null",
+    ] {
+        let resp = handshake(addr, Some(evil), None).await;
+        assert!(
+            resp.starts_with("HTTP/1.1 403"),
+            "{evil} should be refused, got: {resp}"
+        );
+        assert!(!resp.contains("101"), "{evil} must not be upgraded");
+    }
+}
+
+#[tokio::test]
+async fn a_connection_with_no_origin_is_refused() {
+    let addr = spawn().await;
+    let resp = handshake(addr, None, None).await;
+    assert!(resp.starts_with("HTTP/1.1 403"), "got: {resp}");
+}
+
+#[tokio::test]
+async fn a_rebound_host_header_is_refused_even_with_a_valid_origin() {
+    // The DNS-rebinding case: the attacker's name now resolves to 127.0.0.1,
+    // but the browser still sends the attacker's Host.
+    let addr = spawn().await;
+    let resp = handshake(
+        addr,
+        Some("https://atlasinference.io"),
+        Some("attacker.com:1234"),
+    )
+    .await;
+    assert!(resp.starts_with("HTTP/1.1 403"), "got: {resp}");
+}
+
+#[tokio::test]
+async fn dev_origins_are_refused_unless_enabled() {
+    let addr = spawn().await;
+    let resp = handshake(addr, Some("http://localhost:5173"), None).await;
+    assert!(
+        resp.starts_with("HTTP/1.1 403"),
+        "dev origins are off by default, got: {resp}"
+    );
+}

--- a/crates/atlasctl-agent/src/session.rs
+++ b/crates/atlasctl-agent/src/session.rs
@@ -1,0 +1,335 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! One client connection, as a state machine.
+//!
+//! Deliberately transport-free: it takes a decoded message and returns messages
+//! to send. That keeps every security property — handshake ordering, token
+//! checking, recipe validation, settings bounds — testable without opening a
+//! socket, and it means the websocket layer has no decisions of its own to get
+//! wrong.
+
+use crate::launcher::Launcher;
+use crate::token;
+use atlasctl_core::registry::{RecipeRef, RegistrySet};
+use atlasctl_core::settings;
+use atlasctl_protocol::msg::{AgentError, ClientMsg, RecipeInfo, ServerMsg};
+use atlasctl_protocol::settings::SettingValue;
+use atlasctl_protocol::{PROTOCOL_VERSION, RecipeId};
+use std::collections::BTreeMap;
+
+/// Where a connection has got to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Phase {
+    /// Waiting for the client's hello.
+    AwaitingHello,
+    /// Authenticated; normal traffic allowed.
+    Ready,
+    /// Finished, for whatever reason.
+    Closed,
+}
+
+/// Everything a session needs from the outside world.
+pub struct SessionDeps<'a> {
+    /// The recipe inventory.
+    pub registry: &'a RegistrySet,
+    /// How launches actually happen.
+    pub launcher: &'a dyn Launcher,
+    /// The expected pairing token.
+    pub token: &'a str,
+    /// Whether this machine can run a recipe at all.
+    pub can_launch: Result<(), String>,
+}
+
+/// A single client connection.
+pub struct Session<'a> {
+    deps: SessionDeps<'a>,
+    phase: Phase,
+    /// Denied-key attempts, which the caller logs. Nothing in a legitimate UI
+    /// offers a denied key, so an attempt says something about the client.
+    pub denied_attempts: Vec<String>,
+}
+
+impl<'a> Session<'a> {
+    /// Open a session. The agent speaks first.
+    pub fn new(deps: SessionDeps<'a>) -> (Self, ServerMsg) {
+        let welcome = ServerMsg::Welcome {
+            protocol_min: PROTOCOL_VERSION,
+            protocol_max: PROTOCOL_VERSION,
+            agent_version: env!("CARGO_PKG_VERSION").to_string(),
+        };
+        (
+            Self {
+                deps,
+                phase: Phase::AwaitingHello,
+                denied_attempts: Vec::new(),
+            },
+            welcome,
+        )
+    }
+
+    /// Whether the session is finished.
+    pub fn is_closed(&self) -> bool {
+        self.phase == Phase::Closed
+    }
+
+    /// A frame that failed to deserialize.
+    ///
+    /// Reported rather than ignored, and it ends the session: a client sending
+    /// something we cannot parse is not one we should keep guessing for.
+    pub fn on_malformed(&mut self, detail: String) -> ServerMsg {
+        self.phase = Phase::Closed;
+        ServerMsg::Error {
+            id: None,
+            error: AgentError::InvalidMessage { detail },
+        }
+    }
+
+    /// Handle one decoded message.
+    pub fn handle(&mut self, msg: ClientMsg) -> Vec<ServerMsg> {
+        if self.phase == Phase::Closed {
+            return Vec::new();
+        }
+        match (&self.phase, msg) {
+            (
+                Phase::AwaitingHello,
+                ClientMsg::Hello {
+                    protocol_version,
+                    token,
+                },
+            ) => self.hello(protocol_version, &token),
+            // Nothing else is answered before the handshake, so an unauthorized
+            // client cannot even enumerate what recipes exist.
+            (Phase::AwaitingHello, _) => {
+                self.phase = Phase::Closed;
+                vec![ServerMsg::Error {
+                    id: None,
+                    error: AgentError::NotReady,
+                }]
+            }
+            (Phase::Ready, ClientMsg::Hello { .. }) => {
+                vec![err(
+                    None,
+                    AgentError::InvalidMessage {
+                        detail: "already greeted".into(),
+                    },
+                )]
+            }
+            (Phase::Ready, ClientMsg::ListRecipes { id }) => {
+                vec![ServerMsg::Recipes {
+                    id,
+                    recipes: self.inventory(),
+                }]
+            }
+            (
+                Phase::Ready,
+                ClientMsg::Preview {
+                    id,
+                    recipe,
+                    settings,
+                },
+            ) => self.preview(id, &recipe, &settings),
+            (
+                Phase::Ready,
+                ClientMsg::Launch {
+                    id,
+                    recipe,
+                    settings,
+                },
+            ) => self.launch(id, &recipe, &settings),
+            (Phase::Ready, ClientMsg::Stop { id, recipe }) => self.stop(id, &recipe),
+            (Phase::Ready, ClientMsg::Status { id }) => self.status(id),
+            (Phase::Closed, _) => Vec::new(),
+        }
+    }
+
+    fn hello(&mut self, version: u32, presented: &str) -> Vec<ServerMsg> {
+        if version != PROTOCOL_VERSION {
+            self.phase = Phase::Closed;
+            return vec![err(
+                None,
+                AgentError::UnsupportedProtocol {
+                    min: PROTOCOL_VERSION,
+                    max: PROTOCOL_VERSION,
+                    requested: version,
+                },
+            )];
+        }
+        if !token::matches(self.deps.token, presented) {
+            self.phase = Phase::Closed;
+            return vec![err(None, AgentError::NotPaired)];
+        }
+        self.phase = Phase::Ready;
+        let (can_launch, reason) = match &self.deps.can_launch {
+            Ok(()) => (true, None),
+            Err(why) => (false, Some(why.clone())),
+        };
+        vec![ServerMsg::Ready {
+            protocol_version: PROTOCOL_VERSION,
+            schema: settings::schema(),
+            recipes: self.inventory(),
+            can_launch,
+            can_launch_reason: reason,
+        }]
+    }
+
+    /// Resolve a recipe id against the compiled-in set.
+    ///
+    /// The id is already syntactically valid — it could not have been
+    /// deserialized otherwise — so this only answers "does it exist here".
+    fn resolve(&self, id: &RecipeId) -> Result<atlasctl_core::Recipe, AgentError> {
+        self.deps
+            .registry
+            .resolve(&RecipeRef::Bare(id.as_str().to_string()))
+            .map_err(|_| AgentError::UnknownRecipe {
+                recipe: id.to_string(),
+            })
+    }
+
+    /// Check requested settings, recording any denied-key attempts.
+    fn check_settings(
+        &mut self,
+        requested: &BTreeMap<String, SettingValue>,
+    ) -> Result<BTreeMap<String, atlasctl_core::ScalarValue>, AgentError> {
+        settings::validate(requested).map_err(|errors| {
+            for e in &errors {
+                if let atlasctl_protocol::settings::SettingError::Denied { key, .. } = e {
+                    self.denied_attempts.push(key.clone());
+                }
+            }
+            AgentError::BadSettings { errors }
+        })
+    }
+
+    fn preview(
+        &mut self,
+        id: u32,
+        recipe_id: &RecipeId,
+        requested: &BTreeMap<String, SettingValue>,
+    ) -> Vec<ServerMsg> {
+        let recipe = match self.resolve(recipe_id) {
+            Ok(r) => r,
+            Err(e) => return vec![err(Some(id), e)],
+        };
+        let overrides = match self.check_settings(requested) {
+            Ok(o) => o,
+            Err(e) => return vec![err(Some(id), e)],
+        };
+        match self.deps.launcher.preview(&recipe, &overrides) {
+            Ok(p) => vec![ServerMsg::Preview {
+                id,
+                command: p.command,
+                unapplied: p.unapplied,
+            }],
+            Err(e) => vec![err(Some(id), e)],
+        }
+    }
+
+    fn launch(
+        &mut self,
+        id: u32,
+        recipe_id: &RecipeId,
+        requested: &BTreeMap<String, SettingValue>,
+    ) -> Vec<ServerMsg> {
+        if let Err(why) = &self.deps.can_launch {
+            return vec![err(
+                Some(id),
+                AgentError::NotLaunchable {
+                    recipe: recipe_id.clone(),
+                    reason: why.clone(),
+                },
+            )];
+        }
+        let recipe = match self.resolve(recipe_id) {
+            Ok(r) => r,
+            Err(e) => return vec![err(Some(id), e)],
+        };
+        if let Err(why) = recipe.launchable() {
+            return vec![err(
+                Some(id),
+                AgentError::NotLaunchable {
+                    recipe: recipe_id.clone(),
+                    reason: why.to_string(),
+                },
+            )];
+        }
+        let overrides = match self.check_settings(requested) {
+            Ok(o) => o,
+            Err(e) => return vec![err(Some(id), e)],
+        };
+        match self.deps.launcher.launch(&recipe, &overrides) {
+            Ok(started) => vec![ServerMsg::Started {
+                id,
+                recipe: recipe_id.clone(),
+                container: started.container,
+                endpoint: started.endpoint,
+            }],
+            Err(e) => vec![err(Some(id), e)],
+        }
+    }
+
+    fn stop(&mut self, id: u32, recipe_id: &RecipeId) -> Vec<ServerMsg> {
+        match self.deps.launcher.stop(recipe_id.as_str()) {
+            Ok(()) => vec![ServerMsg::Stopped {
+                id,
+                recipe: recipe_id.clone(),
+            }],
+            Err(e) => vec![err(Some(id), e)],
+        }
+    }
+
+    fn status(&mut self, id: u32) -> Vec<ServerMsg> {
+        match self.deps.launcher.running() {
+            Ok(running) => vec![ServerMsg::Status { id, running }],
+            Err(e) => vec![err(Some(id), e)],
+        }
+    }
+
+    fn inventory(&self) -> Vec<RecipeInfo> {
+        self.deps
+            .registry
+            .list()
+            .into_iter()
+            .filter_map(|entry| {
+                let id = RecipeId::parse(&entry.name).ok()?;
+                let r = self
+                    .deps
+                    .registry
+                    .resolve(&RecipeRef::Bare(entry.name))
+                    .ok()?;
+                let (runnable, reason) = match r.launchable() {
+                    Ok(()) => (true, None),
+                    Err(why) => (false, Some(why.to_string())),
+                };
+                Some(RecipeInfo {
+                    id,
+                    model: r.model.clone(),
+                    nodes: r.topology.min_nodes,
+                    runnable,
+                    reason,
+                    defaults: r
+                        .defaults
+                        .iter()
+                        .map(|(k, v)| (k.clone(), to_wire(v)))
+                        .collect(),
+                })
+            })
+            .collect()
+    }
+}
+
+fn to_wire(v: &atlasctl_core::ScalarValue) -> SettingValue {
+    use atlasctl_core::ScalarValue as S;
+    match v {
+        S::Bool(b) => SettingValue::Bool(*b),
+        S::Int(i) => SettingValue::Int(*i),
+        S::Float(f) => SettingValue::Float(*f),
+        S::Str(s) => SettingValue::Str(s.clone()),
+    }
+}
+
+fn err(id: Option<u32>, error: AgentError) -> ServerMsg {
+    ServerMsg::Error { id, error }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/atlasctl-agent/src/session/tests.rs
+++ b/crates/atlasctl-agent/src/session/tests.rs
@@ -1,0 +1,379 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use super::*;
+use crate::launcher::{Call, RecordingLauncher};
+use atlasctl_protocol::settings::SettingError;
+
+const TOKEN: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+/// A recipe that really is in the compiled-in corpus.
+const REAL: &str = "qwen3.6-27b-fp8";
+
+fn set(pairs: &[(&str, SettingValue)]) -> BTreeMap<String, SettingValue> {
+    pairs
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), v.clone()))
+        .collect()
+}
+
+fn id(s: &str) -> RecipeId {
+    RecipeId::parse(s).expect("valid id")
+}
+
+struct Fixture {
+    registry: RegistrySet,
+    launcher: RecordingLauncher,
+    can_launch: Result<(), String>,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        Self {
+            registry: RegistrySet::builtin_only(),
+            launcher: RecordingLauncher::new(),
+            can_launch: Ok(()),
+        }
+    }
+
+    fn cannot_launch(reason: &str) -> Self {
+        Self {
+            can_launch: Err(reason.to_string()),
+            ..Self::new()
+        }
+    }
+
+    fn session(&self) -> Session<'_> {
+        let (s, _welcome) = Session::new(SessionDeps {
+            registry: &self.registry,
+            launcher: &self.launcher,
+            token: TOKEN,
+            can_launch: self.can_launch.clone(),
+        });
+        s
+    }
+
+    /// A session that has already completed the handshake.
+    fn ready(&self) -> Session<'_> {
+        let mut s = self.session();
+        let out = s.handle(ClientMsg::Hello {
+            protocol_version: 1,
+            token: TOKEN.into(),
+        });
+        assert!(
+            matches!(out[0], ServerMsg::Ready { .. }),
+            "handshake failed: {out:?}"
+        );
+        s
+    }
+}
+
+#[test]
+fn the_agent_speaks_first_with_a_version_range() {
+    let f = Fixture::new();
+    let (_s, welcome) = Session::new(SessionDeps {
+        registry: &f.registry,
+        launcher: &f.launcher,
+        token: TOKEN,
+        can_launch: Ok(()),
+    });
+    assert!(matches!(welcome, ServerMsg::Welcome { .. }));
+}
+
+#[test]
+fn nothing_is_answered_before_the_handshake() {
+    // Not even the inventory: an unauthenticated client should not learn what
+    // this machine can run.
+    for msg in [
+        ClientMsg::ListRecipes { id: 1 },
+        ClientMsg::Status { id: 1 },
+        ClientMsg::Launch {
+            id: 1,
+            recipe: id(REAL),
+            settings: BTreeMap::new(),
+        },
+    ] {
+        let f = Fixture::new();
+        let mut s = f.session();
+        let out = s.handle(msg);
+        assert!(
+            matches!(
+                out[0],
+                ServerMsg::Error {
+                    error: AgentError::NotReady,
+                    ..
+                }
+            ),
+            "got {out:?}"
+        );
+        assert!(s.is_closed());
+        assert!(!f.launcher.launched_anything());
+    }
+}
+
+#[test]
+fn a_wrong_token_is_refused_and_ends_the_session() {
+    let f = Fixture::new();
+    let mut s = f.session();
+    let out = s.handle(ClientMsg::Hello {
+        protocol_version: 1,
+        token: "f".repeat(64),
+    });
+    assert!(matches!(
+        out[0],
+        ServerMsg::Error {
+            error: AgentError::NotPaired,
+            ..
+        }
+    ));
+    assert!(s.is_closed());
+    // And a follow-up gets nothing at all.
+    assert!(s.handle(ClientMsg::ListRecipes { id: 1 }).is_empty());
+}
+
+#[test]
+fn an_empty_token_does_not_pass() {
+    let f = Fixture::new();
+    let mut s = f.session();
+    let out = s.handle(ClientMsg::Hello {
+        protocol_version: 1,
+        token: String::new(),
+    });
+    assert!(matches!(
+        out[0],
+        ServerMsg::Error {
+            error: AgentError::NotPaired,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn a_protocol_mismatch_is_reported_rather_than_hung() {
+    let f = Fixture::new();
+    let mut s = f.session();
+    let out = s.handle(ClientMsg::Hello {
+        protocol_version: 99,
+        token: TOKEN.into(),
+    });
+    assert!(matches!(
+        out[0],
+        ServerMsg::Error {
+            error: AgentError::UnsupportedProtocol { requested: 99, .. },
+            ..
+        }
+    ));
+}
+
+#[test]
+fn a_successful_handshake_returns_the_schema_and_the_inventory() {
+    let f = Fixture::new();
+    let mut s = f.session();
+    let out = s.handle(ClientMsg::Hello {
+        protocol_version: 1,
+        token: TOKEN.into(),
+    });
+    let ServerMsg::Ready {
+        schema,
+        recipes,
+        can_launch,
+        ..
+    } = &out[0]
+    else {
+        panic!("expected ready, got {out:?}");
+    };
+    assert!(
+        !schema.is_empty(),
+        "the client renders what we validate, so it needs the schema"
+    );
+    assert!(recipes.iter().any(|r| r.id.as_str() == REAL));
+    assert!(*can_launch);
+    // The schema must never advertise a key clients may not set.
+    assert!(!schema.iter().any(|s| s.key == "model_from_path"));
+}
+
+#[test]
+fn an_unknown_recipe_is_refused_without_reaching_the_launcher() {
+    let f = Fixture::new();
+    let mut s = f.ready();
+    let out = s.handle(ClientMsg::Launch {
+        id: 1,
+        recipe: id("no-such-recipe"),
+        settings: BTreeMap::new(),
+    });
+    assert!(matches!(
+        out[0],
+        ServerMsg::Error {
+            error: AgentError::UnknownRecipe { .. },
+            ..
+        }
+    ));
+    assert!(
+        !f.launcher.launched_anything(),
+        "nothing may run for an unknown recipe"
+    );
+}
+
+#[test]
+fn a_denied_setting_blocks_the_launch_and_is_recorded() {
+    let f = Fixture::new();
+    let mut s = f.ready();
+    let out = s.handle(ClientMsg::Launch {
+        id: 1,
+        recipe: id(REAL),
+        settings: set(&[("model_from_path", SettingValue::Str("/etc/shadow".into()))]),
+    });
+    let ServerMsg::Error {
+        error: AgentError::BadSettings { errors },
+        ..
+    } = &out[0]
+    else {
+        panic!("expected rejected settings, got {out:?}");
+    };
+    assert!(matches!(errors[0], SettingError::Denied { .. }));
+    assert!(
+        !f.launcher.launched_anything(),
+        "a denied key must stop the launch"
+    );
+    // Attempts on denied keys are surfaced for logging: nothing in a real UI
+    // offers one, so trying says something about the client.
+    assert_eq!(s.denied_attempts, ["model_from_path"]);
+}
+
+#[test]
+fn an_out_of_range_setting_blocks_the_launch() {
+    let f = Fixture::new();
+    let mut s = f.ready();
+    let out = s.handle(ClientMsg::Launch {
+        id: 1,
+        recipe: id(REAL),
+        settings: set(&[("port", SettingValue::Int(1))]),
+    });
+    assert!(matches!(
+        out[0],
+        ServerMsg::Error {
+            error: AgentError::BadSettings { .. },
+            ..
+        }
+    ));
+    assert!(!f.launcher.launched_anything());
+}
+
+#[test]
+fn a_valid_launch_reaches_the_launcher_with_exactly_the_checked_settings() {
+    let f = Fixture::new();
+    let mut s = f.ready();
+    let out = s.handle(ClientMsg::Launch {
+        id: 7,
+        recipe: id(REAL),
+        settings: set(&[("port", SettingValue::Int(9001))]),
+    });
+    assert!(
+        matches!(out[0], ServerMsg::Started { id: 7, .. }),
+        "got {out:?}"
+    );
+    match &f.launcher.calls()[0] {
+        Call::Launch(name, overrides) => {
+            assert_eq!(name, REAL);
+            assert_eq!(
+                overrides.len(),
+                1,
+                "only the checked setting may pass through"
+            );
+            assert_eq!(overrides["port"], atlasctl_core::ScalarValue::Int(9001));
+        }
+        other => panic!("wrong call: {other:?}"),
+    }
+}
+
+#[test]
+fn a_multi_node_recipe_is_refused_with_its_reason() {
+    let f = Fixture::new();
+    let mut s = f.ready();
+    // A two-node recipe cannot be started from a page on one box.
+    let out = s.handle(ClientMsg::Launch {
+        id: 1,
+        recipe: id("qwen3.5-122b-a10b-nvfp4-ep2"),
+        settings: BTreeMap::new(),
+    });
+    // It is launchable in principle, so what matters here is that the inventory
+    // told the client it needs two nodes before it ever asked.
+    assert!(!out.is_empty());
+    let inv = match &s.handle(ClientMsg::ListRecipes { id: 2 })[0] {
+        ServerMsg::Recipes { recipes, .. } => recipes.clone(),
+        other => panic!("wrong reply: {other:?}"),
+    };
+    let ep2 = inv
+        .iter()
+        .find(|r| r.id.as_str() == "qwen3.5-122b-a10b-nvfp4-ep2")
+        .unwrap();
+    assert_eq!(ep2.nodes, 2, "the client must be told this needs two nodes");
+}
+
+#[test]
+fn a_recipe_carrying_executable_content_is_never_launched() {
+    let f = Fixture::new();
+    let mut s = f.ready();
+    let out = s.handle(ClientMsg::Launch {
+        id: 1,
+        recipe: id("diffusion-gemma-bf16"),
+        settings: BTreeMap::new(),
+    });
+    assert!(matches!(
+        out[0],
+        ServerMsg::Error {
+            error: AgentError::NotLaunchable { .. },
+            ..
+        }
+    ));
+    assert!(!f.launcher.launched_anything());
+}
+
+#[test]
+fn a_machine_that_cannot_launch_says_so_and_refuses() {
+    let f = Fixture::cannot_launch("docker is not available");
+    let mut s = f.ready();
+    let out = s.handle(ClientMsg::Launch {
+        id: 1,
+        recipe: id(REAL),
+        settings: BTreeMap::new(),
+    });
+    assert!(matches!(
+        out[0],
+        ServerMsg::Error {
+            error: AgentError::NotLaunchable { .. },
+            ..
+        }
+    ));
+    assert!(!f.launcher.launched_anything());
+}
+
+#[test]
+fn preview_renders_without_launching_anything() {
+    let f = Fixture::new();
+    let mut s = f.ready();
+    let out = s.handle(ClientMsg::Preview {
+        id: 1,
+        recipe: id(REAL),
+        settings: BTreeMap::new(),
+    });
+    assert!(matches!(out[0], ServerMsg::Preview { id: 1, .. }));
+    assert!(
+        !f.launcher.launched_anything(),
+        "preview must not start anything"
+    );
+    assert_eq!(f.launcher.calls(), [Call::Preview(REAL.to_string())]);
+}
+
+#[test]
+fn a_malformed_frame_ends_the_session() {
+    let f = Fixture::new();
+    let mut s = f.ready();
+    let out = s.on_malformed("trailing garbage".into());
+    assert!(matches!(
+        out,
+        ServerMsg::Error {
+            error: AgentError::InvalidMessage { .. },
+            ..
+        }
+    ));
+    assert!(s.is_closed());
+}

--- a/crates/atlasctl-agent/src/telemetry/meminfo.rs
+++ b/crates/atlasctl-agent/src/telemetry/meminfo.rs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Host memory, which on unified-memory hardware is the meaningful figure.
+//!
+//! A GB10's 119.7 GB "GPU memory" is the host's LPDDR5X: `nvidia-smi` reports
+//! no framebuffer at all, so this is where the number comes from.
+
+/// Total and in-use memory.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct MemInfo {
+    /// Total, bytes.
+    pub total_bytes: Option<u64>,
+    /// In use, bytes — total minus what is actually available.
+    pub used_bytes: Option<u64>,
+}
+
+/// Whether host memory can be read here.
+pub fn available() -> bool {
+    std::path::Path::new("/proc/meminfo").exists()
+}
+
+/// Read host memory.
+pub fn read() -> MemInfo {
+    std::fs::read_to_string("/proc/meminfo")
+        .map(|s| parse(&s))
+        .unwrap_or_default()
+}
+
+/// Parse `/proc/meminfo`.
+///
+/// Uses `MemAvailable` rather than `MemFree`: free memory excludes reclaimable
+/// page cache, so on a box that has just loaded 100 GB of weights it reads
+/// alarmingly low while the memory is in fact obtainable.
+pub fn parse(body: &str) -> MemInfo {
+    let field = |name: &str| -> Option<u64> {
+        body.lines()
+            .find(|l| l.starts_with(name))?
+            .split_whitespace()
+            .nth(1)?
+            .parse::<u64>()
+            .ok()
+            .map(|kb| kb * 1024)
+    };
+    let total = field("MemTotal:");
+    let avail = field("MemAvailable:");
+    MemInfo {
+        total_bytes: total,
+        used_bytes: match (total, avail) {
+            (Some(t), Some(a)) => Some(t.saturating_sub(a)),
+            _ => None,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Captured from a real DGX Spark.
+    const REAL: &str =
+        "MemTotal:       127601452 kB\nMemFree:        45557560 kB\nMemAvailable:   115669068 kB\n";
+
+    #[test]
+    fn a_real_gb10_meminfo_parses_to_roughly_119_gib() {
+        let m = parse(REAL);
+        let gib = m.total_bytes.unwrap() as f64 / (1024.0 * 1024.0 * 1024.0);
+        assert!((118.0..=123.0).contains(&gib), "got {gib} GiB");
+    }
+
+    #[test]
+    fn used_is_derived_from_available_not_free() {
+        // MemFree would say ~78 GiB used on this box; MemAvailable says ~11.
+        // The second is the honest figure, because page cache is reclaimable.
+        let m = parse(REAL);
+        let used_gib = m.used_bytes.unwrap() as f64 / (1024.0 * 1024.0 * 1024.0);
+        assert!(
+            used_gib < 20.0,
+            "used should follow MemAvailable, got {used_gib} GiB"
+        );
+    }
+
+    #[test]
+    fn missing_fields_yield_absences_rather_than_zeros() {
+        assert_eq!(parse(""), MemInfo::default());
+        assert_eq!(parse("MemTotal:  100 kB\n").used_bytes, None);
+    }
+}

--- a/crates/atlasctl-agent/src/telemetry/mod.rs
+++ b/crates/atlasctl-agent/src/telemetry/mod.rs
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Live numbers about a running model and the machine underneath it.
+
+pub mod meminfo;
+pub mod nvidia;
+pub mod prometheus;
+
+use atlasctl_core::io::ProcessRunner;
+use atlasctl_protocol::telemetry::{DeviceStats, TelemetryCaps};
+
+/// Clock below this while work is in flight counts as clamped.
+///
+/// The number matters. A GB10 idles around 200 MHz and runs above 2000 under
+/// load; a clamp at 513 MHz once made every throughput measurement read two to
+/// three times low while every correctness check stayed green. A threshold in
+/// between catches that without firing at idle.
+pub const DEFAULT_HEALTHY_CLOCK_MHZ: u32 = 1500;
+
+/// Ask the machine what it can actually answer.
+///
+/// Run once at startup. Capabilities are earned by a reading, never assumed:
+/// on unified-memory hardware `nvidia-smi` returns `[N/A]` for memory, and a
+/// dashboard that assumed otherwise would render zeros as measurements.
+pub fn probe(runner: &dyn ProcessRunner) -> TelemetryCaps {
+    let Ok(out) = runner.run(&nvidia::argv()) else {
+        return TelemetryCaps::default();
+    };
+    if !out.success() {
+        return TelemetryCaps::default();
+    }
+    let reading = nvidia::parse(out.stdout.lines().next().unwrap_or_default());
+
+    TelemetryCaps {
+        gpu_util: reading.util_pct.is_some(),
+        sm_clock: reading.sm_clock_mhz.is_some(),
+        temperature: reading.temperature_c.is_some(),
+        power: reading.power_w.is_some(),
+        framebuffer_memory: reading.memory_total_bytes.is_some(),
+        // Host memory is the meaningful figure when there is no framebuffer.
+        unified_memory: meminfo::available(),
+        engine_metrics: false,
+        sm_clock_healthy_mhz: reading.sm_clock_mhz.map(|_| DEFAULT_HEALTHY_CLOCK_MHZ),
+    }
+}
+
+/// Take one device sample, reporting only what the capabilities allow.
+///
+/// `busy` says whether the engine has work in flight, which is what makes a low
+/// clock meaningful: 208 MHz at idle is correct, and the same figure under load
+/// is a problem.
+pub fn sample_device(runner: &dyn ProcessRunner, caps: &TelemetryCaps, busy: bool) -> DeviceStats {
+    let reading = runner
+        .run(&nvidia::argv())
+        .ok()
+        .filter(|o| o.success())
+        .map(|o| nvidia::parse(o.stdout.lines().next().unwrap_or_default()))
+        .unwrap_or_default();
+
+    let clamped = match (busy, reading.sm_clock_mhz, caps.sm_clock_healthy_mhz) {
+        (true, Some(mhz), Some(healthy)) => mhz < healthy,
+        _ => false,
+    };
+
+    let (total, used, unified) = if caps.framebuffer_memory {
+        (reading.memory_total_bytes, reading.memory_used_bytes, false)
+    } else if caps.unified_memory {
+        let m = meminfo::read();
+        (m.total_bytes, m.used_bytes, true)
+    } else {
+        (None, None, false)
+    };
+
+    DeviceStats {
+        gpu_util_pct: caps.gpu_util.then_some(reading.util_pct).flatten(),
+        sm_clock_mhz: caps.sm_clock.then_some(reading.sm_clock_mhz).flatten(),
+        sm_clock_clamped: clamped,
+        temperature_c: caps.temperature.then_some(reading.temperature_c).flatten(),
+        power_w: caps.power.then_some(reading.power_w).flatten(),
+        memory_total_bytes: total,
+        memory_used_bytes: used,
+        memory_is_unified: unified,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use atlasctl_core::io::RecordingRunner;
+    use atlasctl_core::io::process::Output;
+
+    /// Captured from a real DGX Spark.
+    const GB10: &str = "NVIDIA GB10, [N/A], [N/A], 0 %, 208 MHz, 50, 5.24 W";
+
+    fn runner_with(stdout: &str, status: i32) -> RecordingRunner {
+        let r = RecordingRunner::new();
+        r.push_result(Output {
+            status,
+            stdout: stdout.into(),
+            stderr: String::new(),
+        });
+        r
+    }
+
+    #[test]
+    fn probing_a_gb10_finds_no_framebuffer_but_everything_else() {
+        let caps = probe(&runner_with(GB10, 0));
+        assert!(caps.gpu_util && caps.sm_clock && caps.temperature && caps.power);
+        assert!(!caps.framebuffer_memory, "this part reports no framebuffer");
+        assert_eq!(caps.sm_clock_healthy_mhz, Some(DEFAULT_HEALTHY_CLOCK_MHZ));
+    }
+
+    #[test]
+    fn probing_a_machine_without_nvidia_smi_claims_nothing() {
+        let caps = probe(&runner_with("", 127));
+        assert!(!caps.gpu_util);
+        assert!(!caps.sm_clock);
+        assert_eq!(caps.sm_clock_healthy_mhz, None);
+    }
+
+    #[test]
+    fn an_idle_low_clock_is_not_reported_as_clamped() {
+        // 208 MHz with nothing running is correct, not a fault.
+        let caps = probe(&runner_with(GB10, 0));
+        let d = sample_device(&runner_with(GB10, 0), &caps, false);
+        assert_eq!(d.sm_clock_mhz, Some(208));
+        assert!(!d.sm_clock_clamped, "idle must not raise a clamp warning");
+    }
+
+    #[test]
+    fn the_same_clock_under_load_is_reported_as_clamped() {
+        // This is the failure that hid for weeks: throughput reads low while
+        // every correctness check stays green.
+        let caps = probe(&runner_with(GB10, 0));
+        let clamped = "NVIDIA GB10, [N/A], [N/A], 96 %, 513 MHz, 71, 42.0 W";
+        let d = sample_device(&runner_with(clamped, 0), &caps, true);
+        assert!(
+            d.sm_clock_clamped,
+            "a clamped clock under load must be flagged"
+        );
+    }
+
+    #[test]
+    fn a_healthy_clock_under_load_is_not_flagged() {
+        let caps = probe(&runner_with(GB10, 0));
+        let healthy = "NVIDIA GB10, [N/A], [N/A], 96 %, 2405 MHz, 71, 92.0 W";
+        assert!(!sample_device(&runner_with(healthy, 0), &caps, true).sm_clock_clamped);
+    }
+
+    #[test]
+    fn memory_on_a_unified_part_comes_from_the_host_and_says_so() {
+        let caps = probe(&runner_with(GB10, 0));
+        let d = sample_device(&runner_with(GB10, 0), &caps, false);
+        if caps.unified_memory {
+            assert!(
+                d.memory_is_unified,
+                "the client must be told this is not VRAM"
+            );
+            assert!(d.memory_total_bytes.unwrap_or(0) > 0);
+        }
+    }
+
+    #[test]
+    fn a_capability_that_was_not_probed_is_never_reported() {
+        // Even if a later reading contains the field, an unprobed capability
+        // stays absent — otherwise the dashboard would flicker into life.
+        let caps = TelemetryCaps::default();
+        let d = sample_device(&runner_with(GB10, 0), &caps, true);
+        assert_eq!(d.gpu_util_pct, None);
+        assert_eq!(d.sm_clock_mhz, None);
+        assert!(!d.sm_clock_clamped);
+    }
+}

--- a/crates/atlasctl-agent/src/telemetry/nvidia.rs
+++ b/crates/atlasctl-agent/src/telemetry/nvidia.rs
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Parsing `nvidia-smi` CSV output.
+//!
+//! Every field is optional, because on a GB10 several of them genuinely are.
+//! Real output from that hardware:
+//!
+//! ```text
+//! NVIDIA GB10, [N/A], [N/A], 0 %, 208 MHz, 50, 5.24 W
+//! ```
+//!
+//! The two `[N/A]`s are the memory fields. Grace-Blackwell is unified memory,
+//! so there is no framebuffer to report — the pool is the host's, and it comes
+//! from `/proc/meminfo` instead.
+
+/// The query we ask for, in this order.
+pub const QUERY: &str =
+    "name,memory.total,memory.used,utilization.gpu,clocks.current.sm,temperature.gpu,power.draw";
+
+/// Arguments for a telemetry sample.
+pub fn argv() -> Vec<String> {
+    vec![
+        "nvidia-smi".into(),
+        format!("--query-gpu={QUERY}"),
+        "--format=csv,noheader".into(),
+    ]
+}
+
+/// One accelerator's readings, as far as it reports them.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Reading {
+    /// Device name.
+    pub name: Option<String>,
+    /// Framebuffer total, bytes. Absent on unified-memory parts.
+    pub memory_total_bytes: Option<u64>,
+    /// Framebuffer in use, bytes. Absent on unified-memory parts.
+    pub memory_used_bytes: Option<u64>,
+    /// Utilisation, percent.
+    pub util_pct: Option<f64>,
+    /// Current clock, MHz.
+    pub sm_clock_mhz: Option<u32>,
+    /// Temperature, Celsius.
+    pub temperature_c: Option<f64>,
+    /// Power draw, Watts.
+    pub power_w: Option<f64>,
+}
+
+/// A field nvidia-smi declines to answer.
+///
+/// It uses several spellings depending on why, and they all mean the same
+/// thing to us: there is no number here. Treating any of them as a value is
+/// how a dashboard ends up reporting zeros as measurements.
+fn absent(raw: &str) -> bool {
+    let t = raw.trim();
+    t.is_empty()
+        || t.eq_ignore_ascii_case("[N/A]")
+        || t.eq_ignore_ascii_case("N/A")
+        || t.eq_ignore_ascii_case("[Not Supported]")
+        || t.eq_ignore_ascii_case("[Unknown Error]")
+        || t.eq_ignore_ascii_case("[Insufficient Permissions]")
+}
+
+/// Strip a trailing unit and parse the number in front of it.
+fn number(raw: &str) -> Option<f64> {
+    if absent(raw) {
+        return None;
+    }
+    raw.split_whitespace().next()?.parse::<f64>().ok()
+}
+
+/// Parse one line of CSV output.
+pub fn parse(line: &str) -> Reading {
+    let f: Vec<&str> = line.split(',').collect();
+    let at = |i: usize| f.get(i).copied().unwrap_or("");
+    let mib_to_bytes = |v: f64| (v * 1024.0 * 1024.0) as u64;
+
+    Reading {
+        name: (!absent(at(0))).then(|| at(0).trim().to_string()),
+        memory_total_bytes: number(at(1)).map(mib_to_bytes),
+        memory_used_bytes: number(at(2)).map(mib_to_bytes),
+        util_pct: number(at(3)),
+        sm_clock_mhz: number(at(4)).map(|v| v as u32),
+        temperature_c: number(at(5)),
+        power_w: number(at(6)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Captured from a real DGX Spark, not invented.
+    const GB10: &str = "NVIDIA GB10, [N/A], [N/A], 0 %, 208 MHz, 50, 5.24 W";
+
+    #[test]
+    fn a_real_gb10_line_parses_with_no_memory_and_everything_else_present() {
+        let r = parse(GB10);
+        assert_eq!(r.name.as_deref(), Some("NVIDIA GB10"));
+        // The whole reason capabilities are probed: this part has no framebuffer.
+        assert_eq!(r.memory_total_bytes, None);
+        assert_eq!(r.memory_used_bytes, None);
+        assert_eq!(r.util_pct, Some(0.0));
+        assert_eq!(r.sm_clock_mhz, Some(208));
+        assert_eq!(r.temperature_c, Some(50.0));
+        assert_eq!(r.power_w, Some(5.24));
+    }
+
+    #[test]
+    fn a_discrete_card_reports_its_framebuffer() {
+        let r = parse("NVIDIA A100, 40960 MiB, 1024 MiB, 73 %, 1410 MHz, 61, 250.5 W");
+        assert_eq!(r.memory_total_bytes, Some(40960 * 1024 * 1024));
+        assert_eq!(r.memory_used_bytes, Some(1024 * 1024 * 1024));
+        assert_eq!(r.util_pct, Some(73.0));
+    }
+
+    #[test]
+    fn every_spelling_of_unavailable_is_treated_as_absent() {
+        for spelling in [
+            "[N/A]",
+            "N/A",
+            "[Not Supported]",
+            "[Unknown Error]",
+            "  ",
+            "",
+        ] {
+            let line = format!(
+                "GPU, {spelling}, {spelling}, {spelling}, {spelling}, {spelling}, {spelling}"
+            );
+            let r = parse(&line);
+            assert_eq!(r.util_pct, None, "{spelling:?} should be absent");
+            assert_eq!(r.sm_clock_mhz, None, "{spelling:?} should be absent");
+            assert_eq!(r.power_w, None, "{spelling:?} should be absent");
+        }
+    }
+
+    #[test]
+    fn a_truncated_line_does_not_panic_and_yields_absences() {
+        let r = parse("NVIDIA GB10");
+        assert_eq!(r.name.as_deref(), Some("NVIDIA GB10"));
+        assert_eq!(r.util_pct, None);
+    }
+
+    #[test]
+    fn empty_output_yields_nothing_rather_than_defaults_that_look_real() {
+        assert_eq!(parse(""), Reading::default());
+    }
+}

--- a/crates/atlasctl-agent/src/telemetry/prometheus.rs
+++ b/crates/atlasctl-agent/src/telemetry/prometheus.rs
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Reading the model server's own metrics.
+//!
+//! Scraping the engine's `/metrics` is deliberately preferred over parsing its
+//! logs: the endpoint is a versioned contract that ships with the engine, and a
+//! log line is not. Only the handful of series we name are read; everything
+//! else in the exposition is ignored.
+
+use std::collections::BTreeMap;
+
+/// A parsed exposition: series name (with labels dropped) to summed value.
+///
+/// Labels are summed rather than kept because every series we care about is
+/// either unlabelled or wants its total. The one exception, draft acceptance,
+/// needs two specific labels and reads them itself.
+pub type Series = BTreeMap<String, f64>;
+
+/// Parse Prometheus text exposition.
+///
+/// Tolerant by design: an unknown line, a malformed value, or a series we do
+/// not recognise is skipped rather than failing the sample. A dashboard losing
+/// one field is better than losing the whole reading.
+pub fn parse(body: &str) -> Series {
+    let mut out = Series::new();
+    for line in body.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((lhs, rhs)) = line.rsplit_once(' ') else {
+            continue;
+        };
+        let Ok(value) = rhs.trim().parse::<f64>() else {
+            continue;
+        };
+        out.entry(lhs.trim().to_string())
+            .and_modify(|v| *v += value)
+            .or_insert(value);
+        // Also accumulate under the bare name, so a caller can ask for a total
+        // without knowing the label set.
+        if let Some((name, _labels)) = lhs.split_once('{') {
+            out.entry(name.trim().to_string())
+                .and_modify(|v| *v += value)
+                .or_insert(value);
+        }
+    }
+    out
+}
+
+/// Read one series by bare name.
+pub fn value(series: &Series, name: &str) -> Option<f64> {
+    series.get(name).copied()
+}
+
+/// Estimate a histogram quantile from its buckets.
+///
+/// Linear interpolation within the bucket that crosses the target rank, which
+/// is what Prometheus itself does. The result is an estimate and callers label
+/// it as one — bucket boundaries bound how precise it can be.
+pub fn histogram_quantile(series: &Series, metric: &str, q: f64) -> Option<f64> {
+    let prefix = format!("{metric}_bucket{{le=\"");
+    let mut buckets: Vec<(f64, f64)> = series
+        .iter()
+        .filter_map(|(k, v)| {
+            let rest = k.strip_prefix(&prefix)?;
+            let le = rest.split('"').next()?;
+            let bound = if le == "+Inf" {
+                f64::INFINITY
+            } else {
+                le.parse().ok()?
+            };
+            Some((bound, *v))
+        })
+        .collect();
+    if buckets.is_empty() {
+        return None;
+    }
+    buckets.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+
+    let total = buckets.last()?.1;
+    if total <= 0.0 {
+        return None;
+    }
+    let target = q * total;
+    let mut prev_bound = 0.0;
+    let mut prev_count = 0.0;
+    for (bound, count) in buckets {
+        if count >= target {
+            if bound.is_infinite() {
+                return Some(prev_bound);
+            }
+            let span = count - prev_count;
+            let frac = if span > 0.0 {
+                (target - prev_count) / span
+            } else {
+                0.0
+            };
+            return Some(prev_bound + (bound - prev_bound) * frac);
+        }
+        prev_bound = bound;
+        prev_count = count;
+    }
+    Some(prev_bound)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Shaped like the engine's real exposition.
+    const BODY: &str = r#"
+# HELP atlas_requests_total Total requests processed
+# TYPE atlas_requests_total counter
+atlas_requests_total 1042
+# TYPE atlas_requests_active gauge
+atlas_requests_active 3
+atlas_generation_tokens_total 88231
+atlas_time_to_first_token_seconds_bucket{le="0.5"} 10
+atlas_time_to_first_token_seconds_bucket{le="1"} 60
+atlas_time_to_first_token_seconds_bucket{le="2.5"} 90
+atlas_time_to_first_token_seconds_bucket{le="+Inf"} 100
+atlas_spec_decode_verify_total{outcome="accepted"} 700
+atlas_spec_decode_verify_total{outcome="rejected"} 300
+"#;
+
+    #[test]
+    fn plain_series_are_read() {
+        let s = parse(BODY);
+        assert_eq!(value(&s, "atlas_requests_total"), Some(1042.0));
+        assert_eq!(value(&s, "atlas_requests_active"), Some(3.0));
+        assert_eq!(value(&s, "atlas_generation_tokens_total"), Some(88231.0));
+    }
+
+    #[test]
+    fn labelled_series_are_summed_under_their_bare_name() {
+        let s = parse(BODY);
+        assert_eq!(value(&s, "atlas_spec_decode_verify_total"), Some(1000.0));
+        // And remain addressable individually, for a rate that needs one label.
+        assert_eq!(
+            value(&s, r#"atlas_spec_decode_verify_total{outcome="accepted"}"#),
+            Some(700.0)
+        );
+    }
+
+    #[test]
+    fn comments_and_blank_lines_are_ignored() {
+        assert!(!parse(BODY).keys().any(|k| k.starts_with('#')));
+    }
+
+    #[test]
+    fn a_quantile_falls_inside_the_crossing_bucket() {
+        let s = parse(BODY);
+        let p50 = histogram_quantile(&s, "atlas_time_to_first_token_seconds", 0.5).unwrap();
+        // The 50th of 100 observations lands in the (0.5, 1] bucket.
+        assert!((0.5..=1.0).contains(&p50), "p50 was {p50}");
+    }
+
+    #[test]
+    fn a_quantile_of_an_absent_histogram_is_absent_not_zero() {
+        assert_eq!(histogram_quantile(&parse(BODY), "nope_seconds", 0.5), None);
+    }
+
+    #[test]
+    fn malformed_input_is_skipped_rather_than_failing_the_sample() {
+        let s = parse("good 1\nbad_no_value\nalso bad_value\n# comment\n");
+        assert_eq!(value(&s, "good"), Some(1.0));
+        assert_eq!(value(&s, "also"), None);
+        assert!(
+            !s.is_empty(),
+            "one bad line must not lose the whole reading"
+        );
+    }
+
+    #[test]
+    fn an_empty_body_yields_nothing() {
+        assert!(parse("").is_empty());
+    }
+}

--- a/crates/atlasctl-agent/src/token.rs
+++ b/crates/atlasctl-agent/src/token.rs
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The pairing token.
+//!
+//! The site is static and served from a different origin, so it cannot ship a
+//! per-install secret. The user pastes one in once, from a terminal on the
+//! machine that owns the agent, which is what makes "this browser was
+//! deliberately connected to this agent" a statement anyone can rely on.
+//!
+//! What this defends: a page that somehow passes the origin check, and any
+//! other *user* on a shared machine, since loopback is reachable by every local
+//! account. What it does not defend: a process running as the same user, which
+//! can read the token file. That boundary is stated plainly in the docs rather
+//! than implied away — no transport design changes it, because such a process
+//! can run `docker` directly.
+
+use anyhow::{Context, Result, bail};
+use std::path::{Path, PathBuf};
+use subtle::ConstantTimeEq;
+
+/// Bytes of entropy in a token.
+const TOKEN_BYTES: usize = 32;
+
+/// Where the token lives, relative to the config directory.
+pub const TOKEN_FILE: &str = "browser.token";
+
+/// Render bytes as lowercase hex.
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Generate a fresh token from the operating system's CSPRNG.
+///
+/// Reads `/dev/urandom` directly rather than taking a dependency: this is the
+/// one place randomness matters, and the kernel interface is stable.
+pub fn generate() -> Result<String> {
+    let mut buf = [0u8; TOKEN_BYTES];
+    let mut f = std::fs::File::open("/dev/urandom").context("opening the system CSPRNG")?;
+    use std::io::Read;
+    f.read_exact(&mut buf)
+        .context("reading from the system CSPRNG")?;
+    Ok(hex(&buf))
+}
+
+/// Path of the token file within a config directory.
+pub fn path(config_dir: &Path) -> PathBuf {
+    config_dir.join(TOKEN_FILE)
+}
+
+/// Load the token, creating one on first use.
+///
+/// The file is written `0600`. A wider mode is refused rather than silently
+/// tightened: if another account could already read it, the token should be
+/// replaced, and only the user can decide that.
+pub fn load_or_create(config_dir: &Path) -> Result<String> {
+    let p = path(config_dir);
+    if p.exists() {
+        let token = std::fs::read_to_string(&p)
+            .with_context(|| format!("reading {}", p.display()))?
+            .trim()
+            .to_string();
+        check_permissions(&p)?;
+        if token.len() != TOKEN_BYTES * 2 {
+            bail!(
+                "{} does not contain a well-formed token; delete it and run \
+                 `atlasctl agent token --rotate`",
+                p.display()
+            );
+        }
+        return Ok(token);
+    }
+
+    std::fs::create_dir_all(config_dir)
+        .with_context(|| format!("creating {}", config_dir.display()))?;
+    let token = generate()?;
+    write_private(&p, &token)?;
+    Ok(token)
+}
+
+/// Replace the token.
+pub fn rotate(config_dir: &Path) -> Result<String> {
+    let token = generate()?;
+    std::fs::create_dir_all(config_dir)?;
+    write_private(&path(config_dir), &token)?;
+    Ok(token)
+}
+
+#[cfg(unix)]
+fn write_private(p: &Path, token: &str) -> Result<()> {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+    // Create with the right mode rather than chmod-ing after: otherwise the
+    // token exists world-readable for a moment, however short.
+    let mut f = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(p)
+        .with_context(|| format!("creating {}", p.display()))?;
+    f.write_all(token.as_bytes())?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn write_private(p: &Path, token: &str) -> Result<()> {
+    std::fs::write(p, token).with_context(|| format!("creating {}", p.display()))
+}
+
+#[cfg(unix)]
+fn check_permissions(p: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let mode = std::fs::metadata(p)?.permissions().mode() & 0o077;
+    if mode != 0 {
+        bail!(
+            "{} is readable by other accounts (mode {:o}). Another user on this \
+             machine may already have your pairing token; rotate it with \
+             `atlasctl agent token --rotate`.",
+            p.display(),
+            std::fs::metadata(p)?.permissions().mode() & 0o777
+        );
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn check_permissions(_p: &Path) -> Result<()> {
+    Ok(())
+}
+
+/// Compare a presented token against the real one, in constant time.
+///
+/// A byte-by-byte comparison leaks how much of a guess was correct, which turns
+/// a 256-bit secret into a series of 8-bit ones.
+pub fn matches(expected: &str, presented: &str) -> bool {
+    let a = expected.as_bytes();
+    let b = presented.as_bytes();
+    if a.len() != b.len() {
+        // Length alone is not secret: the format is fixed and public.
+        return false;
+    }
+    a.ct_eq(b).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_generated_token_has_the_expected_shape_and_is_not_repeated() {
+        let a = generate().expect("generates");
+        let b = generate().expect("generates");
+        assert_eq!(a.len(), TOKEN_BYTES * 2);
+        assert!(a.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_ne!(a, b, "two tokens must not be identical");
+    }
+
+    #[test]
+    fn comparison_accepts_only_the_exact_token() {
+        let t = generate().unwrap();
+        assert!(matches(&t, &t));
+        assert!(!matches(&t, ""));
+        assert!(!matches(&t, &t[..t.len() - 1]));
+        let mut wrong = t.clone();
+        wrong.replace_range(0..1, if t.starts_with('a') { "b" } else { "a" });
+        assert!(!matches(&t, &wrong), "a single differing byte must fail");
+    }
+
+    #[test]
+    fn a_token_survives_a_round_trip_through_a_directory() {
+        let dir = std::env::temp_dir().join(format!("atlasctl-tok-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let first = load_or_create(&dir).expect("creates");
+        let second = load_or_create(&dir).expect("loads");
+        assert_eq!(first, second, "loading must not mint a new token");
+        let rotated = rotate(&dir).expect("rotates");
+        assert_ne!(rotated, first, "rotation must change the token");
+        assert_eq!(load_or_create(&dir).unwrap(), rotated);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn the_token_file_is_created_private_and_a_loose_one_is_refused() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = std::env::temp_dir().join(format!("atlasctl-perm-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        load_or_create(&dir).expect("creates");
+        let p = path(&dir);
+        let mode = std::fs::metadata(&p).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "token must be created private, got {mode:o}");
+
+        // Widening it must be reported, not quietly accepted.
+        std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o644)).unwrap();
+        let err = load_or_create(&dir).expect_err("a readable token must be refused");
+        assert!(
+            err.to_string().contains("readable by other accounts"),
+            "{err}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/atlasctl-core/src/lib.rs
+++ b/crates/atlasctl-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod io;
 pub mod recipe;
 pub mod registry;
 pub mod scalar;
+pub mod settings;
 
 pub use docker::{DockerCommand, LaunchProfile};
 pub use recipe::{NotLaunchable, Provenance, Recipe, RecipeError, RuntimeKind, Topology};

--- a/crates/atlasctl-core/src/settings/mod.rs
+++ b/crates/atlasctl-core/src/settings/mod.rs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! What a remote client may set on a launch, and the check that enforces it.
+
+mod spec;
+mod table;
+
+pub use spec::{BoundSpec, Disposition, Spec};
+pub use table::DISPOSITIONS;
+
+// `flags` is used by the exhaustiveness tests, which are the reason this
+// module and the flag table must stay in step.
+#[cfg(test)]
+use crate::flags::FlagKind;
+use crate::scalar::ScalarValue;
+use atlasctl_protocol::settings::{SettingError, SettingSpec, SettingValue};
+use std::collections::BTreeMap;
+
+/// The schema, as served to a client at the handshake.
+///
+/// Sent at runtime rather than baked into the page, because the agent is what
+/// validates: a statically-embedded schema is wrong the moment either side
+/// ships independently, and a client rendering bounds the validator does not
+/// share is how "it looked fine and then the launch was rejected" happens.
+pub fn schema() -> Vec<SettingSpec> {
+    DISPOSITIONS
+        .iter()
+        .filter_map(|(key, d)| match d {
+            Disposition::Expose(s) => Some(SettingSpec {
+                key: (*key).to_string(),
+                bound: s.bound.to_bound(),
+                label: s.label.to_string(),
+                help: s.help.to_string(),
+                unit: s.unit.map(str::to_string),
+                group: s.group,
+                advanced: s.advanced,
+                locked: false,
+            }),
+            Disposition::Deny(_) => None,
+        })
+        .collect()
+}
+
+/// Look up a key's disposition.
+fn disposition(key: &str) -> Option<&'static Disposition> {
+    DISPOSITIONS.iter().find(|(k, _)| *k == key).map(|(_, d)| d)
+}
+
+/// Validate a client's requested overrides.
+///
+/// Returns values ready for the config chain. Every error is collected rather
+/// than returning on the first, so a client can fix a form in one pass instead
+/// of discovering problems one at a time.
+pub fn validate(
+    requested: &BTreeMap<String, SettingValue>,
+) -> Result<BTreeMap<String, ScalarValue>, Vec<SettingError>> {
+    let mut out = BTreeMap::new();
+    let mut errors = Vec::new();
+
+    for (key, value) in requested {
+        match disposition(key) {
+            None => errors.push(SettingError::UnknownKey { key: key.clone() }),
+            // A denied key is a signal, not a typo: nothing in a legitimate UI
+            // offers one, so an attempt to set it says something about the
+            // client. The caller logs these.
+            Some(Disposition::Deny(reason)) => errors.push(SettingError::Denied {
+                key: key.clone(),
+                reason: (*reason).to_string(),
+            }),
+            Some(Disposition::Expose(spec)) => match spec.bound.to_bound().check(key, value) {
+                Ok(checked) => {
+                    out.insert(key.clone(), to_scalar(&checked));
+                }
+                Err(e) => errors.push(e),
+            },
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(out)
+    } else {
+        Err(errors)
+    }
+}
+
+/// Convert a checked wire value into the config-chain scalar.
+fn to_scalar(v: &SettingValue) -> ScalarValue {
+    match v {
+        SettingValue::Bool(b) => ScalarValue::Bool(*b),
+        SettingValue::Int(i) => ScalarValue::Int(*i),
+        SettingValue::Float(f) => ScalarValue::Float(*f),
+        SettingValue::Str(s) => ScalarValue::Str(s.clone()),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/atlasctl-core/src/settings/spec.rs
+++ b/crates/atlasctl-core/src/settings/spec.rs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The shape of a disposition: whether a client may set a flag, and how.
+
+use atlasctl_protocol::settings::{Bound, Group};
+
+/// Whether a remote client may set a flag, and how.
+pub enum Disposition {
+    /// Settable, within the stated bound.
+    Expose(Spec),
+    /// Never settable by a client, with the reason recorded.
+    Deny(&'static str),
+}
+
+/// A settable flag's description, before it becomes wire data.
+pub struct Spec {
+    /// What values it accepts.
+    pub bound: BoundSpec,
+    /// Human label.
+    pub label: &'static str,
+    /// One sentence on what it does.
+    pub help: &'static str,
+    /// Unit for display.
+    pub unit: Option<&'static str>,
+    /// Where it belongs in the UI.
+    pub group: Group,
+    /// Hide behind a disclosure.
+    pub advanced: bool,
+}
+
+/// A bound in static form, so the table needs no allocation.
+pub enum BoundSpec {
+    /// Whole number in an inclusive range.
+    Int(i64, i64),
+    /// Fractional number in an inclusive range.
+    Float(f64, f64),
+    /// One of a fixed set.
+    Enum(&'static [&'static str]),
+    /// Bare toggle.
+    Toggle,
+    /// Explicit boolean value.
+    BoolValue,
+    /// `auto` or a number.
+    IntOrAuto(i64, i64),
+}
+
+impl BoundSpec {
+    /// Convert to the wire form.
+    pub fn to_bound(&self) -> Bound {
+        match self {
+            Self::Int(a, b) => Bound::Int { min: *a, max: *b },
+            Self::Float(a, b) => Bound::Float { min: *a, max: *b },
+            Self::Enum(v) => Bound::Enum {
+                variants: v.iter().map(|s| (*s).to_string()).collect(),
+            },
+            Self::Toggle => Bound::Toggle,
+            Self::BoolValue => Bound::BoolValue,
+            Self::IntOrAuto(a, b) => Bound::IntOrAuto { min: *a, max: *b },
+        }
+    }
+}

--- a/crates/atlasctl-core/src/settings/table.rs
+++ b/crates/atlasctl-core/src/settings/table.rs
@@ -1,0 +1,471 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The allow/deny partition of every serve flag.
+//!
+//! This table is the security boundary for remote launches: a key that is not
+//! here cannot be set, and a key marked `Deny` cannot be set by a client no
+//! matter what it sends. It must stay exhaustive over the flag table, which a
+//! test enforces.
+
+use super::spec::{BoundSpec, Disposition, Spec};
+use atlasctl_protocol::settings::Group;
+
+use BoundSpec::{BoolValue, Enum, Float, Int, IntOrAuto, Toggle};
+use Disposition::{Deny, Expose};
+use Group::{MemoryKv, Performance, Server, Speculative, ToolsChat, Topology};
+
+/// Terse constructor, so the table reads as a table.
+const fn e(
+    bound: BoundSpec,
+    label: &'static str,
+    help: &'static str,
+    unit: Option<&'static str>,
+    group: Group,
+    advanced: bool,
+) -> Disposition {
+    Expose(Spec {
+        bound,
+        label,
+        help,
+        unit,
+        group,
+        advanced,
+    })
+}
+
+const DTYPES: &[&str] = &["bf16", "fp8", "nvfp4"];
+
+/// Every flag, and whether a client may set it.
+///
+/// This must stay exhaustive over the flag table: a test asserts the two are in
+/// bijection, so adding flag 49 without deciding whether a webpage may set it
+/// fails the build rather than defaulting to either answer.
+///
+/// Formatting is frozen at one line per flag: reading this against the flag
+/// table is how the partition gets checked by eye, and a formatter that
+/// explodes each entry across six lines makes that impossible.
+#[rustfmt::skip]
+pub static DISPOSITIONS: &[(&str, Disposition)] = &[
+    // --- Server -------------------------------------------------------------
+    (
+        "port",
+        e(
+            Int(1024, 49151),
+            "Port",
+            "Port the model server listens on.",
+            None,
+            Server,
+            false,
+        ),
+    ),
+    (
+        "host",
+        Deny("the bind address is a network-exposure decision the agent owns, not a client"),
+    ),
+    (
+        "served_model_name",
+        Deny("an unbounded name with no operational value; the only free string in the table"),
+    ),
+    // --- Topology (recipe-owned) --------------------------------------------
+    (
+        "tensor_parallel",
+        e(
+            Int(1, 8),
+            "Tensor parallel",
+            "Tensor-parallel degree.",
+            None,
+            Topology,
+            true,
+        ),
+    ),
+    (
+        "ep_size",
+        e(
+            Int(1, 8),
+            "Expert parallel",
+            "Expert-parallel degree.",
+            None,
+            Topology,
+            true,
+        ),
+    ),
+    // --- Performance --------------------------------------------------------
+    (
+        "max_batch_size",
+        e(
+            Int(1, 64),
+            "Max batch size",
+            "Concurrent sequences decoded together.",
+            None,
+            Performance,
+            false,
+        ),
+    ),
+    (
+        "max_num_seqs",
+        e(
+            Int(1, 256),
+            "Max sequences",
+            "Concurrent sequences admitted.",
+            None,
+            Performance,
+            false,
+        ),
+    ),
+    (
+        "max_prefill_tokens",
+        e(
+            Int(256, 262144),
+            "Max prefill tokens",
+            "Largest prefill chunk.",
+            Some("tokens"),
+            Performance,
+            false,
+        ),
+    ),
+    (
+        "max_num_batched_tokens",
+        e(
+            Int(256, 262144),
+            "Max batched tokens",
+            "Alias of max prefill tokens.",
+            Some("tokens"),
+            Performance,
+            true,
+        ),
+    ),
+    (
+        "scheduling_policy",
+        e(
+            Enum(&["fcfs", "slai"]),
+            "Scheduling policy",
+            "How queued requests are ordered.",
+            None,
+            Performance,
+            false,
+        ),
+    ),
+    (
+        "tbt_deadline_ms",
+        e(
+            Int(1, 10000),
+            "Time-between-tokens deadline",
+            "Latency target the scheduler aims for.",
+            Some("ms"),
+            Performance,
+            true,
+        ),
+    ),
+    (
+        "enable_prefix_caching",
+        e(
+            Toggle,
+            "Prefix caching",
+            "Reuse KV for shared prompt prefixes.",
+            None,
+            Performance,
+            false,
+        ),
+    ),
+    // --- Memory & KV --------------------------------------------------------
+    (
+        "gpu_memory_utilization",
+        e(
+            Float(0.10, 0.95),
+            "Memory fraction",
+            "Share of the memory pool the engine may use.",
+            None,
+            MemoryKv,
+            false,
+        ),
+    ),
+    (
+        "max_model_len",
+        e(
+            Int(256, 262144),
+            "Context length",
+            "Longest sequence the server will accept.",
+            Some("tokens"),
+            MemoryKv,
+            false,
+        ),
+    ),
+    (
+        "kv_cache_dtype",
+        e(
+            Enum(DTYPES),
+            "KV cache dtype",
+            "Precision of the key/value cache.",
+            None,
+            MemoryKv,
+            false,
+        ),
+    ),
+    (
+        "kv_high_precision_layers",
+        e(
+            IntOrAuto(0, 256),
+            "High-precision KV layers",
+            "Layers kept at higher KV precision.",
+            None,
+            MemoryKv,
+            true,
+        ),
+    ),
+    (
+        "block_size",
+        e(
+            Enum(&["8", "16", "32", "64"]),
+            "KV block size",
+            "Paged-attention block size.",
+            Some("tokens"),
+            MemoryKv,
+            true,
+        ),
+    ),
+    (
+        "oom_guard_mb",
+        e(
+            Int(0, 16384),
+            "OOM guard",
+            "Memory held back as headroom.",
+            Some("MB"),
+            MemoryKv,
+            true,
+        ),
+    ),
+    (
+        "fp8_kv_calibration_tokens",
+        e(
+            Int(0, 65536),
+            "FP8 KV calibration",
+            "Tokens used to calibrate an FP8 KV cache.",
+            Some("tokens"),
+            MemoryKv,
+            true,
+        ),
+    ),
+    (
+        "ssm_cache_slots",
+        e(
+            Int(0, 4096),
+            "SSM cache slots",
+            "State-space cache slots preallocated.",
+            None,
+            MemoryKv,
+            true,
+        ),
+    ),
+    (
+        "ssm_checkpoint_interval",
+        e(
+            Int(1, 8192),
+            "SSM checkpoint interval",
+            "How often SSM state is checkpointed.",
+            None,
+            MemoryKv,
+            true,
+        ),
+    ),
+    // --- Speculative decoding -----------------------------------------------
+    (
+        "speculative",
+        e(
+            Toggle,
+            "Speculative decoding",
+            "Draft tokens ahead and verify them.",
+            None,
+            Speculative,
+            false,
+        ),
+    ),
+    (
+        "self_speculative",
+        e(
+            Toggle,
+            "Self-speculative",
+            "Draft with the model's own early layers.",
+            None,
+            Speculative,
+            true,
+        ),
+    ),
+    (
+        "ngram_speculative",
+        e(
+            Toggle,
+            "N-gram speculative",
+            "Draft from prompt n-grams.",
+            None,
+            Speculative,
+            true,
+        ),
+    ),
+    (
+        "dflash",
+        e(
+            Toggle,
+            "DFlash",
+            "Enable the DFlash draft path.",
+            None,
+            Speculative,
+            true,
+        ),
+    ),
+    (
+        "num_drafts",
+        e(
+            Int(1, 8),
+            "Draft tokens",
+            "Tokens drafted per verification step.",
+            None,
+            Speculative,
+            false,
+        ),
+    ),
+    (
+        "mtp_quantization",
+        e(
+            Enum(DTYPES),
+            "MTP precision",
+            "Precision of the draft head.",
+            None,
+            Speculative,
+            false,
+        ),
+    ),
+    (
+        "dflash_gamma",
+        e(
+            Int(1, 16),
+            "DFlash gamma",
+            "DFlash draft depth.",
+            None,
+            Speculative,
+            true,
+        ),
+    ),
+    (
+        "dflash_window_size",
+        e(
+            Int(1, 8192),
+            "DFlash window",
+            "DFlash lookahead window.",
+            None,
+            Speculative,
+            true,
+        ),
+    ),
+    (
+        "mtp_vocab",
+        Deny("couples to the checkpoint's draft-head artifact; changing it changes what loads"),
+    ),
+    (
+        "draft_model",
+        Deny("loads a second set of weights of the sender's choosing"),
+    ),
+    // --- Tools & chat -------------------------------------------------------
+    (
+        "tool_call_parser",
+        Deny(
+            "model-coupled correctness pin; changing it away from the recipe can only break tool calls",
+        ),
+    ),
+    (
+        "tool_max_tokens",
+        e(
+            Int(64, 65536),
+            "Tool call budget",
+            "Token budget for a tool call.",
+            Some("tokens"),
+            ToolsChat,
+            true,
+        ),
+    ),
+    (
+        "disable_tool_grammar",
+        e(
+            BoolValue,
+            "Disable tool grammar",
+            "Turn off grammar-constrained tool calls.",
+            None,
+            ToolsChat,
+            true,
+        ),
+    ),
+    (
+        "disable_thinking",
+        e(
+            Toggle,
+            "Disable thinking",
+            "Suppress reasoning output.",
+            None,
+            ToolsChat,
+            false,
+        ),
+    ),
+    (
+        "max_thinking_budget",
+        e(
+            Int(0, 262144),
+            "Thinking budget",
+            "Cap on reasoning tokens.",
+            Some("tokens"),
+            ToolsChat,
+            true,
+        ),
+    ),
+    // --- Denied: paths, credentials, and host hardware ----------------------
+    (
+        "model_from_path",
+        Deny(
+            "a filesystem path that changes which weights load — the exact vector this project exists to close",
+        ),
+    ),
+    (
+        "cache_dir",
+        Deny("a host path controlling where weights are read and written"),
+    ),
+    (
+        "gpu_ordinal",
+        Deny("host hardware selection, not a property of the deployment"),
+    ),
+    (
+        "api_key",
+        Deny(
+            "a credential must not travel from a page into a command line, where `docker inspect` can read it",
+        ),
+    ),
+    (
+        "require_auth",
+        Deny("letting a client turn authentication off is a downgrade attack"),
+    ),
+    (
+        "high_speed_swap",
+        Deny("unusable without a swap directory, which is a host path"),
+    ),
+    (
+        "high_speed_swap_dir",
+        Deny("a host path the engine writes to"),
+    ),
+    (
+        "high_speed_swap_gb",
+        Deny("part of the swap family, which is denied as a group"),
+    ),
+    (
+        "high_speed_swap_resident_blocks",
+        Deny("part of the swap family, which is denied as a group"),
+    ),
+    (
+        "high_speed_swap_rank",
+        Deny("part of the swap family, which is denied as a group"),
+    ),
+    (
+        "high_speed_swap_qd",
+        Deny("part of the swap family, which is denied as a group"),
+    ),
+    (
+        "high_speed_swap_cache_blocks_per_seq",
+        Deny("part of the swap family, which is denied as a group"),
+    ),
+];

--- a/crates/atlasctl-core/src/settings/tests.rs
+++ b/crates/atlasctl-core/src/settings/tests.rs
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use super::*;
+use crate::flags;
+use atlasctl_protocol::settings::Bound;
+
+fn req(pairs: &[(&str, SettingValue)]) -> BTreeMap<String, SettingValue> {
+    pairs
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), v.clone()))
+        .collect()
+}
+
+#[test]
+fn the_partition_is_exhaustive_over_the_flag_table() {
+    // If this fails, a flag was added without deciding whether a webpage may
+    // set it. Failing the build is the point: neither answer is a safe default.
+    for spec in flags::ATLAS_FLAGS.iter() {
+        assert!(
+            disposition(spec.key).is_some(),
+            "flag `{}` has no disposition — decide whether a client may set it",
+            spec.key
+        );
+    }
+    for (key, _) in DISPOSITIONS.iter() {
+        assert!(
+            flags::lookup(key).is_some(),
+            "`{key}` has a disposition but is not a flag"
+        );
+    }
+    assert_eq!(DISPOSITIONS.len(), flags::ATLAS_FLAGS.len());
+}
+
+#[test]
+fn no_key_appears_twice() {
+    let mut seen = std::collections::BTreeSet::new();
+    for (key, _) in DISPOSITIONS.iter() {
+        assert!(seen.insert(*key), "duplicate disposition for `{key}`");
+    }
+}
+
+#[test]
+fn bare_toggles_are_toggles_and_value_flags_are_not() {
+    for (key, d) in DISPOSITIONS.iter() {
+        let Disposition::Expose(spec) = d else {
+            continue;
+        };
+        let is_toggle = matches!(spec.bound.to_bound(), Bound::Toggle);
+        let flag_is_toggle = flags::lookup(key).map(|f| f.kind) == Some(FlagKind::BoolToggle);
+        assert_eq!(
+            is_toggle, flag_is_toggle,
+            "`{key}` disagrees with the flag table about being a bare toggle"
+        );
+    }
+}
+
+#[test]
+fn every_path_credential_and_weight_selector_is_denied() {
+    // Spelled out rather than derived, so removing one from the deny list is a
+    // visible change to this test rather than a quiet change to a filter.
+    for key in [
+        "model_from_path",
+        "cache_dir",
+        "draft_model",
+        "high_speed_swap_dir",
+        "api_key",
+        "require_auth",
+        "gpu_ordinal",
+        "served_model_name",
+        "host",
+    ] {
+        assert!(
+            matches!(disposition(key), Some(Disposition::Deny(_))),
+            "`{key}` must not be settable by a client"
+        );
+    }
+}
+
+#[test]
+fn denied_keys_never_reach_the_schema_a_client_sees() {
+    let schema = schema();
+    for (key, d) in DISPOSITIONS.iter() {
+        if matches!(d, Disposition::Deny(_)) {
+            assert!(
+                !schema.iter().any(|s| s.key == *key),
+                "denied key `{key}` was advertised to clients"
+            );
+        }
+    }
+}
+
+#[test]
+fn a_denied_key_is_refused_by_name_with_its_reason() {
+    let err = validate(&req(&[(
+        "model_from_path",
+        SettingValue::Str("/etc/shadow".into()),
+    )]))
+    .expect_err("must be refused");
+    match &err[0] {
+        SettingError::Denied { key, reason } => {
+            assert_eq!(key, "model_from_path");
+            assert!(!reason.is_empty(), "a refusal should say why");
+        }
+        other => panic!("wrong error: {other:?}"),
+    }
+}
+
+#[test]
+fn an_unknown_key_is_refused() {
+    let err = validate(&req(&[("totally_made_up", SettingValue::Int(1))])).expect_err("refused");
+    assert!(matches!(err[0], SettingError::UnknownKey { .. }));
+}
+
+#[test]
+fn valid_settings_pass_through_typed() {
+    let ok = validate(&req(&[
+        ("port", SettingValue::Int(9000)),
+        ("gpu_memory_utilization", SettingValue::Float(0.85)),
+        ("kv_cache_dtype", SettingValue::Str("fp8".into())),
+        ("speculative", SettingValue::Bool(true)),
+    ]))
+    .expect("all valid");
+    assert_eq!(ok["port"], ScalarValue::Int(9000));
+    assert_eq!(ok["gpu_memory_utilization"], ScalarValue::Float(0.85));
+    assert_eq!(ok["kv_cache_dtype"], ScalarValue::Str("fp8".into()));
+    assert_eq!(ok["speculative"], ScalarValue::Bool(true));
+}
+
+#[test]
+fn every_problem_is_reported_at_once() {
+    // Fixing a form one rejection at a time is a bad experience and encourages
+    // people to stop reading the errors.
+    let err = validate(&req(&[
+        ("port", SettingValue::Int(1)),
+        ("cache_dir", SettingValue::Str("/tmp".into())),
+        ("nope", SettingValue::Int(1)),
+    ]))
+    .expect_err("must be refused");
+    assert_eq!(err.len(), 3, "got {err:?}");
+}
+
+#[test]
+fn nothing_a_client_sends_can_become_a_flag_shaped_argv_element() {
+    // The end-to-end structural claim, exercised across every exposed setting.
+    let hostile = [
+        SettingValue::Str("--model-from-path /etc/shadow".into()),
+        SettingValue::Str("; rm -rf /".into()),
+        SettingValue::Str("$(id)".into()),
+        SettingValue::Int(i64::MAX),
+        SettingValue::Float(f64::NAN),
+    ];
+    for (key, d) in DISPOSITIONS.iter() {
+        if !matches!(d, Disposition::Expose(_)) {
+            continue;
+        }
+        for v in &hostile {
+            if let Ok(ok) = validate(&req(&[(key, v.clone())])) {
+                let rendered = ok[*key].render();
+                assert!(
+                    !rendered.starts_with('-'),
+                    "`{key}` accepted {v:?} and rendered {rendered:?}"
+                );
+                assert!(
+                    !rendered.contains(|c: char| c.is_whitespace() || ";|&$`".contains(c)),
+                    "`{key}` accepted {v:?} and rendered {rendered:?}"
+                );
+            }
+        }
+    }
+}

--- a/crates/atlasctl-protocol/Cargo.toml
+++ b/crates/atlasctl-protocol/Cargo.toml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+[package]
+name = "atlasctl-protocol"
+description = "Wire types shared by the atlasctl agent, the CLI, and the browser client."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[dependencies]
+serde.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+serde_json = "1"
+
+[lints]
+workspace = true

--- a/crates/atlasctl-protocol/src/id.rs
+++ b/crates/atlasctl-protocol/src/id.rs
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The recipe identifier, and why it is a type rather than a string.
+
+use serde::{Deserialize, Deserializer, Serialize};
+use std::fmt;
+
+/// Longest identifier we will accept.
+const MAX_LEN: usize = 64;
+
+/// A validated recipe name.
+///
+/// Parse, don't validate: the only way to obtain one is [`RecipeId::parse`],
+/// and `Deserialize` routes through it, so an invalid id cannot exist anywhere
+/// in the program. A webpage can name a recipe; it cannot name a path, a flag,
+/// or anything a shell would find interesting, because those never become a
+/// `RecipeId` in the first place.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(transparent)]
+pub struct RecipeId(String);
+
+/// Why a candidate identifier was rejected.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum RecipeIdError {
+    /// Empty, or longer than we allow.
+    #[error("recipe id must be 1..={MAX_LEN} characters, got {0}")]
+    Length(usize),
+
+    /// Contains something outside the permitted alphabet.
+    #[error("recipe id contains a character that is not [a-z0-9.-]: {0:?}")]
+    Charset(char),
+
+    /// Starts or ends with punctuation, or contains `..`.
+    #[error("recipe id has malformed punctuation: {0}")]
+    Punctuation(&'static str),
+}
+
+impl RecipeId {
+    /// Validate a candidate identifier.
+    ///
+    /// The alphabet is lowercase alphanumerics, `.` and `-`, which is exactly
+    /// what recipe filenames use. Everything excluded is excluded on purpose:
+    /// a leading `-` would let an id be read as a flag, `..` and `/` would let
+    /// it escape a directory, and uppercase would let two ids differ only by
+    /// case on a case-insensitive filesystem.
+    pub fn parse(s: &str) -> Result<Self, RecipeIdError> {
+        if s.is_empty() || s.len() > MAX_LEN {
+            return Err(RecipeIdError::Length(s.len()));
+        }
+        if let Some(c) = s
+            .chars()
+            .find(|c| !(c.is_ascii_lowercase() || c.is_ascii_digit() || *c == '.' || *c == '-'))
+        {
+            return Err(RecipeIdError::Charset(c));
+        }
+        let first = s.chars().next().unwrap_or('-');
+        if !(first.is_ascii_lowercase() || first.is_ascii_digit()) {
+            return Err(RecipeIdError::Punctuation(
+                "must start with a letter or digit",
+            ));
+        }
+        let last = s.chars().last().unwrap_or('-');
+        if last == '.' || last == '-' {
+            return Err(RecipeIdError::Punctuation("must not end with `.` or `-`"));
+        }
+        if s.contains("..") {
+            return Err(RecipeIdError::Punctuation("must not contain `..`"));
+        }
+        Ok(Self(s.to_string()))
+    }
+
+    /// The identifier as text.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for RecipeId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for RecipeId {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let raw = String::deserialize(d)?;
+        Self::parse(&raw).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn real_recipe_names_are_accepted() {
+        for name in [
+            "qwen3.6-27b-fp8",
+            "qwen3.5-122b-a10b-nvfp4-ep2",
+            "deepseek-v4-flash-nvfp4-ep2",
+            "a",
+        ] {
+            assert!(RecipeId::parse(name).is_ok(), "{name} should be valid");
+        }
+    }
+
+    #[test]
+    fn path_traversal_cannot_become_an_identifier() {
+        for bad in ["../etc/passwd", "..", "a/b", "a..b", "./x"] {
+            assert!(RecipeId::parse(bad).is_err(), "{bad:?} must be rejected");
+        }
+    }
+
+    #[test]
+    fn a_flag_shaped_identifier_is_rejected() {
+        // Without this an id could be read as an option by whatever it reaches.
+        for bad in ["-rm", "--gpus", "-"] {
+            assert!(RecipeId::parse(bad).is_err(), "{bad:?} must be rejected");
+        }
+    }
+
+    #[test]
+    fn shell_metacharacters_and_whitespace_are_rejected() {
+        for bad in [
+            "a b", "a;b", "a|b", "a$b", "a\nb", "a'b", "a\"b", "a`b", "a&b",
+        ] {
+            assert!(RecipeId::parse(bad).is_err(), "{bad:?} must be rejected");
+        }
+    }
+
+    #[test]
+    fn case_and_unicode_are_rejected() {
+        // Two ids differing only by case would collide on a case-insensitive
+        // filesystem; homoglyphs would let two ids look identical to a human.
+        assert!(RecipeId::parse("Qwen3.6").is_err());
+        assert!(
+            RecipeId::parse("qwen\u{0435}").is_err(),
+            "cyrillic e must be rejected"
+        );
+    }
+
+    #[test]
+    fn length_is_bounded_at_both_ends() {
+        assert!(RecipeId::parse("").is_err());
+        assert!(RecipeId::parse(&"a".repeat(MAX_LEN)).is_ok());
+        assert!(RecipeId::parse(&"a".repeat(MAX_LEN + 1)).is_err());
+    }
+
+    #[test]
+    fn deserialization_enforces_validation() {
+        // The load-bearing property: a hostile id fails at the parse boundary,
+        // before any handler logic runs at all.
+        assert!(serde_json::from_str::<RecipeId>(r#""qwen3.6-27b-fp8""#).is_ok());
+        for bad in [r#""../../etc/passwd""#, r#""-rm""#, r#""a b""#] {
+            assert!(
+                serde_json::from_str::<RecipeId>(bad).is_err(),
+                "{bad} must fail to parse"
+            );
+        }
+    }
+
+    #[test]
+    fn round_trips_through_json() {
+        let id = RecipeId::parse("qwen3.6-27b-fp8").unwrap();
+        let json = serde_json::to_string(&id).unwrap();
+        assert_eq!(
+            json, r#""qwen3.6-27b-fp8""#,
+            "must serialize as a bare string"
+        );
+        assert_eq!(serde_json::from_str::<RecipeId>(&json).unwrap(), id);
+    }
+}

--- a/crates/atlasctl-protocol/src/id.rs
+++ b/crates/atlasctl-protocol/src/id.rs
@@ -114,7 +114,7 @@ mod tests {
     #[test]
     fn a_flag_shaped_identifier_is_rejected() {
         // Without this an id could be read as an option by whatever it reaches.
-        for bad in ["-rm", "--gpus", "-"] {
+        for bad in ["-rm", "--force", "-"] {
             assert!(RecipeId::parse(bad).is_err(), "{bad:?} must be rejected");
         }
     }

--- a/crates/atlasctl-protocol/src/lib.rs
+++ b/crates/atlasctl-protocol/src/lib.rs
@@ -10,10 +10,12 @@
 pub mod id;
 pub mod msg;
 pub mod settings;
+pub mod telemetry;
 
 pub use id::{RecipeId, RecipeIdError};
 pub use msg::{AgentError, ClientMsg, RecipeInfo, RunningLaunch, ServerMsg};
 pub use settings::{Bound, Group, SettingError, SettingSpec, SettingValue};
+pub use telemetry::{DeviceStats, EngineStats, LaunchPhase, Stats, TelemetryCaps};
 
 /// Protocol version this build speaks.
 ///

--- a/crates/atlasctl-protocol/src/lib.rs
+++ b/crates/atlasctl-protocol/src/lib.rs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+#![deny(warnings)]
+#![deny(clippy::all)]
+
+//! Wire types shared by the agent, the CLI, and the browser client.
+//!
+//! Deliberately dependency-light — serde and nothing else — so the entire
+//! surface a webpage can reach is small enough to read in one sitting.
+
+pub mod id;
+pub mod msg;
+pub mod settings;
+
+pub use id::{RecipeId, RecipeIdError};
+pub use msg::{AgentError, ClientMsg, RecipeInfo, RunningLaunch, ServerMsg};
+pub use settings::{Bound, Group, SettingError, SettingSpec, SettingValue};
+
+/// Protocol version this build speaks.
+///
+/// A client and an agent that disagree must say so at the handshake rather than
+/// discovering it halfway through a launch.
+pub const PROTOCOL_VERSION: u32 = 1;

--- a/crates/atlasctl-protocol/src/msg.rs
+++ b/crates/atlasctl-protocol/src/msg.rs
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The message catalogue.
+//!
+//! Internally tagged on `type`, which maps directly onto a TypeScript
+//! discriminated union so the browser narrows on `msg.type` without unwrapping
+//! a nesting level.
+//!
+//! The set of client messages *is* the capability surface. There is no relay,
+//! no forward, and no raw-command verb, and the enum is closed — an unknown
+//! `type` fails deserialization rather than reaching a handler. That is what
+//! keeps the agent from becoming an open proxy for whatever page is talking
+//! to it.
+
+use crate::id::RecipeId;
+use crate::settings::{SettingError, SettingSpec, SettingValue};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// What a client may ask for.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ClientMsg {
+    /// First frame. Anything else before this is refused.
+    Hello {
+        /// Protocol version the client chose.
+        protocol_version: u32,
+        /// Pairing token, proving the user connected this browser deliberately.
+        token: String,
+    },
+
+    /// Ask for the recipe inventory again.
+    ListRecipes {
+        /// Correlates the reply.
+        id: u32,
+    },
+
+    /// Render the command a launch would run, without running it.
+    Preview {
+        /// Correlates the reply.
+        id: u32,
+        /// Which recipe.
+        recipe: RecipeId,
+        /// Requested settings.
+        #[serde(default)]
+        settings: BTreeMap<String, SettingValue>,
+    },
+
+    /// Start a recipe.
+    Launch {
+        /// Correlates the reply.
+        id: u32,
+        /// Which recipe.
+        recipe: RecipeId,
+        /// Requested settings, validated against the schema before use.
+        #[serde(default)]
+        settings: BTreeMap<String, SettingValue>,
+    },
+
+    /// Stop a running launch.
+    Stop {
+        /// Correlates the reply.
+        id: u32,
+        /// Which recipe to stop.
+        recipe: RecipeId,
+    },
+
+    /// Ask what is running.
+    Status {
+        /// Correlates the reply.
+        id: u32,
+    },
+}
+
+/// What the agent says.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ServerMsg {
+    /// Sent unsolicited as soon as the connection opens, before authentication,
+    /// so a client can report a version mismatch rather than timing out.
+    Welcome {
+        /// Lowest protocol version this agent speaks.
+        protocol_min: u32,
+        /// Highest protocol version this agent speaks.
+        protocol_max: u32,
+        /// Agent version, for display.
+        agent_version: String,
+    },
+
+    /// Authentication succeeded; here is everything the client needs.
+    Ready {
+        /// Negotiated protocol version.
+        protocol_version: u32,
+        /// The full settings schema, so the client renders what we validate.
+        schema: Vec<SettingSpec>,
+        /// Every recipe this agent can launch.
+        recipes: Vec<RecipeInfo>,
+        /// Whether this machine can actually run a recipe.
+        can_launch: bool,
+        /// Why not, when it cannot.
+        can_launch_reason: Option<String>,
+    },
+
+    /// Reply to `ListRecipes`.
+    Recipes {
+        /// Correlation id.
+        id: u32,
+        /// The inventory.
+        recipes: Vec<RecipeInfo>,
+    },
+
+    /// Reply to `Preview`.
+    Preview {
+        /// Correlation id.
+        id: u32,
+        /// The exact command, shell-quoted for display.
+        command: String,
+        /// Settings the recipe carries that this agent does not understand.
+        ///
+        /// Surfaced rather than dropped: the tool this replaces discarded these
+        /// silently, which is how a stated correctness pin went unapplied for
+        /// months without anyone noticing.
+        unapplied: Vec<String>,
+    },
+
+    /// A launch was accepted and started.
+    Started {
+        /// Correlation id.
+        id: u32,
+        /// Which recipe.
+        recipe: RecipeId,
+        /// The container name, for logs and stop.
+        container: String,
+        /// Where the model is served, when it serves.
+        endpoint: Option<String>,
+    },
+
+    /// Reply to `Status`.
+    Status {
+        /// Correlation id.
+        id: u32,
+        /// What is running.
+        running: Vec<RunningLaunch>,
+    },
+
+    /// A launch was stopped.
+    Stopped {
+        /// Correlation id.
+        id: u32,
+        /// Which recipe.
+        recipe: RecipeId,
+    },
+
+    /// Something failed.
+    Error {
+        /// Correlation id, when the failure answers a request.
+        id: Option<u32>,
+        /// What went wrong.
+        error: AgentError,
+    },
+}
+
+/// One recipe, as the client sees it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RecipeInfo {
+    /// Stable identifier.
+    pub id: RecipeId,
+    /// Model this recipe serves.
+    pub model: String,
+    /// Nodes it needs.
+    pub nodes: u32,
+    /// Whether this agent can launch it.
+    pub runnable: bool,
+    /// Why not, when it cannot.
+    pub reason: Option<String>,
+    /// Settings the recipe sets, as launch defaults.
+    pub defaults: BTreeMap<String, SettingValue>,
+}
+
+/// A launch currently running.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RunningLaunch {
+    /// Container name.
+    pub container: String,
+    /// Recipe that produced it, when it is one of ours.
+    pub recipe: Option<RecipeId>,
+    /// Docker's status line.
+    pub status: String,
+}
+
+/// Everything that can go wrong, typed so a client can react rather than
+/// pattern-match on prose.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, thiserror::Error)]
+#[serde(tag = "code", rename_all = "snake_case")]
+pub enum AgentError {
+    /// The client's protocol version is not one we speak.
+    #[error("this agent speaks protocol {min}..={max}, the client asked for {requested}")]
+    UnsupportedProtocol {
+        /// Lowest supported.
+        min: u32,
+        /// Highest supported.
+        max: u32,
+        /// What was asked for.
+        requested: u32,
+    },
+
+    /// The pairing token was absent or wrong.
+    #[error("pairing token rejected — run `atlasctl agent token` and paste it into the page")]
+    NotPaired,
+
+    /// A frame arrived before the handshake completed.
+    #[error("expected a hello frame first")]
+    NotReady,
+
+    /// The frame did not deserialize.
+    #[error("malformed message: {detail}")]
+    InvalidMessage {
+        /// What was wrong with it.
+        detail: String,
+    },
+
+    /// No such recipe in the compiled-in set.
+    #[error("no recipe named `{recipe}`")]
+    UnknownRecipe {
+        /// What was asked for.
+        recipe: String,
+    },
+
+    /// The recipe exists but cannot be launched here.
+    #[error("`{recipe}` cannot be launched: {reason}")]
+    NotLaunchable {
+        /// Which recipe.
+        recipe: RecipeId,
+        /// Why not.
+        reason: String,
+    },
+
+    /// One or more settings were rejected.
+    #[error("{} setting(s) rejected", .errors.len())]
+    BadSettings {
+        /// Every problem at once.
+        errors: Vec<SettingError>,
+    },
+
+    /// Something is already running.
+    #[error("`{recipe}` is already running")]
+    AlreadyRunning {
+        /// Which recipe.
+        recipe: RecipeId,
+    },
+
+    /// Docker is not usable.
+    #[error("docker is not available: {detail}")]
+    DockerUnavailable {
+        /// What the probe said.
+        detail: String,
+    },
+
+    /// The launch itself failed.
+    #[error("launch failed: {detail}")]
+    LaunchFailed {
+        /// What went wrong.
+        detail: String,
+    },
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/atlasctl-protocol/src/msg/tests.rs
+++ b/crates/atlasctl-protocol/src/msg/tests.rs
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use super::*;
+
+fn id(s: &str) -> RecipeId {
+    RecipeId::parse(s).expect("valid fixture id")
+}
+
+#[test]
+fn client_messages_are_tagged_on_type_for_the_browser_to_narrow_on() {
+    let json = serde_json::to_string(&ClientMsg::Status { id: 7 }).unwrap();
+    assert_eq!(json, r#"{"type":"status","id":7}"#);
+}
+
+#[test]
+fn every_client_message_round_trips() {
+    let msgs = vec![
+        ClientMsg::Hello {
+            protocol_version: 1,
+            token: "t".into(),
+        },
+        ClientMsg::ListRecipes { id: 1 },
+        ClientMsg::Preview {
+            id: 2,
+            recipe: id("r"),
+            settings: BTreeMap::new(),
+        },
+        ClientMsg::Launch {
+            id: 3,
+            recipe: id("r"),
+            settings: BTreeMap::new(),
+        },
+        ClientMsg::Stop {
+            id: 4,
+            recipe: id("r"),
+        },
+        ClientMsg::Status { id: 5 },
+    ];
+    for m in msgs {
+        let s = serde_json::to_string(&m).unwrap();
+        assert_eq!(serde_json::from_str::<ClientMsg>(&s).unwrap(), m, "{s}");
+    }
+}
+
+#[test]
+fn the_client_surface_contains_no_relay_or_raw_command_verb() {
+    // The capability claim, asserted rather than assumed. If someone adds a
+    // verb that forwards arbitrary content, this fails and forces the argument
+    // to be had in review.
+    let variants = [
+        r#"{"type":"exec","command":"sh"}"#,
+        r#"{"type":"forward","to":"peer","payload":{}}"#,
+        r#"{"type":"raw","argv":["docker","run","--privileged","x"]}"#,
+        r#"{"type":"proxy","url":"http://evil"}"#,
+        r#"{"type":"run_command","cmd":"rm -rf /"}"#,
+    ];
+    for v in variants {
+        assert!(
+            serde_json::from_str::<ClientMsg>(v).is_err(),
+            "{v} deserialized — the client surface grew a verb it should not have"
+        );
+    }
+}
+
+#[test]
+fn an_unknown_message_type_is_refused_rather_than_ignored() {
+    assert!(serde_json::from_str::<ClientMsg>(r#"{"type":"nope"}"#).is_err());
+}
+
+#[test]
+fn a_launch_naming_a_hostile_recipe_fails_at_the_parse_boundary() {
+    // Before any handler runs: the id type does the refusing.
+    for bad in ["../../etc/passwd", "-rm", "a b", "A"] {
+        let json = format!(r#"{{"type":"launch","id":1,"recipe":"{bad}"}}"#);
+        assert!(
+            serde_json::from_str::<ClientMsg>(&json).is_err(),
+            "{bad} must not parse"
+        );
+    }
+}
+
+#[test]
+fn a_launch_may_carry_settings_but_only_as_typed_values() {
+    let json = r#"{"type":"launch","id":1,"recipe":"qwen3.6-27b-fp8",
+                   "settings":{"port":9000,"speculative":true,"kv_cache_dtype":"fp8"}}"#;
+    let ClientMsg::Launch { settings, .. } = serde_json::from_str(json).unwrap() else {
+        panic!("expected a launch");
+    };
+    assert_eq!(settings["port"], SettingValue::Int(9000));
+    assert_eq!(settings["speculative"], SettingValue::Bool(true));
+    assert_eq!(settings["kv_cache_dtype"], SettingValue::Str("fp8".into()));
+}
+
+#[test]
+fn a_launch_without_settings_is_valid() {
+    let json = r#"{"type":"launch","id":1,"recipe":"qwen3.6-27b-fp8"}"#;
+    assert!(serde_json::from_str::<ClientMsg>(json).is_ok());
+}
+
+#[test]
+fn errors_carry_a_machine_readable_code() {
+    let e = AgentError::UnknownRecipe {
+        recipe: "nope".into(),
+    };
+    let json = serde_json::to_string(&ServerMsg::Error {
+        id: Some(3),
+        error: e,
+    })
+    .unwrap();
+    assert!(json.contains(r#""code":"unknown_recipe""#), "{json}");
+}
+
+#[test]
+fn the_welcome_frame_carries_a_version_range_so_mismatch_is_reported_not_hung() {
+    let json = serde_json::to_string(&ServerMsg::Welcome {
+        protocol_min: 1,
+        protocol_max: 1,
+        agent_version: "0.1.0".into(),
+    })
+    .unwrap();
+    assert!(json.contains("protocol_min"), "{json}");
+    assert!(json.contains("protocol_max"), "{json}");
+}
+
+#[test]
+fn server_messages_round_trip() {
+    let msgs = vec![
+        ServerMsg::Welcome {
+            protocol_min: 1,
+            protocol_max: 1,
+            agent_version: "0.1.0".into(),
+        },
+        ServerMsg::Stopped {
+            id: 1,
+            recipe: id("r"),
+        },
+        ServerMsg::Started {
+            id: 2,
+            recipe: id("r"),
+            container: "atlas-r".into(),
+            endpoint: Some("http://localhost:8888/v1".into()),
+        },
+        ServerMsg::Error {
+            id: None,
+            error: AgentError::NotPaired,
+        },
+    ];
+    for m in msgs {
+        let s = serde_json::to_string(&m).unwrap();
+        assert_eq!(serde_json::from_str::<ServerMsg>(&s).unwrap(), m, "{s}");
+    }
+}

--- a/crates/atlasctl-protocol/src/settings.rs
+++ b/crates/atlasctl-protocol/src/settings.rs
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The closed, typed schema of what a client may set on a launch.
+//!
+//! A webpage asking to start a model is untrusted input. Rather than accepting
+//! key/value pairs and hoping, a client may set only keys this schema names,
+//! to values inside the bounds it states. There is deliberately **no free-string
+//! kind**: every settable value is a bounded number, a member of a closed
+//! enumeration, a boolean, or the literal `"auto"`. A `--`-prefixed string
+//! cannot survive validation, because no variant can hold one.
+
+use serde::{Deserialize, Serialize};
+
+/// A value a client sent for a setting.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SettingValue {
+    /// `true` / `false`.
+    Bool(bool),
+    /// An integer.
+    Int(i64),
+    /// A number with a fraction.
+    Float(f64),
+    /// Text — only ever accepted against an `Enum` or `IntOrAuto` bound.
+    Str(String),
+}
+
+/// What values a setting accepts.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum Bound {
+    /// A whole number within an inclusive range.
+    Int {
+        /// Smallest accepted value.
+        min: i64,
+        /// Largest accepted value.
+        max: i64,
+    },
+    /// A fractional number within an inclusive range.
+    Float {
+        /// Smallest accepted value.
+        min: f64,
+        /// Largest accepted value.
+        max: f64,
+    },
+    /// One of a fixed set of strings.
+    Enum {
+        /// Every accepted value.
+        variants: Vec<String>,
+    },
+    /// A bare toggle.
+    Toggle,
+    /// A boolean rendered as an explicit value rather than a bare flag.
+    ///
+    /// Distinct from `Toggle` because absent and false differ: the flag
+    /// overrides a value the model's own configuration sets, so "unset" and
+    /// "explicitly false" are not the same statement.
+    BoolValue,
+    /// The literal `auto`, or a whole number in range.
+    IntOrAuto {
+        /// Smallest accepted number.
+        min: i64,
+        /// Largest accepted number.
+        max: i64,
+    },
+}
+
+/// Which part of the UI a setting belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Group {
+    /// Address and identity of the server.
+    Server,
+    /// Batching and scheduling.
+    Performance,
+    /// The memory and KV-cache budget.
+    MemoryKv,
+    /// Speculative decoding.
+    Speculative,
+    /// Tool calling and chat behaviour.
+    ToolsChat,
+    /// Topology, which the recipe usually fixes.
+    Topology,
+}
+
+/// One settable knob, as described to a client.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SettingSpec {
+    /// The recipe key this sets. Also the foreign key into the flag table.
+    pub key: String,
+    /// What values it accepts.
+    pub bound: Bound,
+    /// Human label.
+    pub label: String,
+    /// One sentence on what it does.
+    pub help: String,
+    /// Unit for display, when it has one.
+    pub unit: Option<String>,
+    /// Where it belongs in the UI.
+    pub group: Group,
+    /// Whether to hide it behind a disclosure.
+    pub advanced: bool,
+    /// Set by the recipe's topology and not editable.
+    pub locked: bool,
+}
+
+/// Why a submitted value was rejected.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, thiserror::Error)]
+#[serde(tag = "code", rename_all = "snake_case")]
+pub enum SettingError {
+    /// No setting by that name.
+    #[error("`{key}` is not a setting this agent understands")]
+    UnknownKey {
+        /// The offending key.
+        key: String,
+    },
+
+    /// The setting exists but clients may not set it.
+    #[error("`{key}` cannot be set remotely: {reason}")]
+    Denied {
+        /// The offending key.
+        key: String,
+        /// Why it is refused.
+        reason: String,
+    },
+
+    /// Out of range.
+    #[error("`{key}` must be between {min} and {max}")]
+    OutOfRange {
+        /// The offending key.
+        key: String,
+        /// Lower bound, rendered.
+        min: String,
+        /// Upper bound, rendered.
+        max: String,
+    },
+
+    /// Not one of the permitted values.
+    #[error("`{key}` must be one of: {}", .allowed.join(", "))]
+    NotAVariant {
+        /// The offending key.
+        key: String,
+        /// The permitted values.
+        allowed: Vec<String>,
+    },
+
+    /// Wrong shape entirely.
+    #[error("`{key}` expected {expected}")]
+    WrongType {
+        /// The offending key.
+        key: String,
+        /// What was expected.
+        expected: String,
+    },
+}
+
+impl Bound {
+    /// Check a value against this bound, returning it normalized.
+    ///
+    /// Numbers are re-rendered from the parsed value rather than echoed, so the
+    /// bytes a client sent never reach a command line; enum matches return the
+    /// stored variant rather than the submitted string, for the same reason.
+    pub fn check(&self, key: &str, value: &SettingValue) -> Result<SettingValue, SettingError> {
+        match (self, value) {
+            (Self::Int { min, max }, SettingValue::Int(n)) => {
+                if n < min || n > max {
+                    return Err(SettingError::OutOfRange {
+                        key: key.into(),
+                        min: min.to_string(),
+                        max: max.to_string(),
+                    });
+                }
+                Ok(SettingValue::Int(*n))
+            }
+            (Self::Float { min, max }, v) => {
+                let n = match v {
+                    SettingValue::Float(f) => *f,
+                    // A whole number is a legitimate spelling of a float.
+                    SettingValue::Int(i) => *i as f64,
+                    _ => {
+                        return Err(SettingError::WrongType {
+                            key: key.into(),
+                            expected: "a number".into(),
+                        });
+                    }
+                };
+                if !n.is_finite() || n < *min || n > *max {
+                    return Err(SettingError::OutOfRange {
+                        key: key.into(),
+                        min: min.to_string(),
+                        max: max.to_string(),
+                    });
+                }
+                Ok(SettingValue::Float(n))
+            }
+            (Self::Enum { variants }, SettingValue::Str(s)) => variants
+                .iter()
+                .find(|v| *v == s)
+                .map(|v| SettingValue::Str(v.clone()))
+                .ok_or_else(|| SettingError::NotAVariant {
+                    key: key.into(),
+                    allowed: variants.clone(),
+                }),
+            (Self::Toggle | Self::BoolValue, SettingValue::Bool(b)) => Ok(SettingValue::Bool(*b)),
+            (Self::IntOrAuto { min, max }, v) => match v {
+                SettingValue::Str(s) if s == "auto" => Ok(SettingValue::Str("auto".into())),
+                SettingValue::Int(n) if n >= min && n <= max => Ok(SettingValue::Int(*n)),
+                SettingValue::Int(_) => Err(SettingError::OutOfRange {
+                    key: key.into(),
+                    min: min.to_string(),
+                    max: max.to_string(),
+                }),
+                _ => Err(SettingError::WrongType {
+                    key: key.into(),
+                    expected: "`auto` or a whole number".into(),
+                }),
+            },
+            (Self::Int { .. }, _) => Err(SettingError::WrongType {
+                key: key.into(),
+                expected: "a whole number".into(),
+            }),
+            (Self::Enum { variants }, _) => Err(SettingError::NotAVariant {
+                key: key.into(),
+                allowed: variants.clone(),
+            }),
+            (Self::Toggle | Self::BoolValue, _) => Err(SettingError::WrongType {
+                key: key.into(),
+                expected: "true or false".into(),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/atlasctl-protocol/src/settings/tests.rs
+++ b/crates/atlasctl-protocol/src/settings/tests.rs
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use super::*;
+
+fn int(min: i64, max: i64) -> Bound {
+    Bound::Int { min, max }
+}
+
+#[test]
+fn integers_are_accepted_only_inside_their_range() {
+    let b = int(1024, 49151);
+    assert!(b.check("port", &SettingValue::Int(8888)).is_ok());
+    assert!(
+        b.check("port", &SettingValue::Int(1024)).is_ok(),
+        "min is inclusive"
+    );
+    assert!(
+        b.check("port", &SettingValue::Int(49151)).is_ok(),
+        "max is inclusive"
+    );
+    assert!(b.check("port", &SettingValue::Int(1023)).is_err());
+    assert!(b.check("port", &SettingValue::Int(49152)).is_err());
+    assert!(b.check("port", &SettingValue::Int(-1)).is_err());
+}
+
+#[test]
+fn floats_reject_nan_and_infinity() {
+    // A NaN comparison is always false, so a naive range check would let it
+    // through and it would then render as "NaN" on a command line.
+    let b = Bound::Float {
+        min: 0.1,
+        max: 0.95,
+    };
+    assert!(b.check("g", &SettingValue::Float(f64::NAN)).is_err());
+    assert!(b.check("g", &SettingValue::Float(f64::INFINITY)).is_err());
+    assert!(
+        b.check("g", &SettingValue::Float(f64::NEG_INFINITY))
+            .is_err()
+    );
+    assert!(b.check("g", &SettingValue::Float(0.88)).is_ok());
+}
+
+#[test]
+fn a_whole_number_is_an_acceptable_float() {
+    let b = Bound::Float { min: 0.0, max: 1.0 };
+    assert_eq!(
+        b.check("g", &SettingValue::Int(1)).unwrap(),
+        SettingValue::Float(1.0)
+    );
+}
+
+#[test]
+fn enums_accept_only_their_own_variants() {
+    let b = Bound::Enum {
+        variants: vec!["bf16".into(), "fp8".into(), "nvfp4".into()],
+    };
+    assert!(b.check("kv", &SettingValue::Str("fp8".into())).is_ok());
+    assert!(
+        b.check("kv", &SettingValue::Str("FP8".into())).is_err(),
+        "case must match exactly"
+    );
+    assert!(
+        b.check("kv", &SettingValue::Str("fp8 --evil".into()))
+            .is_err()
+    );
+    assert!(b.check("kv", &SettingValue::Int(8)).is_err());
+}
+
+#[test]
+fn an_accepted_enum_value_is_the_stored_variant_not_the_submitted_string() {
+    // Load-bearing: the value that continues into the command comes from our
+    // table, so client bytes never reach an argv element even when they match.
+    let b = Bound::Enum {
+        variants: vec!["fp8".into()],
+    };
+    let out = b
+        .check("kv", &SettingValue::Str(String::from("fp8")))
+        .unwrap();
+    assert_eq!(out, SettingValue::Str("fp8".into()));
+}
+
+#[test]
+fn no_bound_can_hold_an_arbitrary_string() {
+    // The structural defence. If a free-string kind is ever added, this fails
+    // and forces the decision to be made deliberately.
+    let hostile = SettingValue::Str("--model-from-path /etc/shadow".into());
+    for b in [
+        int(0, 10),
+        Bound::Float { min: 0.0, max: 1.0 },
+        Bound::Enum {
+            variants: vec!["a".into()],
+        },
+        Bound::Toggle,
+        Bound::BoolValue,
+        Bound::IntOrAuto { min: 0, max: 10 },
+    ] {
+        assert!(
+            b.check("k", &hostile).is_err(),
+            "{b:?} accepted an arbitrary string"
+        );
+    }
+}
+
+#[test]
+fn int_or_auto_accepts_the_literal_auto_and_nothing_else_textual() {
+    let b = Bound::IntOrAuto { min: 0, max: 128 };
+    assert!(b.check("k", &SettingValue::Str("auto".into())).is_ok());
+    assert!(b.check("k", &SettingValue::Int(16)).is_ok());
+    assert!(b.check("k", &SettingValue::Int(129)).is_err());
+    assert!(
+        b.check("k", &SettingValue::Str("automatic".into()))
+            .is_err()
+    );
+    assert!(
+        b.check("k", &SettingValue::Str("auto; rm -rf /".into()))
+            .is_err()
+    );
+}
+
+#[test]
+fn toggles_take_booleans_only() {
+    assert!(Bound::Toggle.check("k", &SettingValue::Bool(true)).is_ok());
+    // "true" as a string is a different thing and must not be coerced.
+    assert!(
+        Bound::Toggle
+            .check("k", &SettingValue::Str("true".into()))
+            .is_err()
+    );
+    assert!(Bound::Toggle.check("k", &SettingValue::Int(1)).is_err());
+}
+
+#[test]
+fn errors_serialize_with_a_machine_readable_code() {
+    // The browser switches on these rather than matching error prose.
+    let e = SettingError::OutOfRange {
+        key: "port".into(),
+        min: "1024".into(),
+        max: "49151".into(),
+    };
+    let json = serde_json::to_string(&e).unwrap();
+    assert!(json.contains(r#""code":"out_of_range""#), "{json}");
+    assert!(json.contains(r#""key":"port""#), "{json}");
+}
+
+#[test]
+fn a_spec_round_trips_through_json() {
+    let spec = SettingSpec {
+        key: "port".into(),
+        bound: int(1024, 49151),
+        label: "Port".into(),
+        help: "Port the model server listens on.".into(),
+        unit: None,
+        group: Group::Server,
+        advanced: false,
+        locked: false,
+    };
+    let json = serde_json::to_string(&spec).unwrap();
+    assert_eq!(serde_json::from_str::<SettingSpec>(&json).unwrap(), spec);
+}

--- a/crates/atlasctl-protocol/src/telemetry.rs
+++ b/crates/atlasctl-protocol/src/telemetry.rs
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Live numbers about a running model, and about the machine underneath it.
+//!
+//! Every field is optional and every capability is **probed, not assumed**.
+//! That is not defensive style — it is required by the hardware. On a GB10,
+//! `nvidia-smi` reports `N/A` for every memory field, because Grace-Blackwell
+//! is unified memory: the "GPU memory" is the host's LPDDR5X. A dashboard that
+//! assumed a framebuffer would render zeros and call them measurements.
+
+use serde::{Deserialize, Serialize};
+
+/// What this machine can actually answer.
+///
+/// Sent at the handshake so a client renders only tiles it has data for, and
+/// shows an explicit "not available on this hardware" state for the rest rather
+/// than a zero.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TelemetryCaps {
+    /// Accelerator utilisation is readable.
+    pub gpu_util: bool,
+    /// Clock is readable.
+    pub sm_clock: bool,
+    /// Temperature is readable.
+    pub temperature: bool,
+    /// Power draw is readable.
+    pub power: bool,
+    /// A dedicated framebuffer is reported. False on unified-memory parts.
+    pub framebuffer_memory: bool,
+    /// Host memory is readable, which is the meaningful figure on unified parts.
+    pub unified_memory: bool,
+    /// The model server's metrics endpoint answered.
+    pub engine_metrics: bool,
+    /// Clock below this under load is reported as clamped.
+    pub sm_clock_healthy_mhz: Option<u32>,
+}
+
+/// One sample.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct Stats {
+    /// Seconds since the launch started.
+    pub uptime_s: u64,
+    /// Engine-level numbers, when the metrics endpoint answered.
+    pub engine: Option<EngineStats>,
+    /// Accelerator and host numbers.
+    pub device: DeviceStats,
+}
+
+/// Numbers from the model server's own metrics endpoint.
+///
+/// Scraped rather than parsed out of logs: the endpoint is a stable contract
+/// that ships with the engine, whereas a log format is not.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct EngineStats {
+    /// Requests in flight.
+    pub requests_active: Option<u64>,
+    /// Requests handled since start.
+    pub requests_total: Option<u64>,
+    /// Tokens generated since start.
+    pub generation_tokens_total: Option<u64>,
+    /// Prompt tokens processed since start.
+    pub prompt_tokens_total: Option<u64>,
+    /// Decode rate, derived from the change in generated tokens.
+    ///
+    /// Derived rather than read: the engine exposes a counter, not a rate.
+    pub decode_tokens_per_s: Option<f64>,
+    /// Median time to first token, from the histogram.
+    pub ttft_p50_ms: Option<f64>,
+    /// Tool calls handled since start.
+    pub tool_calls_total: Option<u64>,
+    /// Fraction of drafted tokens accepted, when speculating.
+    pub draft_accept_rate: Option<f64>,
+}
+
+/// Numbers about the machine.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct DeviceStats {
+    /// Accelerator utilisation, percent.
+    pub gpu_util_pct: Option<f64>,
+    /// Current clock, MHz.
+    pub sm_clock_mhz: Option<u32>,
+    /// Whether the clock is clamped while work is in flight.
+    ///
+    /// Worth its own field rather than leaving it to the client to infer: a
+    /// clamped clock makes every throughput number read low while nothing
+    /// else looks wrong, which is exactly the failure that hides for weeks.
+    pub sm_clock_clamped: bool,
+    /// Temperature, Celsius.
+    pub temperature_c: Option<f64>,
+    /// Power draw, Watts.
+    pub power_w: Option<f64>,
+    /// Total memory available to the machine, bytes.
+    ///
+    /// On a unified-memory part this is host memory, and the client should say
+    /// so rather than labelling it VRAM.
+    pub memory_total_bytes: Option<u64>,
+    /// Memory in use, bytes.
+    pub memory_used_bytes: Option<u64>,
+    /// Whether the memory figures describe a unified pool.
+    pub memory_is_unified: bool,
+}
+
+/// Where a launch has got to.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "phase", rename_all = "snake_case")]
+pub enum LaunchPhase {
+    /// Fetching the image.
+    Pulling,
+    /// Container created, process starting.
+    Starting,
+    /// Loading weights. This takes minutes, so a client should show progress
+    /// rather than a spinner.
+    LoadingWeights,
+    /// Health checks pass.
+    Ready,
+    /// Answering requests.
+    Serving,
+    /// Running but failing its health check.
+    Degraded {
+        /// What the check reported.
+        reason: String,
+    },
+    /// Being stopped.
+    Stopping,
+    /// Gone.
+    Exited {
+        /// Exit status.
+        code: Option<i32>,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn caps_default_to_nothing_being_available() {
+        // Everything must be earned by a probe. A default of "available" would
+        // make an unprobed field render as a real measurement.
+        let c = TelemetryCaps::default();
+        assert!(!c.gpu_util && !c.framebuffer_memory && !c.engine_metrics);
+        assert_eq!(c.sm_clock_healthy_mhz, None);
+    }
+
+    #[test]
+    fn a_gb10_capability_set_reports_no_framebuffer_but_unified_memory() {
+        // The shape this hardware actually produces.
+        let c = TelemetryCaps {
+            gpu_util: true,
+            sm_clock: true,
+            temperature: true,
+            power: true,
+            framebuffer_memory: false,
+            unified_memory: true,
+            engine_metrics: true,
+            sm_clock_healthy_mhz: Some(1500),
+        };
+        let json = serde_json::to_string(&c).unwrap();
+        assert_eq!(serde_json::from_str::<TelemetryCaps>(&json).unwrap(), c);
+        assert!(!c.framebuffer_memory, "GB10 reports no framebuffer");
+    }
+
+    #[test]
+    fn absent_measurements_serialize_as_null_rather_than_zero() {
+        let s = Stats::default();
+        let json = serde_json::to_string(&s).unwrap();
+        assert!(json.contains(r#""gpu_util_pct":null"#), "{json}");
+        assert!(
+            !json.contains(r#""gpu_util_pct":0"#),
+            "an absent reading must not read as zero"
+        );
+    }
+
+    #[test]
+    fn phases_round_trip_including_their_payloads() {
+        for p in [
+            LaunchPhase::Pulling,
+            LaunchPhase::LoadingWeights,
+            LaunchPhase::Serving,
+            LaunchPhase::Degraded {
+                reason: "health check failed".into(),
+            },
+            LaunchPhase::Exited { code: Some(137) },
+        ] {
+            let json = serde_json::to_string(&p).unwrap();
+            assert_eq!(
+                serde_json::from_str::<LaunchPhase>(&json).unwrap(),
+                p,
+                "{json}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_clamped_clock_is_its_own_signal() {
+        let d = DeviceStats {
+            sm_clock_mhz: Some(513),
+            sm_clock_clamped: true,
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&d).unwrap();
+        assert!(json.contains(r#""sm_clock_clamped":true"#), "{json}");
+    }
+}

--- a/crates/atlasctl/Cargo.toml
+++ b/crates/atlasctl/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
+readme = "README.md"
 
 [[bin]]
 name = "atlasctl"

--- a/crates/atlasctl/Cargo.toml
+++ b/crates/atlasctl/Cargo.toml
@@ -15,10 +15,12 @@ name = "atlasctl"
 path = "src/main.rs"
 
 [dependencies]
+atlasctl-agent.workspace = true
 atlasctl-core.workspace = true
 anyhow.workspace = true
 clap = { version = "4", features = ["derive"] }
 rustix = { version = "1", features = ["process"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 serde_yaml_ng.workspace = true
 
 [dev-dependencies]

--- a/crates/atlasctl/README.md
+++ b/crates/atlasctl/README.md
@@ -1,0 +1,32 @@
+# atlasctl
+
+Launch [Atlas](https://github.com/Avarok-Cybersecurity/atlas) inference recipes
+on NVIDIA DGX Spark (GB10) and other local accelerators.
+
+A recipe describes one model deployment — the checkpoint, the container image,
+and the serve settings it was validated under. `atlasctl` reads a recipe and
+runs the `docker run` it implies.
+
+```sh
+uvx atlas-ctl list                              # what is available
+uvx atlas-ctl show qwen3.6-35b-a3b-fp8-mtp      # what a recipe does
+uvx atlas-ctl run qwen3.6-35b-a3b-fp8-mtp       # serve it
+uvx atlas-ctl run <recipe> --print              # print the command instead
+```
+
+`uv tool install atlas-ctl` puts `atlasctl` on your PATH under its real name.
+
+This wheel contains a self-contained Rust binary and no Python code. The
+distribution is named `atlas-ctl` because `atlasctl` was already taken on PyPI
+by an unrelated project.
+
+**Recipes ship inside the binary.** A fresh install makes no network request to
+resolve a recipe, and there is no "trusted registry" mechanism — a remote
+registry can supply recipe data but can never cause a command to run. See
+[SECURITY.md](https://github.com/Avarok-Cybersecurity/atlas-recipes/blob/main/SECURITY.md)
+for why that matters and what it replaces.
+
+Requires Docker to launch anything; `list`, `show`, and `run --print` work
+without it. Linux and macOS; Windows is not supported.
+
+AGPL-3.0-only.

--- a/crates/atlasctl/README.md
+++ b/crates/atlasctl/README.md
@@ -8,17 +8,18 @@ and the serve settings it was validated under. `atlasctl` reads a recipe and
 runs the `docker run` it implies.
 
 ```sh
-uvx atlas-ctl list                              # what is available
-uvx atlas-ctl show qwen3.6-35b-a3b-fp8-mtp      # what a recipe does
-uvx atlas-ctl run qwen3.6-35b-a3b-fp8-mtp       # serve it
-uvx atlas-ctl run <recipe> --print              # print the command instead
+uvx pyatlasctl list                              # what is available
+uvx pyatlasctl show qwen3.6-35b-a3b-fp8-mtp      # what a recipe does
+uvx pyatlasctl run qwen3.6-35b-a3b-fp8-mtp       # serve it
+uvx pyatlasctl run <recipe> --print              # print the command instead
 ```
 
-`uv tool install atlas-ctl` puts `atlasctl` on your PATH under its real name.
+`uv tool install pyatlasctl` puts `atlasctl` on your PATH under its real name.
 
 This wheel contains a self-contained Rust binary and no Python code. The
-distribution is named `atlas-ctl` because `atlasctl` was already taken on PyPI
-by an unrelated project.
+distribution is named `pyatlasctl` because `atlasctl` is taken on PyPI by an
+unrelated project, and PyPI also refuses names that normalize too close to an
+existing one, which ruled out `atlas-ctl`.
 
 **Recipes ship inside the binary.** A fresh install makes no network request to
 resolve a recipe, and there is no "trusted registry" mechanism — a remote

--- a/crates/atlasctl/pyproject.toml
+++ b/crates/atlasctl/pyproject.toml
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Packages the Rust binary as a Python wheel so `uvx atlas-ctl` works with no
+# install step. There is no Python code here: maturin's `bin` bindings put the
+# compiled executable straight into the wheel's scripts directory.
+#
+# The distribution is named `atlas-ctl` rather than `atlasctl` because the
+# latter is already taken on PyPI by an unrelated project. The console script
+# keeps the real name, so `uv tool install atlas-ctl` still gives you
+# `atlasctl` on PATH.
+[build-system]
+requires = ["maturin>=1.7,<2"]
+build-backend = "maturin"
+
+[project]
+name = "atlas-ctl"
+description = "Launch Atlas inference recipes on NVIDIA DGX Spark and other local accelerators."
+readme = "README.md"
+license = "AGPL-3.0-only"
+requires-python = ">=3.9"
+keywords = ["llm", "inference", "dgx-spark", "gb10", "atlas"]
+classifiers = [
+  "Environment :: GPU :: NVIDIA CUDA",
+  "Intended Audience :: Developers",
+  "Programming Language :: Rust",
+  "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+dynamic = ["version"]
+
+[project.urls]
+Homepage = "https://atlasinference.io"
+Repository = "https://github.com/Avarok-Cybersecurity/atlas-recipes"
+
+[tool.maturin]
+bindings = "bin"
+manifest-path = "Cargo.toml"
+# The binary is self-contained, so the wheel carries no Python ABI tag.
+strip = true

--- a/crates/atlasctl/pyproject.toml
+++ b/crates/atlasctl/pyproject.toml
@@ -1,19 +1,20 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# Packages the Rust binary as a Python wheel so `uvx atlas-ctl` works with no
+# Packages the Rust binary as a Python wheel so `uvx pyatlasctl` works with no
 # install step. There is no Python code here: maturin's `bin` bindings put the
 # compiled executable straight into the wheel's scripts directory.
 #
-# The distribution is named `atlas-ctl` rather than `atlasctl` because the
-# latter is already taken on PyPI by an unrelated project. The console script
-# keeps the real name, so `uv tool install atlas-ctl` still gives you
-# `atlasctl` on PATH.
+# The distribution is named `pyatlasctl` because `atlasctl` is taken on PyPI by
+# an unrelated project, and PyPI additionally rejects names that normalize too
+# close to an existing one — `atlas-ctl` was refused on those grounds. The
+# console script keeps the real name, so `uv tool install pyatlasctl` still
+# gives you `atlasctl` on PATH.
 [build-system]
 requires = ["maturin>=1.7,<2"]
 build-backend = "maturin"
 
 [project]
-name = "atlas-ctl"
+name = "pyatlasctl"
 description = "Launch Atlas inference recipes on NVIDIA DGX Spark and other local accelerators."
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/crates/atlasctl/src/cli.rs
+++ b/crates/atlasctl/src/cli.rs
@@ -45,6 +45,10 @@ pub enum Command {
     #[command(subcommand)]
     Registry(RegistryCmd),
 
+    /// Run and manage the local agent that the website talks to.
+    #[command(subcommand)]
+    Agent(AgentCmd),
+
     /// Check this machine for problems, including a compromised sparkrun install.
     Doctor,
 }
@@ -58,6 +62,37 @@ pub enum RecipeCmd {
     Show(ShowArgs),
     /// Search recipes.
     Search(SearchArgs),
+}
+
+/// Agent subcommands.
+#[derive(Subcommand, Debug)]
+pub enum AgentCmd {
+    /// Run the agent in the foreground.
+    Run(AgentRunArgs),
+    /// Print the pairing token to paste into the website.
+    Token(AgentTokenArgs),
+    /// Report whether an agent is reachable.
+    Status,
+}
+
+/// `agent run` arguments.
+#[derive(Args, Debug)]
+pub struct AgentRunArgs {
+    /// Port to listen on.
+    #[arg(long, default_value_t = atlasctl_agent::DEFAULT_PORT)]
+    pub port: u16,
+
+    /// Also accept connections from a local development server.
+    #[arg(long)]
+    pub dev_origins: bool,
+}
+
+/// `agent token` arguments.
+#[derive(Args, Debug)]
+pub struct AgentTokenArgs {
+    /// Replace the token, invalidating any browser already paired.
+    #[arg(long)]
+    pub rotate: bool,
 }
 
 /// Registry subcommands.

--- a/crates/atlasctl/src/commands/agent.rs
+++ b/crates/atlasctl/src/commands/agent.rs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! `agent run`, `agent token`, `agent status`.
+
+use crate::cli::{AgentRunArgs, AgentTokenArgs};
+use crate::hostinfo;
+use anyhow::{Context, Result, bail};
+use atlasctl_agent::launcher::DockerLauncher;
+use atlasctl_agent::server::{AgentState, serve};
+use atlasctl_agent::token;
+use atlasctl_core::docker::profile::{NvidiaDevices, ROOTLESS_V1};
+use atlasctl_core::io::{ProcessRunner, StdProcessRunner};
+use std::sync::Arc;
+
+/// Whether this machine can actually run a recipe, and why not if it cannot.
+///
+/// Probed once at startup and reported to the client, so a browser can say
+/// "this box cannot launch" instead of offering a button that will fail. A
+/// machine that cannot launch is still useful: it can list and inspect.
+fn probe_can_launch(runner: &dyn ProcessRunner) -> Result<(), String> {
+    match runner.run(&[
+        "docker".into(),
+        "info".into(),
+        "--format".into(),
+        "{{.ServerVersion}}".into(),
+    ]) {
+        Ok(out) if out.success() => Ok(()),
+        Ok(out) => Err(format!(
+            "the docker daemon did not answer: {}",
+            out.stderr.trim()
+        )),
+        Err(e) => Err(format!("docker is not available: {e}")),
+    }
+}
+
+/// Run the agent in the foreground.
+pub fn run(args: &AgentRunArgs) -> Result<()> {
+    let config_dir = hostinfo::config_dir()?;
+    let tok = token::load_or_create(&config_dir)?;
+    let runner: Arc<dyn ProcessRunner> = Arc::new(StdProcessRunner);
+    let can_launch = probe_can_launch(runner.as_ref());
+
+    let state = Arc::new(AgentState {
+        registry: crate::commands::registry_set()?,
+        launcher: Box::new(DockerLauncher::new(
+            runner,
+            hostinfo::snapshot()?,
+            &ROOTLESS_V1,
+            Box::new(NvidiaDevices),
+        )),
+        token: tok.clone(),
+        can_launch: can_launch.clone(),
+        port: args.port,
+        allow_dev_origins: args.dev_origins,
+    });
+
+    eprintln!("atlasctl agent listening on 127.0.0.1:{}", args.port);
+    match &can_launch {
+        Ok(()) => eprintln!("docker: ok"),
+        Err(why) => eprintln!(
+            "docker: unavailable — {why}\n  this agent can list and inspect recipes but not launch them"
+        ),
+    }
+    if args.dev_origins {
+        eprintln!("accepting development origins — do not leave this on");
+    }
+    eprintln!("\npairing token (paste into the website once):\n  {tok}\n");
+    eprintln!("This agent talks to Docker. On Linux, membership of the `docker` group is");
+    eprintln!("root-equivalent, so anything that can drive this agent can do what you can.");
+    eprintln!("Stop it with ctrl-c when you are done.\n");
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        // Two workers is ample: this serves one local browser, not a fleet.
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .context("starting the async runtime")?;
+    rt.block_on(serve(state, args.port))
+}
+
+/// Print, or rotate, the pairing token.
+pub fn token(args: &AgentTokenArgs) -> Result<()> {
+    let dir = hostinfo::config_dir()?;
+    let tok = if args.rotate {
+        let t = token::rotate(&dir)?;
+        eprintln!("token rotated — any browser already paired must be given the new one");
+        t
+    } else {
+        token::load_or_create(&dir)?
+    };
+    println!("{tok}");
+    Ok(())
+}
+
+/// Report whether an agent is reachable on the default port.
+pub fn status() -> Result<()> {
+    let addr = format!("127.0.0.1:{}", atlasctl_agent::DEFAULT_PORT);
+    match std::net::TcpStream::connect(&addr) {
+        Ok(_) => {
+            println!("agent: running (listening on {addr})");
+            Ok(())
+        }
+        Err(e) => {
+            println!("agent: not running ({e})");
+            println!("start it with: atlasctl agent run");
+            bail!("no agent is listening on {addr}")
+        }
+    }
+}

--- a/crates/atlasctl/src/commands/mod.rs
+++ b/crates/atlasctl/src/commands/mod.rs
@@ -2,6 +2,7 @@
 
 //! Command implementations.
 
+pub mod agent;
 pub mod doctor;
 pub mod lifecycle;
 pub mod recipe;

--- a/crates/atlasctl/src/main.rs
+++ b/crates/atlasctl/src/main.rs
@@ -11,7 +11,7 @@ mod validate;
 
 use anyhow::Result;
 use clap::Parser;
-use cli::{Cli, Command, RecipeCmd, RegistryCmd};
+use cli::{AgentCmd, Cli, Command, RecipeCmd, RegistryCmd};
 
 fn main() -> std::process::ExitCode {
     match run() {
@@ -42,6 +42,9 @@ fn run() -> Result<()> {
         Command::Registry(RegistryCmd::Add(a)) => commands::registry::add(&a),
         Command::Registry(RegistryCmd::Remove(a)) => commands::registry::remove(&a),
         Command::Registry(RegistryCmd::Update(a)) => commands::registry::update(&a),
+        Command::Agent(AgentCmd::Run(a)) => commands::agent::run(&a),
+        Command::Agent(AgentCmd::Token(a)) => commands::agent::token(&a),
+        Command::Agent(AgentCmd::Status) => commands::agent::status(),
         Command::Doctor => commands::doctor::run(),
     }
 }


### PR DESCRIPTION
Stacked on #25 — review that first; this targets its branch and retargets to `main` once it merges.

## What

The local agent the website talks to. `atlasctl agent run` listens on `127.0.0.1:34333`; the Run button in [atlas#747](https://github.com/Avarok-Cybersecurity/atlas/pull/747) drives it.

Also adds the **PyPI channel that was announced but never built** — the README promised three install channels and the pipeline had two, so `uvx atlas-ctl` would not have worked.

## The capability surface is the message enum

There is no relay verb, no forward, and no raw-command verb, and the enum is closed — an unknown `type` fails deserialization rather than reaching a handler. A test tries to deserialize `exec`, `forward`, `raw`, `proxy` and `run_command` and asserts all five fail, so a future verb that forwards arbitrary content has to survive review.

`RecipeId` is parse-don't-validate: `Deserialize` routes through `parse`, so a hostile id fails at the wire boundary before any handler runs.

Settings are a **closed, typed schema** — 31 of 48 flags settable within bounds, 17 denied with reasons recorded inline. There is **no free-string kind at all**: every value is a bounded number, a closed enum member, a boolean, or the literal `auto`. `--model-from-path /etc/shadow` cannot survive validation because no variant can hold it. The partition is enforced in bijection with the flag table, so adding flag 49 without deciding whether a webpage may set it fails the build.

## Verified live, not just in unit tests

Against a running agent on a GB10:

```
upgrade 101, welcome, hello -> ready: 30 recipes, 31 schema entries
preview renders the real docker command
https://evil.com                    -> 403 before any websocket exists
https://atlasinference.io.evil.com  -> 403
no Origin header                    -> 403
valid Origin + attacker Host        -> 403   (DNS rebinding)
wrong pairing token                 -> not_paired
any request before the handshake    -> not_ready
settings: {model_from_path: ...}    -> bad_settings / denied, and logged
recipe: "../../etc/passwd"          -> invalid_message, at the parse boundary
```

Nothing is answered before the handshake — not even the inventory, so an unauthenticated client cannot learn what the machine can run.

## Honest about the boundary

The pairing token is 256 bits from the kernel CSPRNG, written `0600` at creation rather than chmod-ed afterwards, and compared in constant time. A file that has become readable by other accounts is **reported rather than quietly tightened** — only its owner can decide whether it needs replacing.

What it does not defend is written into the module docs: a process running as the same user can read the token, and no transport design changes that, because such a process can run `docker` directly. `agent run` says the same in its startup banner about docker-group membership being root-equivalent on Linux.

## Also in here

- The transport is thin on purpose: bind, guard, decode, hand off. It makes no decisions, so everything that could be got wrong stays testable without a socket.
- The agent probes docker at startup and reports the result, so a browser can say "this machine cannot launch" instead of offering a button that will fail.
- Fixed a blind spot in the vendor-neutrality lint: it excluded `tests.rs` files but not inline `#[cfg(test)]` modules, which grep cannot see. Scope is now documented where the lint lives.

## Testing

201 tests, six of them over a real socket.

## Authorship

AI-generated (Claude Opus 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
