### PR TITLE
test: agent re-adoption coverage, and take the patched `time`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@1.85.0
+      - uses: dtolnay/rust-toolchain@1.88.0
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --workspace --locked
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,9 +934,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -1468,9 +1468,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -1483,15 +1483,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = ["crates/atlasctl-core", "crates/atlasctl", "crates/atlasctl-protocol"
 # carries a literal version, and the plugin keeps them in lockstep on release.
 # Everything else here is still shared.
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 license = "AGPL-3.0-only"
 repository = "https://github.com/Avarok-Cybersecurity/atlas-recipes"
 authors = ["Avarok Cybersecurity"]

--- a/crates/atlasctl-agent/src/discovery/mdns.rs
+++ b/crates/atlasctl-agent/src/discovery/mdns.rs
@@ -135,10 +135,10 @@ impl DiscoveryBrowser for MdnsDiscovery {
                         // nodes do not blink out of the interface.
                         _ => None,
                     };
-                    if let Some(ev) = out {
-                        if tx.send(ev).is_err() {
-                            break;
-                        }
+                    if let Some(ev) = out
+                        && tx.send(ev).is_err()
+                    {
+                        break;
                     }
                 }
             })

--- a/crates/atlasctl/src/launchtelemetry/mod.rs
+++ b/crates/atlasctl/src/launchtelemetry/mod.rs
@@ -168,3 +168,6 @@ impl LaunchTelemetry for LocalLaunchTelemetry {
         })
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/atlasctl/src/launchtelemetry/tests.rs
+++ b/crates/atlasctl/src/launchtelemetry/tests.rs
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Why an agent can pick up a launch it did not start.
+//!
+//! Nothing here is remembered from a launch this process performed. The
+//! container and the port are asked of the container runtime every time, which
+//! is what lets a restarted agent adopt what its predecessor left running —
+//! and what stops it reporting another model's numbers under this one's name.
+
+use super::*;
+use atlasctl_agent::launchstats::MetricsSource;
+use atlasctl_core::io::RecordingRunner;
+use atlasctl_core::io::process::Output;
+use std::sync::Mutex as StdMutex;
+
+const RECIPE: &str = "qwen3.6-35b-a3b-fp8-bf16head";
+const NAME: &str = "atlas-qwen3.6-35b-a3b-fp8-bf16head";
+
+fn ok(stdout: &str) -> Output {
+    Output {
+        status: 0,
+        stdout: stdout.to_owned(),
+        stderr: String::new(),
+    }
+}
+
+/// Records which port it was asked to scrape.
+struct PortSpy(StdMutex<Vec<u16>>);
+
+impl MetricsSource for PortSpy {
+    fn scrape(&self, port: u16) -> anyhow::Result<String> {
+        self.0.lock().expect("lock").push(port);
+        Ok("atlas_requests_total 7\n".to_owned())
+    }
+}
+
+fn recipe_id() -> RecipeId {
+    RecipeId::parse(RECIPE).expect("a valid id")
+}
+
+fn telemetry(runner: &Arc<RecordingRunner>) -> LocalLaunchTelemetry {
+    LocalLaunchTelemetry::new(
+        Arc::clone(runner) as Arc<dyn ProcessRunner>,
+        atlasctl_agent::launchstats::LaunchSampler::new(Box::new(PortSpy(StdMutex::new(
+            Vec::new(),
+        )))),
+    )
+}
+
+/// The property re-adoption rests on: the port comes from the container that is
+/// actually running, not from the recipe. A launch can override the port, and
+/// trusting the recipe would scrape whatever else was on the default and report
+/// another model's throughput under this one's name.
+#[test]
+fn the_port_is_read_from_the_running_container_not_the_recipe() {
+    let runner = Arc::new(RecordingRunner::new());
+    runner.push_result(ok(&format!("{NAME}\trunning\n")));
+    runner.push_result(ok("serve\n--port\n9911\n--host\n0.0.0.0\n"));
+
+    let t = telemetry(&runner);
+    let reading = t.sample(&recipe_id()).expect("samples");
+    assert_eq!(reading.requests_total, Some(7.0));
+
+    // The port reached the scraper by way of the container's own arguments,
+    // which is the only place it could have come from: the recipe was never
+    // consulted.
+    let calls = runner.calls();
+    assert_eq!(calls[0][1], "ps", "it must ask what is running first");
+    assert!(calls[1].contains(&"inspect".to_owned()), "{calls:?}");
+    assert!(calls[1].contains(&NAME.to_owned()), "{calls:?}");
+}
+
+#[test]
+fn an_equals_form_port_is_understood_too() {
+    let runner = Arc::new(RecordingRunner::new());
+    runner.push_result(ok(&format!("{NAME}\trunning\n")));
+    runner.push_result(ok("serve\n--port=9911\n"));
+    let t = telemetry(&runner);
+    assert!(t.sample(&recipe_id()).is_ok());
+}
+
+/// Guessing would scrape somebody else's server and label the numbers with this
+/// recipe's name.
+#[test]
+fn a_launch_with_no_port_is_refused_rather_than_guessed() {
+    let runner = Arc::new(RecordingRunner::new());
+    runner.push_result(ok(&format!("{NAME}\trunning\n")));
+    runner.push_result(ok("serve\n--host\n0.0.0.0\n"));
+    let t = telemetry(&runner);
+    let err = t.sample(&recipe_id()).expect_err("no port to scrape");
+    assert!(err.contains("does not name a port"), "{err}");
+}
+
+#[test]
+fn a_recipe_that_was_never_launched_here_says_so() {
+    let runner = Arc::new(RecordingRunner::new());
+    runner.push_result(ok(""));
+    let t = telemetry(&runner);
+    let err = t.sample(&recipe_id()).expect_err("nothing launched");
+    assert!(err.contains("has not been launched"), "{err}");
+}
+
+/// A launch that has stopped is exactly the one whose log an operator wants.
+/// Listing only running containers would answer "no such launch" at the moment
+/// the question matters most.
+#[test]
+fn logs_are_available_from_a_container_that_has_exited() {
+    let runner = Arc::new(RecordingRunner::new());
+    runner.push_result(ok(&format!("{NAME}\texited\n")));
+    runner.push_result(Output {
+        status: 0,
+        stdout: String::new(),
+        stderr: "Error: Snapshot has no weight files\n".to_owned(),
+    });
+    let t = telemetry(&runner);
+
+    let tail = t.logs(&recipe_id(), 50).expect("reads the log");
+    assert_eq!(tail.container, NAME);
+    assert!(!tail.running, "the container has exited");
+    // The interesting half of a failed start is usually the stderr half.
+    assert_eq!(tail.lines, vec!["Error: Snapshot has no weight files"]);
+
+    assert!(
+        runner.calls()[0].contains(&"-a".to_owned()),
+        "stopped containers must be listed: {:?}",
+        runner.calls()[0]
+    );
+}
+
+/// Sampling is refused for a launch that has stopped: a rate needs a live
+/// engine, and the last scrape of a dead one is not news.
+#[test]
+fn stats_are_refused_for_a_container_that_has_exited() {
+    let runner = Arc::new(RecordingRunner::new());
+    runner.push_result(ok(&format!("{NAME}\texited\n")));
+    let t = telemetry(&runner);
+    let err = t.sample(&recipe_id()).expect_err("not running");
+    assert!(err.contains("is not running"), "{err}");
+}


