### PR TITLE
fix: the release PR gets no CI, so it kept cutting tags that cannot build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,38 @@ jobs:
             echo "release=false" >> "$GITHUB_OUTPUT"
           fi
 
+  # A pull request opened by the default GITHUB_TOKEN does not trigger
+  # workflows, so the standing release PR gets no CI — which is how three
+  # separate releases were cut from a tree that could not build. Push events do
+  # run, so the pending release branch is verified from here instead. Advisory
+  # (continue-on-error): this must surface a bad release PR, never block an
+  # unrelated push to main.
+  check-release-pr:
+    name: verify the pending release PR
+    needs: [release-please]
+    if: github.event_name == 'push'
+    runs-on: ubuntu-24.04
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: release-please--branches--main
+          fetch-depth: 1
+        continue-on-error: true
+        id: co
+      - if: steps.co.outcome == 'success'
+        uses: dtolnay/rust-toolchain@stable
+      - if: steps.co.outcome == 'success'
+        name: the release PR's lock must match its manifests
+        run: |
+          set -eu
+          if ! cargo metadata --locked --format-version 1 >/dev/null; then
+            echo "::error::The pending release PR has a stale Cargo.lock."
+            echo "::error::Merging it would cut a tag that cannot build."
+            exit 1
+          fi
+          echo "pending release PR is publishable"
+
   preflight:
     name: preflight at the tag
     needs: [resolve]
@@ -96,13 +128,21 @@ jobs:
           ref: ${{ needs.resolve.outputs.tag }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      # release-please bumps versions in Cargo.toml but does not reliably
-      # update every matching entry in Cargo.lock — v0.1.1 shipped with
-      # atlasctl-protocol still at 0.1.0 in the lock, which made `--locked`
-      # refuse and killed the release before it built anything. This resolves
-      # workspace members only, so external dependencies stay pinned and
-      # `--locked` below still means what it says.
-      - run: cargo update --workspace
+      # This step used to run `cargo update --workspace`, which REPAIRED a
+      # stale lock — so preflight passed while every job in the build matrix,
+      # which uses --locked without the repair, failed at the same tag. A
+      # preflight that hides the condition it exists to catch is worse than
+      # none. Assert instead: a tag whose lock does not already match its
+      # manifests is not publishable, and says so in eight seconds rather than
+      # after four runners have each rediscovered it.
+      - name: the lock must already match the manifests
+        run: |
+          set -eu
+          if ! cargo metadata --locked --format-version 1 >/dev/null; then
+            echo "::error::Cargo.lock at this tag does not match the manifests."
+            echo "::error::Run 'cargo update --workspace' on main and commit the result."
+            exit 1
+          fi
 
       # Re-verify at the exact commit being published. CI passing on main is
       # not the same statement as "this tag is good".

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,5 +2,6 @@
   ".": "0.1.1",
   "crates/atlasctl": "0.1.1",
   "crates/atlasctl-agent": "0.1.1",
-  "crates/atlasctl-core": "0.1.1"
+  "crates/atlasctl-core": "0.1.1",
+  "crates/atlasctl-protocol": "0.1.1"
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,10 @@ repository = "https://github.com/Avarok-Cybersecurity/atlas-recipes"
 authors = ["Avarok Cybersecurity"]
 
 [workspace.dependencies]
-atlas-recipes-data = { path = ".", version = "0.1.0" }
-atlasctl-core = { path = "crates/atlasctl-core", version = "0.1.0" }
-atlasctl-protocol = { path = "crates/atlasctl-protocol", version = "0.1.0" }
-atlasctl-agent = { path = "crates/atlasctl-agent", version = "0.1.0" }
+atlas-recipes-data = { path = ".", version = "0.1.1" }
+atlasctl-core = { path = "crates/atlasctl-core", version = "0.1.1" }
+atlasctl-protocol = { path = "crates/atlasctl-protocol", version = "0.1.1" }
+atlasctl-agent = { path = "crates/atlasctl-agent", version = "0.1.1" }
 anyhow = "1"
 include_dir = "0.7"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
Three releases in a row were cut from a tree that fails `cargo build --locked`.
`v0.1.1` still has **no assets**, so the documented install command is broken.
Each previous fix addressed a symptom one layer up. Here are the three actual
causes.

## 1. The lock drift

release-please maintains `Cargo.lock` entries only for packages listed in
`.release-please-manifest.json`, and `crates/atlasctl-protocol` was never listed:

```json
{ ".": "0.1.1", "crates/atlasctl": "0.1.1",
  "crates/atlasctl-agent": "0.1.1", "crates/atlasctl-core": "0.1.1" }
```

The `cargo-workspace` plugin bumped its **manifest** version while its **lock**
entry stayed behind. Verified on the current release branch:

```
atlas-recipes-data     0.1.2
atlasctl               0.1.2
atlasctl-agent         0.1.2
atlasctl-core          0.1.2
atlasctl-protocol      0.1.1   <-- manifest says 0.1.2
```

Adding it to the manifest fixes this at the source.

## 2. preflight was hiding it

`preflight` ran `cargo update --workspace`, which **repaired** the stale lock —
so preflight went green while all four jobs in the build matrix, which use
`--locked` without that repair, failed at the same tag:

```
error: cannot update the lock file ... because --locked was passed to prevent this
```

A preflight that silently fixes the condition it exists to catch is worse than
no preflight. It now asserts and fails in seconds, instead of after four runners
have each rediscovered it.

## 3. The release PR had no CI at all

A pull request opened by the default `GITHUB_TOKEN` **does not trigger
workflows** — the same class of gotcha as `GITHUB_TOKEN` tags not triggering
`on: push: tags`, which this workflow already documents in its header. So the
one pull request in this repository that publishes anything was merging with
nothing but a secrets scan:

```
$ gh pr checks 32
GitGuardian Security Checks   pass   1s
```

That is the systemic cause: no amount of care in a release PR helps if nothing
ever checks it. `push` events do run, so `check-release-pr` verifies the pending
release branch from there. It is `continue-on-error` on purpose — it must
surface a bad release PR, never block an unrelated push to main.

## Also

`[workspace.dependencies]` pinned every internal crate at `version = "0.1.0"`
while the crates were at `0.1.1`. `^0.1.0` still matched, so nothing was broken
today — but it becomes a hard failure at `0.2.0`, and release-please rewrites
these, so bringing them in step now means one less thing for the next bump to
get wrong.

## After merge

release-please regenerates the release PR. Verify its lock is consistent
(`cargo metadata --locked` on that branch — `check-release-pr` now does this
automatically), then merge it to cut `v0.1.2` through the automatic path.
`v0.1.1` stays as it is: its tree genuinely cannot build, and no workflow change
makes it publishable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)