### PR TITLE
fix: release the workspace as one version, and give it a baseline tag

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -64,6 +64,17 @@ attached to it — and is kept afterwards only as a recovery path. Delete it, an
 revoke `CARGO_REGISTRY_TOKEN`, once `release.yml` has published cleanly at least
 once.
 
+## Version history baseline
+
+`v0.1.0` is tagged at the commit the bootstrap workflow published from
+(`7b86068`). The tag was added afterwards, because that publish predated the
+automated pipeline and did not tag.
+
+This matters: release-please computes the next version from commits **since the
+last tag**. Without it, the first release PR proposed 0.2.0 and swept every
+historical recipe commit into the changelog, because it had no baseline to
+compare against.
+
 ## Verifying a release
 
 ```sh

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,20 @@
       "changelog-path": "CHANGELOG.md"
     }
   },
-  "plugins": ["cargo-workspace"],
+  "plugins": [
+    "cargo-workspace",
+    {
+      "type": "linked-versions",
+      "groupName": "atlasctl",
+      "components": [
+        "atlas-recipes-data",
+        "atlasctl-protocol",
+        "atlasctl-core",
+        "atlasctl-agent",
+        "atlasctl"
+      ]
+    }
+  ],
   "separate-pull-requests": false,
   "include-component-in-tag": false
 }


### PR DESCRIPTION
Follow-up to #28. That fix let release-please run at all; this fixes what it then produced.

## It proposed divergent versions

The first release PR wanted root and `atlasctl` at 0.2.0 and the three libraries at 0.1.1, because the `cargo-workspace` plugin bumps each crate by what changed inside it.

That is correct behaviour and the wrong shape here. These five crates are one product released together, and diverging turns *"which `atlasctl-core` goes with which `atlasctl`?"* into a question nobody should have to ask. The `linked-versions` plugin holds them together.

## It had no baseline

The 0.1.0 publish went out through the bootstrap workflow, which does not tag. So release-please compared against nothing: it proposed **0.2.0**, swept **every historical recipe commit** into the changelog, and linked to a `compare/v0.1.0...v0.2.0` range that did not exist.

`v0.1.0` is now tagged at `7b86068` — the commit that publish actually ran from, taken from the workflow run's `head_sha` rather than guessed. With a baseline, the next release PR should propose a patch bump covering only #27 and #28.

`docs/RELEASING.md` records why the tag was added after the fact, so it does not become folklore.

## What to expect

Once this merges, release-please will regenerate the release PR. It should show one version across all five crates and a changelog covering only what landed since v0.1.0.

## Authorship

AI-generated (Claude Opus 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)