### PR TITLE
fix: cross builds and a publish job that could never have worked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@v7
       - name: Every source file carries an SPDX header
         run: |
-          missing=$(git ls-files '*.rs' '*.sh' '*.yml' \
+          missing=$(git ls-files '*.rs' '*.sh' '*.yml' '*.py' \
             | while read -r f; do
                 head -3 "$f" | grep -q 'SPDX-License-Identifier: AGPL-3.0-only' || echo "$f"
               done)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,8 +236,13 @@ jobs:
         with:
           ref: ${{ needs.resolve.outputs.tag }}
       - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
+      # rust-toolchain.toml pins 1.93.1, and that override governs every cargo
+      # invocation in this job. The action's `targets:` input installed the std
+      # for the toolchain the ACTION picked (stable), which is then never used —
+      # so all three CROSS targets died with "can't find crate for `core`" while
+      # aarch64-apple-darwin, the one native target, passed. Add the target to
+      # the toolchain that actually runs.
+      - run: rustup target add ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
       - name: musl toolchain
         if: contains(matrix.target, 'linux-musl')
@@ -309,7 +314,14 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
           set -eu
-          for crate in atlas-recipes-data atlasctl-core atlasctl; do
+          # This job had never executed — every previous release died before
+          # reaching it — and it was wrong twice over: it named three of the
+          # five workspace crates, in an order that could not work. Publishing
+          # atlasctl-core requires atlasctl-protocol to already be on the
+          # registry, and protocol was not in the list at all.
+          order=$(cargo metadata --no-deps --format-version 1 | python3 scripts/publish-order.py)
+          echo "publish order: $(echo "$order" | tr '\n' ' ')"
+          for crate in $order; do
             version=$(cargo metadata --no-deps --format-version 1 \
               | python3 -c "import json,sys;print(next(p['version'] for p in json.load(sys.stdin)['packages'] if p['name']=='$crate'))")
             # Idempotent: re-running a partially-failed publish must not fail on

--- a/scripts/publish-order.py
+++ b/scripts/publish-order.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Print the workspace's publishable crates in dependency order.
+
+crates.io refuses a crate whose path dependencies are not already published, so
+`cargo publish` has to walk the workspace bottom-up. The release workflow used
+to carry that order as a hand-written list, which listed three of the five
+crates and put atlasctl-core before atlasctl-protocol that it depends on — a
+publish that could never have succeeded. Deriving the order from the manifests
+means adding a crate cannot silently reintroduce that.
+
+Reads `cargo metadata --no-deps` on stdin, writes one crate name per line.
+Exits non-zero on a dependency cycle rather than emitting a partial order.
+"""
+
+import json
+import sys
+
+
+def main() -> int:
+    meta = json.load(sys.stdin)
+    # `publish = false` marks a crate as deliberately unpublishable; absent or
+    # true means it ships. Anything else is a registry allow-list, still ships.
+    packages = {
+        p["name"]: p
+        for p in meta["packages"]
+        if p.get("publish") is None or p.get("publish")
+    }
+    edges = {
+        name: {d["name"] for d in pkg["dependencies"] if d["name"] in packages}
+        for name, pkg in packages.items()
+    }
+
+    order: list[str] = []
+    done: set[str] = set()
+
+    def visit(name: str, stack: tuple[str, ...] = ()) -> None:
+        if name in done:
+            return
+        if name in stack:
+            raise SystemExit("dependency cycle: " + " -> ".join(stack + (name,)))
+        for dep in sorted(edges[name]):
+            visit(dep, stack + (name,))
+        done.add(name)
+        order.append(name)
+
+    # Sorted entry points so the output is byte-stable across runs.
+    for name in sorted(packages):
+        visit(name)
+
+    print("\n".join(order))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
`v0.1.2` got further than any release before it — `resolve`, `sync-release-lock`
and `preflight` all green, and it is the first tag this repo has cut whose lock
matches its manifests:

```
prepare release            ✓
resolve the release        ✓
sync the release lock      ✓   (repaired atlasctl-protocol 0.1.1 → 0.1.2)
verify the pending PR      ✓
preflight at the tag       ✓   ← never reached before
build matrix               ✗
```

It then hit two problems that were only *reachable* once the earlier layers
stopped failing first. Both are fixed here, in one change.

## 1. Cross targets never existed on the toolchain that runs

`rust-toolchain.toml` pins `1.93.1`, and that override governs every cargo
invocation. The build job asked for:

```yaml
- uses: dtolnay/rust-toolchain@stable
  with:
    targets: ${{ matrix.target }}
```

which installs the std for the toolchain **the action selects** — `stable` —
which the override then never uses. Result:

| target | runner | native? | result |
| --- | --- | --- | --- |
| `aarch64-unknown-linux-musl` | ubuntu-24.04-arm | cross | ✗ `can't find crate for core` |
| `x86_64-unknown-linux-musl` | ubuntu-24.04 | cross | ✗ same |
| `x86_64-apple-darwin` | macos-14 | cross | ✗ same |
| `aarch64-apple-darwin` | macos-14 | **native** | ✓ |

That 3-of-4 split is the signature. `rustup target add` respects the override
file, so the target lands on the toolchain that actually builds.

**Verified locally, end to end.** After `rustup target add
aarch64-unknown-linux-musl`:

```
$ cargo build --release --locked -p atlasctl --target aarch64-unknown-linux-musl
    Finished `release` profile [optimized] target(s) in 8.37s
$ file target/aarch64-unknown-linux-musl/release/atlasctl
ELF 64-bit LSB executable, ARM aarch64, statically linked
$ ./atlasctl --version
atlasctl 0.1.2
$ ./atlasctl recipe list | wc -l
31
```

## 2. `publish-crates` listed three of five crates, in an impossible order

This job had **never executed** — every previous release died before reaching it
— so nothing had ever checked it:

```sh
for crate in atlas-recipes-data atlasctl-core atlasctl; do
```

`atlasctl-protocol` and `atlasctl-agent` are missing entirely. crates.io refuses
a crate whose path dependencies are not already published, and the real graph is:

```
atlas-recipes-data  -> []
atlasctl-protocol   -> []
atlasctl-core       -> [atlas-recipes-data, atlasctl-protocol]
atlasctl-agent      -> [atlasctl-core, atlasctl-protocol]
atlasctl            -> [atlasctl-agent, atlasctl-core]
```

So the second iteration — `cargo publish -p atlasctl-core` — would have failed
against a registry that had never seen `atlasctl-protocol`.

The order is now derived from the manifests by `scripts/publish-order.py`
instead of written down, so adding a crate cannot silently reintroduce this. It
exits non-zero on a dependency cycle rather than emitting a partial order (both
paths tested locally).

## 3. The SPDX check did not cover Python

`publish-order.py` is this repository's first `.py` file, and the header check
covered only `.rs`, `.sh` and `.yml` — so it would have shipped unlicensed. Now
covered.

## Not affected

The wheels. `maturin-action` carries its own toolchain, and all four wheel jobs
plus `sdist` succeeded in the `v0.1.2` run — including `x86_64-apple-darwin`,
which cross-compiles.

## After merge

Re-dispatch against `v0.1.2`. Its tree is already verified consistent, so this
goes straight to the build matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)