### PR TITLE
fix: a skipped job skips its whole needs chain, not one hop

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
   preflight:
     name: preflight at the tag
     needs: [resolve]
-    if: needs.resolve.outputs.release == 'true'
+    if: ${{ !cancelled() && needs.resolve.outputs.release == 'true' }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
@@ -115,6 +115,7 @@ jobs:
   build:
     name: build ${{ matrix.target }}
     needs: [resolve, preflight]
+    if: ${{ !cancelled() && needs.resolve.outputs.release == 'true' && needs.preflight.result == 'success' }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -169,6 +170,7 @@ jobs:
   github-release:
     name: publish release assets
     needs: [resolve, build]
+    if: ${{ !cancelled() && needs.resolve.outputs.release == 'true' && needs.build.result == 'success' }}
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -193,6 +195,7 @@ jobs:
   publish-crates:
     name: crates.io
     needs: [resolve, github-release]
+    if: ${{ !cancelled() && needs.resolve.outputs.release == 'true' && needs['github-release'].result == 'success' }}
     runs-on: ubuntu-24.04
     environment: crates-io
     permissions:
@@ -226,6 +229,7 @@ jobs:
   wheels:
     name: wheel ${{ matrix.target }}
     needs: [resolve, preflight]
+    if: ${{ !cancelled() && needs.resolve.outputs.release == 'true' && needs.preflight.result == 'success' }}
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -278,6 +282,7 @@ jobs:
   sdist:
     name: sdist
     needs: [resolve, preflight]
+    if: ${{ !cancelled() && needs.resolve.outputs.release == 'true' && needs.preflight.result == 'success' }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
@@ -298,6 +303,7 @@ jobs:
   publish-pypi:
     name: PyPI
     needs: [resolve, github-release, wheels, sdist]
+    if: ${{ !cancelled() && needs.resolve.outputs.release == 'true' && needs['github-release'].result == 'success' && needs.wheels.result == 'success' && needs.sdist.result == 'success' }}
     runs-on: ubuntu-24.04
     environment: pypi
     permissions:
@@ -319,6 +325,7 @@ jobs:
   smoke-install:
     name: smoke ${{ matrix.runner }}
     needs: [resolve, github-release]
+    if: ${{ !cancelled() && needs.resolve.outputs.release == 'true' && needs['github-release'].result == 'success' }}
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
@@ -333,3 +340,34 @@ jobs:
           sh scripts/install.sh
           "$HOME/.local/bin/atlasctl" --version
           "$HOME/.local/bin/atlasctl" list | head -5
+
+  # Twice now a release run reported success while every publish job was
+  # skipped. A green run that shipped nothing is the failure, so it is asserted
+  # here rather than left to be noticed by a 404 on the install path.
+  verify-published:
+    name: assert the release actually shipped
+    needs: [resolve, github-release, publish-crates, publish-pypi, smoke-install]
+    if: ${{ !cancelled() && needs.resolve.outputs.release == 'true' }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: every publish job must have succeeded
+        env:
+          GH_RELEASE: ${{ needs['github-release'].result }}
+          CRATES: ${{ needs['publish-crates'].result }}
+          PYPI: ${{ needs['publish-pypi'].result }}
+          SMOKE: ${{ needs['smoke-install'].result }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+        run: |
+          set -eu
+          fail=0
+          for pair in "github-release:$GH_RELEASE" "crates.io:$CRATES" \
+                      "PyPI:$PYPI" "smoke-install:$SMOKE"; do
+            name=${pair%%:*}; result=${pair#*:}
+            printf '%-16s %s\n' "$name" "$result"
+            [ "$result" = success ] || fail=1
+          done
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::release $TAG did not ship: at least one publish job did not succeed"
+            exit 1
+          fi
+          echo "release $TAG shipped on every channel"


### PR DESCRIPTION
## The bug

`v0.1.1` exists as a tag and a GitHub Release, but carries **no assets**, so the
documented install path is broken end to end:

```
$ curl -sSIL -o /dev/null -w '%{http_code}\n' \
    https://github.com/Avarok-Cybersecurity/atlas-recipes/releases/latest/download/SHA256SUMS
404
```

`install.sh` itself serves fine from atlasinference.io — it 404s at the download
step, because nothing was ever built and uploaded.

## Why the previous fix was not enough

#33 added the `resolve` job so the manual and automatic paths agree on "are we
releasing, and what tag". `resolve` ran and did exactly that:

```
INPUT_TAG: v0.1.1
manual dispatch for v0.1.1
Set output 'tag'
Set output 'release'
```

Every job after it still skipped. In GitHub Actions a skipped job propagates its
skip **transitively down the whole `needs` graph**, not one hop: with
`release-please` skipped on `workflow_dispatch`, `preflight` inherited that skip
through `resolve` no matter what `resolve` itself resulted in. `resolve` had
opted out with `!cancelled()`; nothing downstream had.

## The fix

- Every downstream gate opts out with `!cancelled()`.
- Because `!cancelled()` would then also let a job run after its predecessor
  **failed**, each gate now states the predecessor success it requires.
- Job ids containing a hyphen are indexed (`needs['github-release']`), not
  dotted — a hyphen in a context path parses as subtraction.
- New `verify-published` job. Twice now a release run has reported success while
  every publish job was skipped. A green run that shipped nothing is the actual
  failure mode here, so it is asserted and red rather than discovered later as a
  404 on the install command.

## After merge

Re-dispatch against `v0.1.1` to attach the assets the tag should already have.