### PR TITLE
fix: give every crate a literal version so release-please can read them

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,11 @@ resolver = "3"
 members = ["crates/atlasctl-core", "crates/atlasctl", "crates/atlasctl-protocol", "crates/atlasctl-agent"]
 
 [workspace.package]
-version = "0.1.0"
+# NOTE: version is deliberately NOT inherited. release-please's cargo-workspace
+# plugin parses each Cargo.toml directly and cannot resolve workspace
+# inheritance — it fails with "invalid [package.version]" — so every crate
+# carries a literal version, and the plugin keeps them in lockstep on release.
+# Everything else here is still shared.
 edition = "2024"
 rust-version = "1.85"
 license = "AGPL-3.0-only"
@@ -39,7 +43,7 @@ all = "deny"
 [package]
 name = "atlas-recipes-data"
 description = "Vendored Atlas Spark recipe corpus, embedded at compile time."
-version.workspace = true
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/atlasctl-agent/Cargo.toml
+++ b/crates/atlasctl-agent/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "atlasctl-agent"
 description = "Local agent that lets the Atlas website launch recipes on this machine."
-version.workspace = true
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/atlasctl-core/Cargo.toml
+++ b/crates/atlasctl-core/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "atlasctl-core"
 description = "Recipe model and deterministic recipe-to-docker translation for atlasctl."
-version.workspace = true
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/atlasctl-protocol/Cargo.toml
+++ b/crates/atlasctl-protocol/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "atlasctl-protocol"
 description = "Wire types shared by the atlasctl agent, the CLI, and the browser client."
-version.workspace = true
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/atlasctl/Cargo.toml
+++ b/crates/atlasctl/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "atlasctl"
 description = "Launch Atlas inference recipes on NVIDIA DGX Spark and other local accelerators."
-version.workspace = true
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
The release workflow has failed on **every push to main** since the launcher landed, and no release PR has ever been opened:

```
release-please failed: cargo-workspace (Avarok-Cybersecurity/atlas-recipes):
package manifest at crates/atlasctl-core/Cargo.toml has an invalid [package.version]
```

release-please's `cargo-workspace` plugin parses each `Cargo.toml` directly and cannot resolve workspace inheritance, so `version.workspace = true` reads as invalid. Every crate now carries a literal version — which is what the plugin expects, since it is the thing that bumps them, and it keeps them in lockstep.

Also removed the now-dead `[workspace.package].version`. Nothing inherits it any more, and leaving it would invite someone to edit it expecting an effect. The reason is recorded where the field was. Everything else stays inherited.

## Why this matters more than it looks

The automated release path has never worked. The 0.1.0 publish went out through the one-off bootstrap workflow with a stored token, so this failure was invisible — the crates are on crates.io and everything looked fine.

I found it by checking whether a release PR had appeared after merging, not because anything reported it. **A workflow failing on `main` is silent unless someone goes looking**, which is worth knowing about this repo generally.

The OIDC publish path is still unproven after this. The first real test is the next `feat:`/`fix:` merge producing a release PR, and that PR being merged.

## Testing

228 tests pass, manifest resolves, fmt clean.

## Authorship

AI-generated (Claude Opus 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)