### PR DESCRIPTION
Two things, both small.

## 1. Agent re-adoption, verified and covered

The plan requires that killing the agent mid-run leaves the container running and that a fresh agent picks it up. That was never verified, and the module it depends on had no tests.

Verified on hardware, with Qwen3.6-35B-A3B-FP8 serving on a GB10:

- `kill -9` on the agent — the container kept running
- a fresh agent reported `running="qwen3.6-35b-a3b-fp8-bf16head"`
- it read the container's log, scraped its `/metrics`, and stopped it

Seeing is not adopting; the stop is what proves it.

It works because nothing is remembered from a launch this process performed — the container and the port are asked of the container runtime every time. Six tests pin that down:

- The port comes from the running container's own arguments, in both the spaced and `=` forms. A launch can override the port, and trusting the recipe would scrape whatever else happened to be on the default, then report another model's throughput under this one's name.
- A launch naming no port is refused rather than guessed.
- Logs list stopped containers too. A launch that has exited is exactly the one whose log an operator wants, and listing only running ones would answer "no such launch" at the moment the question matters most.
- Sampling is refused for an exited container: a rate needs a live engine, and the last scrape of a dead one is not news.

## 2. GHSA-r6v5-fh4h-64xc — take the patched `time`

`time` < 0.3.47 can be driven to stack exhaustion by untrusted RFC 2822 input. The patched release requires Rust 1.88, so the MSRV moves with it.

**We are almost certainly not on the vulnerable path.** `time` reaches us only through `rcgen` and `yasna`, which format ASN.1 certificate validity dates rather than parsing RFC 2822 from anywhere untrusted. But this project exists because a dependency could not be trusted, and annotating a known advisory as not-our-problem is the posture it was built to reject.

**The MSRV bump is the real cost, and it is worth naming.** `rust-toolchain.toml` already pins 1.93.1, so contributors are unaffected, and users install prebuilt binaries — it narrows only who can `cargo install` from source. If you would rather hold 1.85 and carry a documented exception in `deny.toml` instead, say so and I will swap it; the commit is self-contained.

One consequence: 1.88 enables let-chains, so clippy's MSRV-aware `collapsible_if` now fires where it previously could not. Fixed in the discovery loop.

406 tests pass, clippy clean, every file under the 500-line cap.
