### PR TITLE
docs: record how releasing works, now that it does

### DIFF
--- a/.github/workflows/bootstrap-publish.yml
+++ b/.github/workflows/bootstrap-publish.yml
@@ -1,17 +1,25 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 name: Bootstrap crates.io publish
 
-# A one-off, run by hand.
+# SUPERSEDED — kept as a recovery path, not a normal one.
 #
-# crates.io has no pending-publisher mechanism: a crate must already exist
-# before a Trusted Publisher can be attached to it. So the very first publish
-# of each crate cannot use OIDC and has to present a token. Every release after
-# this one goes through release.yml, which uses Trusted Publishing and stores no
-# token at all.
+# This existed because crates.io has no pending-publisher mechanism: a crate
+# must already exist before a Trusted Publisher can be attached to it, so the
+# very first publish could not use OIDC and had to present a token. That has
+# happened; all five crates were published at 0.1.0 on 2026-08-25 and their
+# Trusted Publishers are configured.
 #
-# Delete this workflow once the five crates exist and their publishers are
-# configured. It is kept deliberately awkward to run — a typed confirmation, and
-# no automatic trigger — because publishing to crates.io is irreversible.
+# Normal releases now go through release.yml, which mints a short-lived token
+# from its own OIDC identity and stores nothing. This file only matters if that
+# path is broken and something has to ship anyway.
+#
+# Delete it, and revoke CARGO_REGISTRY_TOKEN, once you are satisfied release.yml
+# publishes cleanly. Both are being kept deliberately for now: removing the
+# fallback before the primary has been exercised end to end would leave no way
+# to ship a fix.
+#
+# It stays awkward to run on purpose — a typed confirmation, a dry run by
+# default, and no automatic trigger — because publishing is irreversible.
 
 on:
   workflow_dispatch:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,78 @@
+# Releasing
+
+`atlasctl` ships to three places from one pipeline: GitHub Releases (the
+`curl | sh` installer), crates.io, and PyPI.
+
+## How a release happens
+
+Merges to `main` do not publish. release-please maintains a standing
+"Release vX.Y.Z" pull request, and **merging that PR is the release**. Merging
+it tags, builds, and publishes everything since the last one.
+
+That reconciles "merging to main ships" with the fact that crates.io versions
+are immutable. Recipe edits — which are this repository's main traffic — land on
+`main` immediately and are visible to the website, and they accumulate in the
+pending release PR rather than burning a version each.
+
+Commit titles decide the version, so they must be conventional commits:
+`feat:` for a minor bump, `fix:` for a patch, `feat!:` or a `BREAKING CHANGE:`
+footer for a major. The repository squash-merges, so the PR title becomes the
+commit message.
+
+## What publishes, and how it authenticates
+
+| Target | Job | Credential |
+|---|---|---|
+| GitHub Release (tarballs, checksums, `install.sh`) | `github-release` | the run's own `GITHUB_TOKEN` |
+| crates.io | `publish-crates` | Trusted Publishing (OIDC), environment `crates-io` |
+| PyPI (`pyatlasctl`) | `publish-pypi` | Trusted Publishing (OIDC), environment `pypi` |
+
+No long-lived registry token is used. Each publish job mints a short-lived one
+from its own OIDC identity, and both environments are restricted to `main` and
+`v*` tags, so a feature branch cannot reach them.
+
+Both publish steps are idempotent — crates check the index first, PyPI uses
+`skip-existing` — so re-running a partially failed release is safe.
+
+## The distribution names
+
+The crate and the binary are both `atlasctl`. The **PyPI distribution is
+`pyatlasctl`**: `atlasctl` is taken there by an unrelated project, and PyPI also
+refuses names that normalize too close to an existing one, which ruled out
+`atlas-ctl`. The wheel's console script keeps the real name, so
+`uv tool install pyatlasctl` still puts `atlasctl` on your PATH.
+
+## Recipes are part of the binary
+
+Recipes are compiled in, so **a recipe change only reaches users when a release
+ships**. That is the security property, not an oversight: there is no remote
+registry to redirect and nothing fetched at runtime. The website reads recipes
+from git, so it reflects `main` immediately either way.
+
+The workspace root is itself a package (`atlas-recipes-data`) for this reason —
+`cargo package` only includes files beneath the crate root, so a crate under
+`crates/` could not embed `../../recipes` and still work when installed from
+crates.io.
+
+## If the pipeline is broken
+
+`.github/workflows/bootstrap-publish.yml` publishes to crates.io with a stored
+token instead of OIDC. It is manual-dispatch only, dry-runs by default, and
+requires a typed confirmation. It exists because the *first* publish of a crate
+cannot use Trusted Publishing — a crate must exist before a publisher can be
+attached to it — and is kept afterwards only as a recovery path. Delete it, and
+revoke `CARGO_REGISTRY_TOKEN`, once `release.yml` has published cleanly at least
+once.
+
+## Verifying a release
+
+```sh
+cargo install atlasctl --locked      # from crates.io
+uvx pyatlasctl list                  # from PyPI, no install step
+curl -fsSL https://atlasinference.io/install.sh | sh
+```
+
+The installer verifies SHA-256 against the release, and verifies Sigstore build
+provenance too when `gh` is present. A `smoke-install` job runs the published
+one-liner on both architectures before anyone follows the website's
+instructions.


### PR DESCRIPTION
All five crates are published at 0.1.0 and their Trusted Publishers are configured, so the release process is live. This writes it down.

## `docs/RELEASING.md`

Covers what actually trips people up:

- **Merging to main does not publish.** release-please maintains a standing release PR; merging *that* is the release. This is what reconciles "merging ships" with crates.io immutability — recipe edits, which are this repo's main traffic, accumulate rather than burning a version each.
- **Commit titles decide the version**, so they must be conventional commits. The repo squash-merges, so the PR title is the commit message.
- **No long-lived registry token is used.** Each publish job mints a short-lived one from its own OIDC identity, and both environments are restricted to `main` and `v*` tags so a feature branch cannot reach them.
- **The PyPI distribution is `pyatlasctl`**, not `atlasctl` — that name is taken by an unrelated project, and PyPI also refuses names normalizing too close to an existing one, which ruled out `atlas-ctl`. The console script keeps the real name.
- **Recipes are compiled in**, so a recipe change only reaches users when a release ships. That is the security property rather than an oversight, and the website reads recipes from git so it reflects main immediately either way.

## The bootstrap workflow's header was stale

It told the reader to delete it once the crates existed and publishers were configured. Both are now true, and yet it is being kept on purpose: removing the fallback before `release.yml` has been exercised end to end would leave no way to ship a fix.

The comment now says that, and says what has to be true before deleting it — so the next person does not delete it on the strength of an instruction that was written before the situation changed.

## Authorship

AI-generated (Claude Opus 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)