### PR TITLE
fix: keep Cargo.lock in step with the versions release-please writes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,14 @@ jobs:
           ref: ${{ needs.release-please.outputs.tag_name || inputs.tag }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      # release-please bumps versions in Cargo.toml but does not reliably
+      # update every matching entry in Cargo.lock — v0.1.1 shipped with
+      # atlasctl-protocol still at 0.1.0 in the lock, which made `--locked`
+      # refuse and killed the release before it built anything. This resolves
+      # workspace members only, so external dependencies stay pinned and
+      # `--locked` below still means what it says.
+      - run: cargo update --workspace
+
       # Re-verify at the exact commit being published. CI passing on main is
       # not the same statement as "this tag is good".
       - run: cargo test --workspace --locked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "atlasctl-protocol"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",


### PR DESCRIPTION
The v0.1.1 release died in preflight:

```
error: cannot update the lock file /home/runner/.../Cargo.lock
       because --locked was passed to prevent this
```

release-please bumped all five crates in `Cargo.toml` but updated only **four of the five** matching entries in `Cargo.lock` — `atlasctl-protocol` stayed at 0.1.0. The manifests and the lock disagreed, `--locked` refused, and the release stopped before building anything.

**This is currently user-visible.** No release assets exist, so `curl -fsSL https://atlasinference.io/install.sh | sh` — the command on the front page — returns 404. `cargo install atlasctl` is unaffected.

## Two changes

The lock is resynced here, and preflight now runs `cargo update --workspace` before testing. That resolves **workspace members only**, so external dependencies stay pinned and the `--locked` run below still means what it says. It tolerates release-please's partial update rather than depending on it being complete, which it demonstrably is not.

## After this merges

Re-run the release workflow against the existing `v0.1.1` tag with `workflow_dispatch` — the tag was created before preflight failed, so it exists and points at the right commit.

## Testing

228 tests, `cargo metadata --locked` passes.

## Authorship

AI-generated (Claude Opus 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)