### PR TITLE
fix: enforce the release PR's lock on the artifact, not on release-please

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,15 +85,70 @@ jobs:
             echo "release=false" >> "$GITHUB_OUTPUT"
           fi
 
+  # release-please rewrites the version in every workspace manifest but updates
+  # Cargo.lock only for the members its own discovery finds — its log reports
+  # "updating atlasctl / atlasctl-agent / atlasctl-core" and never
+  # atlasctl-protocol, whose lock entry therefore drifts one version behind on
+  # every release. That is what made v0.1.1 unbuildable, and adding protocol to
+  # .release-please-manifest.json did not change the set it updates.
+  #
+  # Rather than keep guessing at that discovery logic, the invariant is enforced
+  # on the artifact: after release-please writes the branch, the lock must match
+  # the manifests, and if it does not it is repaired in place. The tag is cut
+  # from this branch, so the tag then carries a lock that builds. The repair is
+  # idempotent (release-please rebuilds the branch each run, so this re-applies)
+  # and loud, so a silent recurrence is not possible.
+  sync-release-lock:
+    name: sync the release PR's Cargo.lock
+    needs: [release-please]
+    if: github.event_name == 'push'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        id: co
+        continue-on-error: true
+        with:
+          ref: release-please--branches--main
+          fetch-depth: 1
+      - if: steps.co.outcome == 'success'
+        uses: dtolnay/rust-toolchain@stable
+      - if: steps.co.outcome == 'success'
+        name: repair the lock if release-please left it behind
+        run: |
+          set -eu
+          if cargo metadata --locked --format-version 1 >/dev/null 2>&1; then
+            echo "release PR lock already matches its manifests"
+            exit 0
+          fi
+          echo "::warning::release-please left Cargo.lock behind its manifests; repairing"
+          # --workspace resolves workspace members only, so external
+          # dependencies stay exactly as pinned and --locked keeps its meaning.
+          cargo update --workspace
+          # If the lock check failed but resolving workspace members changed
+          # nothing, the cause is something other than version drift and this
+          # job must not paper over it.
+          if git diff --quiet -- Cargo.lock; then
+            echo "::error::Cargo.lock failed --locked but resolving the workspace changed nothing."
+            echo "::error::Something other than release-please version drift is wrong here."
+            exit 1
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Cargo.lock
+          git commit -m "chore: sync Cargo.lock with the versions release-please wrote"
+          git push origin HEAD:release-please--branches--main
+
   # A pull request opened by the default GITHUB_TOKEN does not trigger
   # workflows, so the standing release PR gets no CI — which is how three
   # separate releases were cut from a tree that could not build. Push events do
-  # run, so the pending release branch is verified from here instead. Advisory
-  # (continue-on-error): this must surface a bad release PR, never block an
-  # unrelated push to main.
+  # run, so the pending release branch is verified from here instead, after the
+  # repair above. Advisory (continue-on-error): this must surface a bad release
+  # PR, never block an unrelated push to main.
   check-release-pr:
     name: verify the pending release PR
-    needs: [release-please]
+    needs: [release-please, sync-release-lock]
     if: github.event_name == 'push'
     runs-on: ubuntu-24.04
     continue-on-error: true


### PR DESCRIPTION
## What #35 got right, and what it missed

`check-release-pr` from #35 worked immediately — it caught the very next release
PR as unbuildable. What did **not** work is the other half: adding
`crates/atlasctl-protocol` to `.release-please-manifest.json` did not change the
set of packages release-please updates. Its log on the next run:

```
✔ updating atlasctl in
✔ updating atlasctl-agent in
✔ updating atlasctl-core in
```

Still no `atlasctl-protocol`. So on the regenerated release branch:

```
lock: atlas-recipes-data 0.1.2 · atlasctl 0.1.2 · atlasctl-agent 0.1.2
      atlasctl-core 0.1.2 · atlasctl-protocol 0.1.1
manifests: all five at 0.1.2
→ error: cannot update the lock file ... because --locked was passed
```

Same drift that made `v0.1.1` unbuildable.

## Approach

Stop trying to control release-please's discovery and enforce the invariant on
the artifact it produces. `sync-release-lock` runs after release-please writes
the branch:

1. If the lock already matches the manifests — do nothing, say so.
2. Otherwise `::warning::`, `cargo update --workspace` (workspace members only,
   so external pins and the meaning of `--locked` are untouched), commit, push.
3. If resolving the workspace changed nothing, **fail** — the lock failed
   `--locked` for some reason other than version drift, and papering over that
   would hide a real problem.

The tag is cut from this branch, so the tag carries a lock that builds.
`check-release-pr` now runs after the repair and verifies the result. The repair
is idempotent: release-please rebuilds the branch on every push to main, so it
re-applies each time.

## Deliberately not done

Restructuring `release-please-config.json` to register each crate as its own
package. That would plausibly fix the discovery — but it also changes changelog
and tag generation, and this pipeline has now been broken three times by changes
made on a guess about how release-please behaves. I wrote that change, then
reverted it rather than ship a fourth guess.

## After merge

The push to main runs release-please → `sync-release-lock` repairs the branch →
`check-release-pr` confirms it. Then the release PR is mergeable and cuts
`v0.1.2` through the automatic path, which is the path that actually needs to
work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)