### PR TITLE
fix: make the manual release path actually run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,15 +48,52 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+  # Single source of truth for "are we releasing, and what tag?".
+  #
+  # This job exists because release-please only runs on push. A job that `needs`
+  # a skipped job is itself skipped no matter what its own `if` says, so every
+  # downstream job silently skipped when the workflow was dispatched by hand —
+  # the run went green having done nothing. Depending on this job instead means
+  # the manual path and the automatic path resolve identically.
+  resolve:
+    name: resolve the release
+    needs: [release-please]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-24.04
+    outputs:
+      tag: ${{ steps.pick.outputs.tag }}
+      release: ${{ steps.pick.outputs.release }}
+    steps:
+      - id: pick
+        env:
+          RP_RESULT: ${{ needs.release-please.result }}
+          RP_CREATED: ${{ needs.release-please.outputs.release_created }}
+          RP_TAG: ${{ needs.release-please.outputs.tag_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -eu
+          if [ -n "$INPUT_TAG" ]; then
+            echo "manual dispatch for $INPUT_TAG"
+            echo "tag=$INPUT_TAG" >> "$GITHUB_OUTPUT"
+            echo "release=true" >> "$GITHUB_OUTPUT"
+          elif [ "$RP_RESULT" = "success" ] && [ "$RP_CREATED" = "true" ]; then
+            echo "release-please cut $RP_TAG"
+            echo "tag=$RP_TAG" >> "$GITHUB_OUTPUT"
+            echo "release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "nothing to release on this run"
+            echo "release=false" >> "$GITHUB_OUTPUT"
+          fi
+
   preflight:
     name: preflight at the tag
-    needs: [release-please]
-    if: needs.release-please.outputs.release_created == 'true' || inputs.tag != ''
+    needs: [resolve]
+    if: needs.resolve.outputs.release == 'true'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ needs.release-please.outputs.tag_name || inputs.tag }}
+          ref: ${{ needs.resolve.outputs.tag }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       # release-please bumps versions in Cargo.toml but does not reliably
@@ -77,7 +114,7 @@ jobs:
 
   build:
     name: build ${{ matrix.target }}
-    needs: [preflight]
+    needs: [resolve, preflight]
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -101,7 +138,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ needs.release-please.outputs.tag_name || inputs.tag }}
+          ref: ${{ needs.resolve.outputs.tag }}
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -131,7 +168,7 @@ jobs:
 
   github-release:
     name: publish release assets
-    needs: [release-please, build]
+    needs: [resolve, build]
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -150,12 +187,12 @@ jobs:
       - name: upload
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ needs.release-please.outputs.tag_name || inputs.tag }}
+          TAG: ${{ needs.resolve.outputs.tag }}
         run: gh release upload "$TAG" dist/* --clobber
 
   publish-crates:
     name: crates.io
-    needs: [release-please, github-release]
+    needs: [resolve, github-release]
     runs-on: ubuntu-24.04
     environment: crates-io
     permissions:
@@ -163,7 +200,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ needs.release-please.outputs.tag_name || inputs.tag }}
+          ref: ${{ needs.resolve.outputs.tag }}
       - uses: dtolnay/rust-toolchain@stable
       # Trusted publishing: a short-lived token minted from this job's OIDC
       # identity, so no long-lived registry token is stored in the repository.
@@ -188,7 +225,7 @@ jobs:
 
   wheels:
     name: wheel ${{ matrix.target }}
-    needs: [preflight]
+    needs: [resolve, preflight]
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -205,7 +242,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ needs.release-please.outputs.tag_name || inputs.tag }}
+          ref: ${{ needs.resolve.outputs.tag }}
       # A statically-linked musl binary satisfies the manylinux policy trivially,
       # so each Linux target is emitted twice from one build: manylinux for glibc
       # hosts and musllinux for Alpine. The binary is identical; only the tag
@@ -240,12 +277,12 @@ jobs:
 
   sdist:
     name: sdist
-    needs: [preflight]
+    needs: [resolve, preflight]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ needs.release-please.outputs.tag_name || inputs.tag }}
+          ref: ${{ needs.resolve.outputs.tag }}
       # Published for source availability under the AGPL, and for platforms the
       # wheel matrix does not cover. Building it needs a Rust toolchain, which
       # the project README says.
@@ -260,7 +297,7 @@ jobs:
 
   publish-pypi:
     name: PyPI
-    needs: [release-please, github-release, wheels, sdist]
+    needs: [resolve, github-release, wheels, sdist]
     runs-on: ubuntu-24.04
     environment: pypi
     permissions:
@@ -281,7 +318,7 @@ jobs:
 
   smoke-install:
     name: smoke ${{ matrix.runner }}
-    needs: [github-release]
+    needs: [resolve, github-release]
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
@@ -291,7 +328,7 @@ jobs:
       # Prove the published artifacts actually install, on both architectures,
       # before anyone follows the instructions on the website.
       - env:
-          ATLASCTL_VERSION: ${{ needs.release-please.outputs.tag_name || inputs.tag }}
+          ATLASCTL_VERSION: ${{ needs.resolve.outputs.tag }}
         run: |
           sh scripts/install.sh
           "$HOME/.local/bin/atlasctl" --version


### PR DESCRIPTION
Re-running the release against the existing `v0.1.1` tag **did nothing**. Every job skipped, and [the run reported success](https://github.com/Avarok-Cybersecurity/atlas-recipes/actions/runs/32895749532) having built and published nothing.

## Cause

A GitHub Actions rule that is easy to miss: **a job that `needs` a skipped job is itself skipped, regardless of what its own `if` says.**

`release-please` has `if: github.event_name == 'push'`, so on `workflow_dispatch` it skipped — and the entire graph hanging off it skipped with it. That included `preflight`, whose `if` explicitly handled the dispatch case and never got the chance to be evaluated.

**A green run that did nothing is the worst possible shape for this.** It looked like the release had succeeded.

## Fix

A `resolve` job that always runs and is the single source of both "are we releasing" and "which tag". Everything downstream depends on it rather than on release-please, so the manual and automatic paths resolve identically.

Also adds `resolve` to the `needs` of four jobs that referenced `needs.resolve.outputs.tag` without declaring it — a job can only read outputs of jobs it lists, so those would have silently resolved to an empty string. That is the same class of bug as the one being fixed, and I caught it by checking rather than by it failing.

## Testing

The resolve logic was exercised against all five paths before committing:

| scenario | result |
|---|---|
| manual dispatch with a tag | `tag=v0.1.1 release=true` |
| release-please cut a release | `tag=v0.2.0 release=true` |
| push, nothing to release | `release=false` |
| release-please failed | `release=false` |
| push, neither | `release=false` |

## Context

This is the fifth defect in the release pipeline, each hidden behind the last: workspace-inherited versions, divergent bumps, a missing baseline tag, a stale lockfile, and now a dependency graph that silently no-ops. The path had never run end to end, so every layer was unproven until the one above it worked.

**The front-page install command is still 404ing** until a release actually produces assets.

## Authorship

AI-generated (Claude Opus 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)