### PR TITLE
fix(security): parse the rendezvous address before it reaches argv

### DIFF
--- a/crates/atlasctl-core/src/docker/translate.rs
+++ b/crates/atlasctl-core/src/docker/translate.rs
@@ -88,6 +88,25 @@ pub enum TranslateError {
         /// Nodes the placement offers.
         supplied: u32,
     },
+
+    /// The rendezvous address is not an address.
+    ///
+    /// It arrives from the head over the peer channel and is the one value in a
+    /// rank's command line that a rank cannot derive for itself. Everything
+    /// else the head sends is bounded by the settings schema; without this,
+    /// this one field was an unbounded string going straight into argv, which
+    /// let a paired head append serve flags to another machine's command line.
+    #[error(
+        "{name}: rendezvous address {addr:?} is not an IP address. The head \
+         chooses it from addresses this fleet actually reported, so anything \
+         else means the plan did not come from where it claims."
+    )]
+    BadRendezvousAddress {
+        /// Recipe name.
+        name: String,
+        /// What was offered.
+        addr: String,
+    },
 }
 
 /// The injected policy a launch runs under.
@@ -160,6 +179,14 @@ pub fn translate(
         serve_flags.push(rank.to_string());
         serve_flags.push("--world-size".into());
         serve_flags.push(world_size.to_string());
+        // Parsed, not trusted. This is the only value in a rank's command line
+        // that comes from another machine, and it reaches argv directly.
+        if master_addr.parse::<std::net::IpAddr>().is_err() {
+            return Err(TranslateError::BadRendezvousAddress {
+                name: recipe.name.clone(),
+                addr: master_addr.clone(),
+            });
+        }
         serve_flags.push("--master-addr".into());
         serve_flags.push(master_addr.clone());
         serve_flags.push("--master-port".into());

--- a/crates/atlasctl-core/src/docker/translate/tests.rs
+++ b/crates/atlasctl-core/src/docker/translate/tests.rs
@@ -250,3 +250,234 @@ fn the_same_recipe_translates_on_a_different_vendor_without_special_casing() {
     assert!(amd.docker.to_string().contains("/dev/kfd"));
     assert!(!amd.docker.to_string().contains("--gpus"));
 }
+
+/// The whole-pipeline form of the argv-purity property.
+///
+/// [`crate::settings`] already proves no *setting* can render into something
+/// flag-shaped. This proves the stronger thing the security model actually
+/// rests on: that after a hostile override map has been validated, translated
+/// and rendered, **every `-`-prefixed element of the final docker argv came
+/// from a static table in this crate.** Nothing a client sends can become an
+/// option, at any layer.
+///
+/// It runs over the whole flag table rather than a chosen few, so a flag added
+/// without thought is caught here rather than in the field.
+mod argv_purity {
+    use super::*;
+    use crate::flags::ATLAS_FLAGS;
+    use crate::settings;
+    use std::collections::BTreeSet;
+
+    /// Every `-`-prefixed token this crate is allowed to emit.
+    ///
+    /// Derived from the static tables rather than typed out, so that changing
+    /// the profile or adding a flag cannot silently widen what this test
+    /// accepts. Some options are emitted joined (`--cap-add=IPC_LOCK`) and some
+    /// separated (`--security-opt` then its value), so both forms are built
+    /// from the same source.
+    fn permitted() -> BTreeSet<String> {
+        let mut ok: BTreeSet<String> = ATLAS_FLAGS.iter().map(|f| f.flag.to_string()).collect();
+        let p = &ROOTLESS_V1;
+
+        ok.insert(format!("--ipc={}", p.ipc));
+        ok.insert(format!("--network={}", p.network));
+        ok.insert(format!("--shm-size={}", p.shm_size));
+        for c in p.cap_add {
+            ok.insert(format!("--cap-add={c}"));
+        }
+        if p.privileged {
+            ok.insert("--privileged".into());
+        }
+
+        // Options whose value is a separate argv element, plus the renderer's
+        // own fixed tokens.
+        for t in [
+            "-d",
+            "--rm",
+            "--name",
+            "--entrypoint",
+            "--user",
+            "-v",
+            "-e",
+            "--label",
+            "--gpus",
+            "--device",
+            "--security-opt",
+            "--ulimit",
+            "--restart",
+            "--group-add",
+        ] {
+            ok.insert(t.to_string());
+        }
+        // Rank placement, emitted by translate itself.
+        for t in ["--rank", "--world-size", "--master-addr", "--master-port"] {
+            ok.insert(t.to_string());
+        }
+        ok
+    }
+
+    /// Values a hostile client might try, shaped to become options or to break
+    /// out of an argument.
+    fn hostile() -> Vec<ScalarValue> {
+        vec![
+            ScalarValue::Str("--privileged".into()),
+            ScalarValue::Str("-v /:/host".into()),
+            ScalarValue::Str("--entrypoint=/bin/sh".into()),
+            ScalarValue::Str("; rm -rf /".into()),
+            ScalarValue::Str("$(id -u)".into()),
+            ScalarValue::Str("`whoami`".into()),
+            ScalarValue::Str("a b --gpus all".into()),
+            ScalarValue::Str("--".into()),
+            ScalarValue::Str("-".into()),
+            ScalarValue::Int(-1),
+            ScalarValue::Int(i64::MIN),
+            ScalarValue::Float(-1.0),
+            ScalarValue::Float(f64::NAN),
+            ScalarValue::Float(f64::INFINITY),
+            ScalarValue::Bool(true),
+        ]
+    }
+
+    fn wire(v: &ScalarValue) -> atlasctl_protocol::settings::SettingValue {
+        use atlasctl_protocol::settings::SettingValue as S;
+        match v {
+            ScalarValue::Bool(b) => S::Bool(*b),
+            ScalarValue::Int(i) => S::Int(*i),
+            ScalarValue::Float(f) => S::Float(*f),
+            ScalarValue::Str(s) => S::Str(s.clone()),
+        }
+    }
+
+    #[test]
+    fn no_client_value_can_become_an_option_in_the_final_argv() {
+        let allowed = permitted();
+        let r = recipe("");
+        let mut accepted = 0usize;
+
+        for spec in &ATLAS_FLAGS {
+            for v in hostile() {
+                let req = [(spec.key.to_string(), wire(&v))].into_iter().collect();
+                // Most of these are refused outright, which is the first line of
+                // defence. The interesting ones are those that get through.
+                let Ok(overrides) = settings::validate(&req) else {
+                    continue;
+                };
+                accepted += 1;
+
+                let plan = translate(
+                    &r,
+                    &overrides,
+                    &UserConfig::new(),
+                    &host(),
+                    &Placement::Solo,
+                    &ctx(&NvidiaDevices),
+                )
+                .expect("a validated override must still translate");
+
+                for arg in plan.docker.to_argv() {
+                    assert!(
+                        !arg.starts_with('-') || allowed.contains(&arg),
+                        "`{}` = {v:?} produced the option {arg:?}",
+                        spec.key
+                    );
+                }
+            }
+        }
+
+        // If nothing were ever accepted the loop would prove nothing at all.
+        assert!(
+            accepted > 0,
+            "no hostile value was accepted, so this test asserted nothing"
+        );
+    }
+
+    /// The rendezvous address is the one value in a rank's command line that
+    /// comes from another machine, and it reached argv directly. This test
+    /// found that: `master_addr = "--privileged"` emitted `--privileged` as its
+    /// own argv element, letting a paired head append serve flags to another
+    /// machine's command line.
+    #[test]
+    fn a_rendezvous_address_that_is_not_an_address_is_refused() {
+        let r = recipe("min_nodes: 2\nmax_nodes: 2\n");
+
+        for addr in [
+            "--privileged",
+            "-v /:/host",
+            "10.0.0.1 --gpus all",
+            "; rm -rf /",
+            "",
+            "$(hostname)",
+            "head.local",
+        ] {
+            let out = translate(
+                &r,
+                &BTreeMap::new(),
+                &UserConfig::new(),
+                &host(),
+                &Placement::Rank {
+                    rank: 1,
+                    world_size: 2,
+                    master_addr: addr.to_string(),
+                    master_port: 29500,
+                },
+                &ctx(&NvidiaDevices),
+            );
+            assert!(
+                matches!(out, Err(TranslateError::BadRendezvousAddress { .. })),
+                "master_addr {addr:?} was accepted"
+            );
+        }
+    }
+
+    /// The addresses a fleet actually reports still work, in both families.
+    #[test]
+    fn a_real_rendezvous_address_still_translates() {
+        let allowed = permitted();
+        let r = recipe("min_nodes: 2\nmax_nodes: 2\n");
+
+        for addr in ["10.10.10.9", "192.168.1.4", "::1", "fe80::1"] {
+            let plan = translate(
+                &r,
+                &BTreeMap::new(),
+                &UserConfig::new(),
+                &host(),
+                &Placement::Rank {
+                    rank: 1,
+                    world_size: 2,
+                    master_addr: addr.to_string(),
+                    master_port: 29500,
+                },
+                &ctx(&NvidiaDevices),
+            )
+            .unwrap_or_else(|e| panic!("{addr} must translate: {e}"));
+
+            let argv = plan.docker.to_argv();
+            assert!(argv.contains(&addr.to_string()), "{addr} missing from argv");
+            for arg in argv {
+                assert!(
+                    !arg.starts_with('-') || allowed.contains(&arg),
+                    "{addr} produced the option {arg:?}"
+                );
+            }
+        }
+    }
+
+    /// argv is a vector, never a shell string, so a value containing a
+    /// separator stays one inert argument.
+    #[test]
+    fn a_value_with_shell_syntax_stays_a_single_argument() {
+        let req = [(
+            "served_model_name".to_string(),
+            atlasctl_protocol::settings::SettingValue::Str("a; rm -rf /".into()),
+        )]
+        .into_iter()
+        .collect();
+
+        // It is a denied key, so it never even reaches translate — which is the
+        // stronger answer, and the one the schema exists to give.
+        assert!(
+            settings::validate(&req).is_err(),
+            "an unbounded string must not be settable from a client"
+        );
+    }
+}


### PR DESCRIPTION
Found by writing the whole-pipeline argv-purity test the plan asks for but that did not exist.

## The gap

Every value a client sends is bounded by the settings schema, and `atlasctl-core/src/settings` already proves none of them can render into something flag-shaped. **The rendezvous address was not one of those.** It arrives from the head over the peer channel, it is the one value in a rank's command line that a rank cannot derive for itself, and it went into argv as an unbounded string.

So `master_addr = "--privileged"` emitted `--privileged` as its own argv element.

It lands among the serve arguments rather than docker's, so it could not make a container privileged. But it let a **paired head append serve flags to another machine's command line** — exactly the bounded-input rule the two-phase design states and did not enforce:

> `CommHints` carries only bounded, validated scalars a worker genuinely cannot self-derive, each range-checked.

## The fix

The address is parsed as an `IpAddr` before it reaches argv. The head chooses it from addresses the fleet actually reported, so anything else means the plan did not come from where it claims. Both families work; hostnames do not, deliberately.

## The test that found it

Runs the **whole flag table** through hostile values — shell metacharacters, option-shaped strings, `--`, negative and non-finite numbers — validates them, translates them, and asserts every `-`-prefixed element of the final docker argv came from a static table in this crate.

Two details that keep it from rotting:

- The permitted set is **derived** from the flag table and the launch profile rather than typed out, so changing either cannot silently widen what the test accepts. (Writing it out by hand is what initially made it fail on `--cap-add=IPC_LOCK`, which is the renderer's joined form.)
- It asserts at least one hostile value survived validation. A test where everything is rejected before it reaches the code under test proves nothing, and would keep passing if validation later became a no-op.

## Verified

410 tests pass, clippy clean, every file under the 500-line cap. After the change, a real two-node preview still renders both ranks across the two GB10 Sparks.
