### PR TITLE
fix(cluster): choose, verify and pin the link the collective runs on

### DIFF
--- a/crates/atlasctl-agent/src/cluster.rs
+++ b/crates/atlasctl-agent/src/cluster.rs
@@ -162,9 +162,14 @@ pub fn plan(
         .iter()
         .find(|n| n.id == head)
         .ok_or(PlanError::HeadNotSelected)?;
-    let master = head_node
-        .preferred_address()
-        .ok_or_else(|| PlanError::NoUsableLink {
+    // Not simply the head's best link. A DGX Spark carries several
+    // point-to-point RoCE links, and `preferred_address` ranks by link *class*
+    // — so with two RoCE ports it returns whichever sorts first, which is a
+    // coin flip as to whether the workers are on it. Choosing wrong is not a
+    // slow cluster but a hung one: the workers sit at the collective barrier
+    // retrying a connection that will never complete.
+    let master =
+        rendezvous_address(head_node, selected).ok_or_else(|| PlanError::NoUsableLink {
             name: head_node.name.to_string(),
         })?;
 
@@ -233,6 +238,52 @@ pub fn new_epoch() -> String {
     })
 }
 
+/// Choose an address on the head that every worker shares a subnet with.
+///
+/// Preference order is the head's own — best link class first — so among
+/// addresses the workers can all reach, the fastest still wins. Only when no
+/// address is demonstrably shared does this fall back to the head's favourite,
+/// because a worker whose subnets are unknown (paired but never dialled, or
+/// running an older agent that does not report them) would otherwise make the
+/// launch impossible rather than merely uncertain. The workers re-check
+/// reachability at prepare, so a wrong guess is refused rather than hung.
+#[must_use]
+fn rendezvous_address<'a>(
+    head: &'a NodeDescriptor,
+    selected: &[&NodeDescriptor],
+) -> Option<&'a atlasctl_protocol::fleet::NodeAddress> {
+    let workers: Vec<&NodeDescriptor> = selected
+        .iter()
+        .copied()
+        .filter(|n| n.id != head.id)
+        .collect();
+
+    // Same filter and ordering as `preferred_address`, because sharing a
+    // subnet is a tiebreak between *usable* links, not a licence to promote an
+    // unusable one. Without this a docker bridge wins: every machine has one on
+    // the same private range, so it "shares a subnet" with everything, and the
+    // collective would be pointed at a local bridge that reaches no other node.
+    let shared = head
+        .addresses
+        .iter()
+        .filter(|a| a.class.usable_for_cluster() && a.prefix_len > 0)
+        .filter(|candidate| {
+            workers.iter().all(|w| {
+                w.addresses.iter().any(|a| {
+                    a.class.usable_for_cluster()
+                        && crate::rendezvous::shares_network(
+                            &candidate.addr,
+                            candidate.prefix_len,
+                            &a.addr,
+                        )
+                })
+            })
+        })
+        .max_by_key(|a| (a.class.rank(), a.speed_mbps.unwrap_or(0)));
+
+    shared.or_else(|| head.preferred_address())
+}
+
 /// What a worker says when asked to prepare.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "result", rename_all = "snake_case")]
@@ -281,6 +332,15 @@ pub enum RefusalReason {
         /// Which recipe the outstanding reservation is for.
         recipe: String,
     },
+    /// The rendezvous address is on a link this node is not attached to.
+    ///
+    /// Separate from every other refusal because it is the one an operator can
+    /// act on directly, and because without it the failure is not a refusal at
+    /// all -- the rank starts, waits at the collective barrier, and retries
+    /// until somebody reads the logs.
+    #[error("{0}")]
+    RendezvousUnreachable(String),
+
     /// The container runtime is unavailable.
     #[error("the container runtime is not answering on this node")]
     DockerUnavailable,

--- a/crates/atlasctl-agent/src/cluster/tests.rs
+++ b/crates/atlasctl-agent/src/cluster/tests.rs
@@ -12,6 +12,8 @@ fn addr(iface: &str, a: &str, class: LinkClass, speed: Option<u32>) -> NodeAddre
         class,
         speed_mbps: speed,
         rdma: matches!(class, LinkClass::Roce | LinkClass::InfiniBand),
+        // Point-to-point, like the RoCE links on a real Spark.
+        prefix_len: 30,
     }
 }
 
@@ -303,4 +305,109 @@ fn a_recipe_that_differs_between_nodes_refuses_and_says_both_hashes() {
         msg.contains("same atlasctl"),
         "must say how to fix it: {msg}"
     );
+}
+
+/// The head must offer an address the workers are actually attached to.
+///
+/// A DGX Spark carries several point-to-point RoCE links. Ranking by link
+/// class alone returns whichever sorts first, and on the real pair that was
+/// the head's *other* port — the workers hung at the collective barrier.
+mod rendezvous_choice {
+    use super::*;
+
+    /// dgx1's two RoCE ports; only 10.10.10.9/30 reaches the peer.
+    fn head_with_two_roce() -> NodeDescriptor {
+        node(
+            1,
+            "spark-256a",
+            vec![
+                addr("enp1s0f1np1", "10.10.10.13", LinkClass::Roce, Some(200_000)),
+                addr("enp1s0f0np0", "10.10.10.9", LinkClass::Roce, Some(200_000)),
+            ],
+        )
+    }
+
+    fn peer_on_first_link() -> NodeDescriptor {
+        node(
+            2,
+            "spark-43fa",
+            vec![
+                addr("enp1s0f0np0", "10.10.10.10", LinkClass::Roce, Some(200_000)),
+                addr("enp1s0f1np1", "10.10.10.17", LinkClass::Roce, Some(200_000)),
+            ],
+        )
+    }
+
+    #[test]
+    fn it_picks_the_link_the_worker_is_on() {
+        let head = head_with_two_roce();
+        let peer = peer_on_first_link();
+        let sel = vec![&head, &peer];
+        let p = plan(
+            "r",
+            "hash",
+            2,
+            &sel,
+            head.id,
+            &BTreeMap::new(),
+            "e".to_owned(),
+        )
+        .expect("plans");
+        assert_eq!(
+            p.ranks[0].master_addr, "10.10.10.9",
+            "must choose the shared /30, not the head's other RoCE port"
+        );
+        assert!(p.ranks.iter().all(|r| r.master_addr == "10.10.10.9"));
+    }
+
+    /// Among addresses every worker can reach, the head's own ordering still
+    /// decides — a shared ethernet link must not beat a shared RoCE one.
+    #[test]
+    fn among_shared_links_the_faster_class_still_wins() {
+        let head = node(
+            1,
+            "head",
+            vec![
+                addr("enp1s0f0np0", "10.10.10.9", LinkClass::Roce, Some(200_000)),
+                addr("eth0", "192.168.1.2", LinkClass::Ethernet, Some(1000)),
+            ],
+        );
+        let peer = node(
+            2,
+            "peer",
+            vec![
+                addr("enp1s0f0np0", "10.10.10.10", LinkClass::Roce, Some(200_000)),
+                addr("eth0", "192.168.1.3", LinkClass::Ethernet, Some(1000)),
+            ],
+        );
+        let sel = vec![&head, &peer];
+        let p = plan("r", "h", 2, &sel, head.id, &BTreeMap::new(), "e".to_owned()).expect("plans");
+        assert_eq!(p.ranks[0].master_addr, "10.10.10.9");
+    }
+
+    /// A worker whose subnets are unknown — an older agent, or one never
+    /// dialled — must not make the launch impossible. The rank re-checks
+    /// reachability at prepare, so a guess is refused rather than hung.
+    #[test]
+    fn an_unknown_worker_subnet_falls_back_rather_than_failing() {
+        let head = head_with_two_roce();
+        let mut peer = peer_on_first_link();
+        for a in &mut peer.addresses {
+            a.prefix_len = 0;
+        }
+        let sel = vec![&head, &peer];
+        let p = plan("r", "h", 2, &sel, head.id, &BTreeMap::new(), "e".to_owned()).expect("plans");
+        // Falls back to the head's preferred address rather than refusing.
+        assert!(!p.ranks[0].master_addr.is_empty());
+    }
+
+    /// A single-node plan has no worker to share a link with, and must still
+    /// produce an address.
+    #[test]
+    fn a_solo_plan_still_gets_an_address() {
+        let head = head_with_two_roce();
+        let sel = vec![&head];
+        let p = plan("r", "h", 1, &sel, head.id, &BTreeMap::new(), "e".to_owned()).expect("plans");
+        assert!(!p.ranks[0].master_addr.is_empty());
+    }
 }

--- a/crates/atlasctl-agent/src/clusterdriver.rs
+++ b/crates/atlasctl-agent/src/clusterdriver.rs
@@ -65,6 +65,17 @@ struct Running {
     started: Vec<RankStarted>,
 }
 
+impl Target {
+    /// Enough of a target to ask whether its rank is alive.
+    fn clone_shallow(&self) -> Self {
+        Self {
+            assignment: self.assignment.clone(),
+            addr: self.addr,
+            name: self.name.clone(),
+        }
+    }
+}
+
 /// A prepare that has been accepted and is waiting to be committed.
 struct Pending {
     epoch: String,
@@ -341,6 +352,53 @@ impl ClusterControl for ClusterDriver {
         }
     }
 
+    fn supervise(&self) -> Option<String> {
+        // Read the roster under the lock, then release it: asking a peer
+        // whether it is alive dials the network, and holding the lock across
+        // that would block a stop the operator asked for.
+        let (targets, started) = {
+            let held = self.running.lock().expect("running lock poisoned");
+            let r = held.as_ref()?;
+            (
+                r.targets
+                    .iter()
+                    .map(Target::clone_shallow)
+                    .collect::<Vec<_>>(),
+                r.started.clone(),
+            )
+        };
+
+        let mut dead = Vec::new();
+        for r in &started {
+            let Some(t) = targets.iter().find(|t| t.assignment.node == r.node) else {
+                continue;
+            };
+            let alive = match t.addr {
+                None => self.rank.alive(&r.container).unwrap_or(false),
+                // Unreachable is not alive. A rank we cannot ask is not one we
+                // can count as part of a whole cluster — and if the answer is
+                // wrong, tearing down is the cheap mistake.
+                Some(addr) => self
+                    .transport
+                    .alive(t.assignment.node, addr, &r.container)
+                    .unwrap_or(false),
+            };
+            if !alive {
+                dead.push(t.name.to_string());
+            }
+        }
+        if dead.is_empty() {
+            return None;
+        }
+
+        let _ = self.stop_cluster();
+        Some(format!(
+            "{} stopped, so the cluster was torn down. A half cluster waits at a \
+             rendezvous that will never complete while its survivors hold their GPUs.",
+            dead.join(" and ")
+        ))
+    }
+
     fn stop_cluster(&self) -> Result<Vec<RankStarted>, String> {
         let running = self
             .running
@@ -371,6 +429,14 @@ impl ClusterControl for ClusterDriver {
         } else {
             Err(format!("could not stop {}", failures.join("; ")))
         }
+    }
+}
+
+#[cfg(test)]
+impl ClusterDriver {
+    /// Mark a rank's container dead, so supervision has something to find.
+    pub(crate) fn kill_for_test(&self, node: NodeId) {
+        self.transport.kill_for_test(node);
     }
 }
 

--- a/crates/atlasctl-agent/src/clusterdriver/cases.rs
+++ b/crates/atlasctl-agent/src/clusterdriver/cases.rs
@@ -415,3 +415,45 @@ fn a_cluster_that_failed_to_settle_is_not_recorded_as_running() {
         "nothing is running, so there is nothing to stop"
     );
 }
+
+/// The gap the settle gate cannot close.
+///
+/// A rank that dies four minutes in — during model build — passed the
+/// five-second gate. Its peers then hold their GPUs indefinitely, waiting at a
+/// rendezvous that will never complete, and nothing notices.
+#[test]
+fn a_rank_that_dies_after_commit_tears_the_cluster_down() {
+    let log = new_log();
+    let (d, _) = driver(ready_rank(&log), transport(&log));
+    let (epoch, _, _) = d
+        .prepare(&recipe(), &all_three(), node_id(1), &BTreeMap::new())
+        .expect("prepares");
+    d.commit(&epoch).expect("commits");
+
+    // It was whole a moment ago.
+    assert!(d.supervise().is_none(), "a healthy cluster is left alone");
+
+    // Now rank 2 dies.
+    d.kill_for_test(node_id(2));
+    let why = d.supervise().expect("a dead rank must be noticed");
+    assert!(why.contains("spark-2"), "must name what died: {why}");
+
+    let c = calls(&log);
+    assert!(
+        c.contains(&"local.stop(head-container)".to_owned()),
+        "the survivors must be stopped: {c:?}"
+    );
+    assert!(
+        d.stop_cluster().is_err(),
+        "the cluster is gone, so there is nothing left to stop"
+    );
+}
+
+/// Supervising when nothing is running must not reach for the network.
+#[test]
+fn supervising_an_idle_agent_does_nothing() {
+    let log = new_log();
+    let (d, _) = driver(ready_rank(&log), transport(&log));
+    assert!(d.supervise().is_none());
+    assert!(calls(&log).is_empty(), "{:?}", calls(&log));
+}

--- a/crates/atlasctl-agent/src/clusterdriver/plan.rs
+++ b/crates/atlasctl-agent/src/clusterdriver/plan.rs
@@ -116,8 +116,17 @@ impl ClusterDriver {
         if node.is_local {
             return Ok(None);
         }
-        let addr = node
-            .preferred_address()
+        // The peer's best address *from here*, not its best address outright.
+        // A Spark answers on several point-to-point links and this machine is
+        // attached to only some of them; picking by class alone dials one that
+        // goes nowhere and times out.
+        let local = self.fleet.nodes();
+        let mine = local
+            .iter()
+            .find(|n| n.is_local)
+            .map(|n| n.addresses.clone())
+            .unwrap_or_default();
+        let addr = crate::rendezvous::best_reachable(&node.addresses, &mine)
             .ok_or_else(|| format!("{} has no usable network link", node.name))?;
         format!("{}:{}", addr.addr, self.peer_port)
             .parse()

--- a/crates/atlasctl-agent/src/clusterdriver/tests.rs
+++ b/crates/atlasctl-agent/src/clusterdriver/tests.rs
@@ -121,6 +121,8 @@ pub(super) struct FixtureTransport {
     prepare: BTreeMap<NodeId, PrepareReply>,
     commit: BTreeMap<NodeId, Result<String, String>>,
     dead: BTreeMap<NodeId, bool>,
+    /// Ranks killed mid-run by a test, after commit succeeded.
+    killed: StdMutex<std::collections::BTreeSet<NodeId>>,
 }
 
 impl FixtureTransport {
@@ -130,6 +132,7 @@ impl FixtureTransport {
             prepare: BTreeMap::new(),
             commit: BTreeMap::new(),
             dead: BTreeMap::new(),
+            killed: StdMutex::new(std::collections::BTreeSet::new()),
         }
     }
     /// A peer whose container does not survive its own start.
@@ -185,10 +188,16 @@ impl RankTransport for FixtureTransport {
     }
     fn alive(&self, node: NodeId, _: SocketAddr, container: &str) -> anyhow::Result<bool> {
         self.note(format!("{}.alive({container})", node.short()));
+        if self.killed.lock().expect("killed lock").contains(&node) {
+            return Ok(false);
+        }
         Ok(!self.dead.get(&node).copied().unwrap_or(false))
     }
     fn stop(&self, node: NodeId, _: SocketAddr, container: &str) {
         self.note(format!("{}.stop({container})", node.short()));
+    }
+    fn kill_for_test(&self, node: NodeId) {
+        self.killed.lock().expect("killed lock").insert(node);
     }
 }
 

--- a/crates/atlasctl-agent/src/clusterdriver/tests.rs
+++ b/crates/atlasctl-agent/src/clusterdriver/tests.rs
@@ -35,6 +35,7 @@ fn descriptor(seed: u8, local: bool) -> NodeDescriptor {
             addr: format!("10.0.0.{seed}"),
             class: LinkClass::Roce,
             speed_mbps: Some(200_000),
+            prefix_len: 30,
             rdma: true,
         }],
         launchability: Launchability::yes(),

--- a/crates/atlasctl-agent/src/daemon.rs
+++ b/crates/atlasctl-agent/src/daemon.rs
@@ -133,6 +133,7 @@ fn spawn_peer_listener(
                     fleet.can_launch(),
                     "",
                     vitals,
+                    &fleet.local_addresses(),
                 )
                 .await
                 .is_err()
@@ -169,7 +170,16 @@ fn spawn_peer_poll(
                     continue;
                 };
                 let link = fleet.classify_peer_address(&addr);
-                match crate::peer::link::query(&identity, pins.clone(), sock, id, link).await {
+                match crate::peer::link::query(
+                    &identity,
+                    pins.clone(),
+                    sock,
+                    id,
+                    link,
+                    &fleet.local_addresses(),
+                )
+                .await
+                {
                     Ok(report) => {
                         fleet.record_report(report);
                         if let Some(node) = fleet.nodes().into_iter().find(|n| n.id == id) {

--- a/crates/atlasctl-agent/src/fabric.rs
+++ b/crates/atlasctl-agent/src/fabric.rs
@@ -32,7 +32,10 @@ mod tests;
 pub struct RawIface {
     /// Interface name.
     pub name: String,
-    /// IPv4 addresses bound to it, without the prefix length.
+    /// IPv4 addresses bound to it, each as `host/prefix`.
+    ///
+    /// The prefix is kept because it is the only thing that says which of four
+    /// point-to-point RoCE links reaches a given peer.
     pub addrs: Vec<String>,
     /// Whether the kernel reports a carrier.
     pub carrier: bool,
@@ -82,6 +85,18 @@ pub fn classify(raw: &RawIface) -> LinkClass {
     LinkClass::Ethernet
 }
 
+/// Split `10.10.10.9/30` into its host and prefix.
+///
+/// A bare address means an unknown subnet, reported as `0` rather than guessed:
+/// claiming `/32` would say "shares a link with nothing", and claiming `/24`
+/// would say the opposite. Both are inventions; zero is the truth.
+fn split_prefix(raw: &str) -> (String, u8) {
+    match raw.split_once('/') {
+        Some((host, len)) => (host.to_owned(), len.parse().unwrap_or(0)),
+        None => (raw.to_owned(), 0),
+    }
+}
+
 /// Turn a raw interface table into the addresses a peer may be reached on.
 ///
 /// Drops anything with no address, no carrier, or a class that cannot carry a
@@ -94,12 +109,16 @@ pub fn usable_addresses(raws: &[RawIface]) -> Vec<NodeAddress> {
         .filter(|r| r.carrier)
         .flat_map(|r| {
             let class = classify(r);
-            r.addrs.iter().map(move |addr| NodeAddress {
-                iface: r.name.clone(),
-                addr: addr.clone(),
-                class,
-                speed_mbps: r.speed_mbps,
-                rdma: r.rdma,
+            r.addrs.iter().map(move |raw| {
+                let (host, prefix) = split_prefix(raw);
+                NodeAddress {
+                    iface: r.name.clone(),
+                    addr: host,
+                    class,
+                    speed_mbps: r.speed_mbps,
+                    rdma: r.rdma,
+                    prefix_len: prefix,
+                }
             })
         })
         .filter(|a| a.class.usable_for_cluster())

--- a/crates/atlasctl-agent/src/fabric/linux.rs
+++ b/crates/atlasctl-agent/src/fabric/linux.rs
@@ -49,28 +49,44 @@ fn read_trimmed(path: &Path) -> Option<String> {
 /// `rocep1s0f0 -> enp1s0f0np0`, which is exactly how a RoCE port is told apart
 /// from an ordinary NIC that happens to be fast.
 fn rdma_backed_interfaces() -> BTreeSet<String> {
-    let mut out = BTreeSet::new();
+    rdma_devices_by_interface().into_keys().collect()
+}
+
+/// Which RDMA device backs each network interface.
+///
+/// The mapping, not just the set. NCCL is told *which* device to use, and on a
+/// machine with four RoCE ports the difference between `rocep1s0f0` and
+/// `rocep1s0f1` is the difference between a collective that runs and one that
+/// times out at `ibv_modify_qp`.
+pub fn rdma_devices_by_interface() -> BTreeMap<String, String> {
+    let mut out = BTreeMap::new();
     let Ok(devices) = std::fs::read_dir(IB_DIR) else {
         return out;
     };
     for dev in devices.flatten() {
+        let Some(ibdev) = dev.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
         let net = dev.path().join("device").join("net");
         let Ok(entries) = std::fs::read_dir(net) else {
             continue;
         };
         for e in entries.flatten() {
             if let Some(name) = e.file_name().to_str() {
-                out.insert(name.to_owned());
+                out.insert(name.to_owned(), ibdev.clone());
             }
         }
     }
     out
 }
 
-/// IPv4 addresses per interface.
+/// IPv4 addresses per interface, each as `host/prefix`.
 ///
-/// The prefix length is dropped: a peer address is a host address, and keeping
-/// `/30` around would only invite someone to parse it again later.
+/// The prefix is kept. An earlier version dropped it — "a peer address is a
+/// host address" — and that is exactly the information needed to tell which of
+/// four point-to-point RoCE links reaches a given peer. Without it the head
+/// chose a rendezvous address on a link the worker was not attached to, and
+/// the cluster hung at the NCCL barrier.
 fn addresses_by_interface() -> Result<BTreeMap<String, Vec<String>>> {
     let out = Command::new("ip")
         .args(["-o", "-4", "addr", "show"])
@@ -89,10 +105,9 @@ fn addresses_by_interface() -> Result<BTreeMap<String, Vec<String>>> {
         else {
             continue;
         };
-        let host = addr.split('/').next().unwrap_or(addr);
         map.entry(iface.to_owned())
             .or_default()
-            .push(host.to_owned());
+            .push(addr.to_owned());
     }
     Ok(map)
 }

--- a/crates/atlasctl-agent/src/fleet.rs
+++ b/crates/atlasctl-agent/src/fleet.rs
@@ -141,6 +141,16 @@ impl LocalFleet {
         self
     }
 
+    /// This machine's own addresses, with their subnets.
+    ///
+    /// Told to peers over the authenticated channel, because a rendezvous
+    /// address has to be one every rank can reach and only a node knows which
+    /// links it is attached to.
+    #[must_use]
+    pub fn local_addresses(&self) -> Vec<NodeAddress> {
+        self.local_addresses.clone()
+    }
+
     /// Re-read what is running here, and report whether it changed.
     ///
     /// Returns the new value only when it differs, so a caller can push an

--- a/crates/atlasctl-agent/src/fleet/listing.rs
+++ b/crates/atlasctl-agent/src/fleet/listing.rs
@@ -57,6 +57,12 @@ impl FleetView for LocalFleet {
                 // machine look unreachable-and-addressless.
                 addresses: report
                     .map(|r| {
+                        // What the peer said about its own links, when it said
+                        // anything: it is the only source that knows subnets,
+                        // and it came over the authenticated channel.
+                        if !r.addresses.is_empty() {
+                            return r.addresses.clone();
+                        }
                         // Reached and authenticated, so the link class is ours
                         // to state rather than a guess.
                         vec![NodeAddress {
@@ -64,6 +70,8 @@ impl FleetView for LocalFleet {
                             addr: pin.last_address.clone().unwrap_or_default(),
                             class: r.link,
                             speed_mbps: None,
+                            // A pin records a host address, never its subnet.
+                            prefix_len: 0,
                             rdma: matches!(
                                 r.link,
                                 atlasctl_protocol::fleet::LinkClass::Roce
@@ -82,6 +90,8 @@ impl FleetView for LocalFleet {
                                             addr: a.clone(),
                                             class: atlasctl_protocol::fleet::LinkClass::Unverified,
                                             speed_mbps: None,
+                                            // Last known host address; no subnet.
+                                            prefix_len: 0,
                                             rdma: false,
                                         }]
                                     })
@@ -189,6 +199,8 @@ fn addresses_of(beacon: &Beacon) -> Vec<NodeAddress> {
             addr: a.to_string(),
             class: atlasctl_protocol::fleet::LinkClass::Unverified,
             speed_mbps: None,
+            // A beacon carries observed host addresses, not interface subnets.
+            prefix_len: 0,
             rdma: false,
         })
         .collect()

--- a/crates/atlasctl-agent/src/fleet/tests.rs
+++ b/crates/atlasctl-agent/src/fleet/tests.rs
@@ -35,6 +35,7 @@ fn roce(addr: &str) -> NodeAddress {
         addr: addr.to_owned(),
         class: LinkClass::Roce,
         speed_mbps: Some(200_000),
+        prefix_len: 30,
         rdma: true,
     }
 }

--- a/crates/atlasctl-agent/src/lib.rs
+++ b/crates/atlasctl-agent/src/lib.rs
@@ -18,6 +18,7 @@ pub mod logs;
 pub mod pairing;
 pub mod peer;
 pub mod rank;
+pub mod rendezvous;
 pub mod server;
 pub mod session;
 pub mod telemetry;

--- a/crates/atlasctl-agent/src/peer/cluster.rs
+++ b/crates/atlasctl-agent/src/peer/cluster.rs
@@ -71,7 +71,7 @@ pub async fn preview_rank(
     assignment: RankAssignment,
 ) -> Result<(String, Vec<String>)> {
     let mut tls = dial(identity, pins, addr, expect).await?;
-    exchange_hello(&mut tls, addr).await?;
+    exchange_hello(&mut tls, addr, &[]).await?;
     write_frame(
         &mut tls,
         &PeerFrame::PreviewRank {
@@ -107,7 +107,7 @@ pub async fn prepare_rank(
     assignment: RankAssignment,
 ) -> Result<PrepareReply> {
     let mut tls = dial(identity, pins, addr, expect).await?;
-    exchange_hello(&mut tls, addr).await?;
+    exchange_hello(&mut tls, addr, &[]).await?;
     write_frame(
         &mut tls,
         &PeerFrame::Prepare {
@@ -147,7 +147,7 @@ pub async fn commit_rank(
     epoch: &str,
 ) -> Result<String> {
     let mut tls = dial(identity, pins, addr, expect).await?;
-    exchange_hello(&mut tls, addr).await?;
+    exchange_hello(&mut tls, addr, &[]).await?;
     write_frame(
         &mut tls,
         &PeerFrame::Commit {
@@ -183,7 +183,7 @@ pub async fn abort_rank(
     epoch: &str,
 ) -> Result<()> {
     let mut tls = dial(identity, pins, addr, expect).await?;
-    exchange_hello(&mut tls, addr).await?;
+    exchange_hello(&mut tls, addr, &[]).await?;
     write_frame(
         &mut tls,
         &PeerFrame::Abort {
@@ -212,7 +212,7 @@ pub async fn rank_alive(
     container: &str,
 ) -> Result<bool> {
     let mut tls = dial(identity, pins, addr, expect).await?;
-    exchange_hello(&mut tls, addr).await?;
+    exchange_hello(&mut tls, addr, &[]).await?;
     write_frame(
         &mut tls,
         &PeerFrame::IsRankAlive {
@@ -245,7 +245,7 @@ pub async fn stop_rank(
     container: &str,
 ) -> Result<()> {
     let mut tls = dial(identity, pins, addr, expect).await?;
-    exchange_hello(&mut tls, addr).await?;
+    exchange_hello(&mut tls, addr, &[]).await?;
     write_frame(
         &mut tls,
         &PeerFrame::StopRank {

--- a/crates/atlasctl-agent/src/peer/link.rs
+++ b/crates/atlasctl-agent/src/peer/link.rs
@@ -29,6 +29,19 @@ use std::time::Duration;
 /// How long to wait for a peer to answer before treating it as down.
 pub const DIAL_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// What a peer said when it introduced itself.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Hello {
+    /// Its display name.
+    pub name: String,
+    /// Whether it can run a model.
+    pub can_launch: bool,
+    /// Its accelerator tag.
+    pub accelerator: String,
+    /// The addresses it is reachable on, with subnets.
+    pub addresses: Vec<atlasctl_protocol::fleet::NodeAddress>,
+}
+
 /// What a peer told us about itself over the authenticated channel.
 ///
 /// Distinct from a beacon: everything here was said by something holding the
@@ -47,6 +60,12 @@ pub struct PeerReport {
     pub vitals: Option<NodeVitals>,
     /// The class of the link we actually reached it over.
     pub link: LinkClass,
+    /// The addresses it says it is reachable on, with their subnets.
+    ///
+    /// Said over the authenticated channel by something holding the pinned
+    /// key, so it can be believed — unlike a beacon, which reports whatever
+    /// address the multicast arrived from and no subnet at all.
+    pub addresses: Vec<atlasctl_protocol::fleet::NodeAddress>,
 }
 
 /// Dial a pinned peer and complete the mutually authenticated handshake.
@@ -101,7 +120,11 @@ pub async fn dial(
 ///
 /// # Errors
 /// If the peer does not introduce itself back, or speaks another version.
-pub async fn exchange_hello<S>(tls: &mut S, addr: SocketAddr) -> Result<(String, bool, String)>
+pub async fn exchange_hello<S>(
+    tls: &mut S,
+    addr: SocketAddr,
+    local: &[atlasctl_protocol::fleet::NodeAddress],
+) -> Result<Hello>
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
 {
@@ -112,6 +135,7 @@ where
             name: crate::discovery::local_display_name().as_str().to_owned(),
             can_launch: true,
             accelerator: String::new(),
+            addresses: local.to_vec(),
         },
     )
     .await?;
@@ -126,12 +150,18 @@ where
             name,
             can_launch,
             accelerator,
+            addresses,
         } => {
             anyhow::ensure!(
                 version == PEER_PROTOCOL_VERSION,
                 "this node speaks peer protocol {PEER_PROTOCOL_VERSION}, {name} speaks {version}"
             );
-            Ok((name, can_launch, accelerator))
+            Ok(Hello {
+                name,
+                can_launch,
+                accelerator,
+                addresses,
+            })
         }
         other => bail!("expected a hello from {addr}, got {other:?}"),
     }
@@ -156,9 +186,10 @@ pub async fn query(
     addr: SocketAddr,
     expect: NodeId,
     link: LinkClass,
+    local: &[atlasctl_protocol::fleet::NodeAddress],
 ) -> Result<PeerReport> {
     let mut tls = dial(identity, pins, addr, expect).await?;
-    let (name, can_launch, accelerator) = exchange_hello(&mut tls, addr).await?;
+    let hello = exchange_hello(&mut tls, addr, local).await?;
 
     // Vitals are optional: an agent may be up and simply have nothing to say
     // about its hardware, which is not a failure.
@@ -170,11 +201,12 @@ pub async fn query(
 
     Ok(PeerReport {
         node: expect,
-        name,
-        can_launch,
-        accelerator,
+        name: hello.name,
+        can_launch: hello.can_launch,
+        accelerator: hello.accelerator,
         vitals,
         link,
+        addresses: hello.addresses,
     })
 }
 
@@ -192,6 +224,7 @@ pub async fn serve_query<S>(
     can_launch: bool,
     accelerator: &str,
     vitals: Option<NodeVitals>,
+    local: &[atlasctl_protocol::fleet::NodeAddress],
 ) -> Result<()>
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
@@ -209,6 +242,7 @@ where
             name: name.to_owned(),
             can_launch,
             accelerator: accelerator.to_owned(),
+            addresses: local.to_vec(),
         },
     )
     .await?;

--- a/crates/atlasctl-agent/src/peer/pair.rs
+++ b/crates/atlasctl-agent/src/peer/pair.rs
@@ -85,6 +85,9 @@ where
         name: crate::discovery::local_display_name().as_str().to_owned(),
         can_launch: true,
         accelerator: String::new(),
+        // Pairing is about identity, not topology; addresses are exchanged on
+        // the authenticated channel once there is a pin to believe them under.
+        addresses: Vec::new(),
     };
     let peer_hello = match role {
         Role::Initiator => {

--- a/crates/atlasctl-agent/src/peer/wire.rs
+++ b/crates/atlasctl-agent/src/peer/wire.rs
@@ -34,6 +34,18 @@ pub enum PeerFrame {
         can_launch: bool,
         /// Coarse accelerator tag.
         accelerator: String,
+        /// The addresses this node can be reached on, with their subnets.
+        ///
+        /// Only a node knows which links it is attached to, and a rendezvous
+        /// address must be one every rank can reach. A beacon cannot supply
+        /// this — it carries whatever address the multicast happened to arrive
+        /// from, with no subnet — so it comes over the authenticated channel
+        /// where it can be believed.
+        ///
+        /// Defaulted so a peer built before this field is understood as
+        /// "did not say" rather than refused.
+        #[serde(default)]
+        addresses: Vec<atlasctl_protocol::fleet::NodeAddress>,
     },
 
     /// Begin a pairing exchange. Carries the initiator's SPAKE2 message.

--- a/crates/atlasctl-agent/src/rendezvous.rs
+++ b/crates/atlasctl-agent/src/rendezvous.rs
@@ -1,0 +1,360 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Can this machine actually reach the address it has been told to meet at?
+//!
+//! A rank that cannot reach the rendezvous does not fail. It waits at the NCCL
+//! barrier, retrying, for as long as the collective's timeout allows — and the
+//! operator sees two containers running and no server. That happened on the
+//! real pair: a DGX Spark carries four RoCE ports on separate point-to-point
+//! `/30`s, the head offered its address on one of them, and the worker was
+//! attached to a different one. `Connection timed out (os error 110), retrying`
+//! every second, forever.
+//!
+//! So this is checked during prepare, where a refusal is cheap and says why,
+//! rather than after commit, where it is a silent hang.
+//!
+//! Two questions, in order of confidence:
+//!
+//! 1. **Is it on a subnet I am directly attached to?** Exact, needs no network,
+//!    and is the case that matters for point-to-point RoCE.
+//! 2. **Does something answer there?** For anything routed, where subnet
+//!    arithmetic cannot see the path. A refused connection proves the host is
+//!    reachable just as well as an accepted one — better, since nothing is
+//!    listening on the rendezvous port until rank 0 starts.
+
+use atlasctl_protocol::fleet::NodeAddress;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpStream};
+use std::time::Duration;
+
+/// How long to wait for the routed check before calling it unreachable.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Whether `target` sits on a subnet one of `local` is directly attached to.
+///
+/// Addresses with an unknown prefix (`0`) are skipped rather than guessed at: a
+/// beacon reports a host address with no subnet, and treating that as `/32`
+/// would say "shares a link with nothing" while `/24` would say the opposite.
+#[must_use]
+pub fn on_local_subnet(target: &str, local: &[NodeAddress]) -> bool {
+    let Ok(t) = target.parse::<Ipv4Addr>() else {
+        return false;
+    };
+    local.iter().any(|a| {
+        if a.prefix_len == 0 || a.prefix_len > 32 {
+            return false;
+        }
+        let Ok(host) = a.addr.parse::<Ipv4Addr>() else {
+            return false;
+        };
+        same_network(host, t, a.prefix_len)
+    })
+}
+
+/// Whether `other` sits inside `host`'s network of the given prefix length.
+///
+/// Used by the head when choosing a rendezvous address, and by a rank when
+/// judging one it has been given — the same arithmetic on both sides, so the
+/// two cannot disagree about what "reachable" means.
+#[must_use]
+pub fn shares_network(host: &str, prefix: u8, other: &str) -> bool {
+    match (host.parse::<Ipv4Addr>(), other.parse::<Ipv4Addr>()) {
+        (Ok(h), Ok(o)) => same_network(h, o, prefix),
+        _ => false,
+    }
+}
+
+/// Whether two addresses share a network of the given prefix length.
+fn same_network(a: Ipv4Addr, b: Ipv4Addr, prefix: u8) -> bool {
+    // A /0 would make every address "local", which is never what a fabric
+    // table means; callers filter it out, and this is the second line.
+    if prefix == 0 || prefix > 32 {
+        return false;
+    }
+    let mask: u32 = if prefix == 32 {
+        u32::MAX
+    } else {
+        u32::MAX << (32 - prefix)
+    };
+    (u32::from(a) & mask) == (u32::from(b) & mask)
+}
+
+/// Asking the network whether a host is there.
+///
+/// Behind a trait because it is the only I/O in this module, and without it a
+/// test of the refusal path silently depends on the machine it runs on: the
+/// address that broke the real cluster is one of *this* host's own interfaces,
+/// so a live probe answers "reachable" and the test passes for the wrong
+/// reason.
+pub trait Reachability: Send + Sync {
+    /// Whether something answers at this address, well enough to prove the
+    /// host is routable.
+    fn answers(&self, addr: &str, port: u16) -> bool;
+}
+
+/// The real probe, over TCP.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct TcpProbe;
+
+impl Reachability for TcpProbe {
+    fn answers(&self, addr: &str, port: u16) -> bool {
+        answers(addr, port)
+    }
+}
+
+/// Whether a TCP connect gets far enough to prove the host is there.
+///
+/// **A refused connection counts as reachable.** Nothing listens on the
+/// rendezvous port until rank 0 starts, so "refused" is the expected answer
+/// from a healthy peer and the one that distinguishes it from a link that goes
+/// nowhere. Only a timeout or a routing error means unreachable.
+#[must_use]
+pub fn answers(target: &str, port: u16) -> bool {
+    let Ok(ip) = target.parse::<IpAddr>() else {
+        return false;
+    };
+    match TcpStream::connect_timeout(&SocketAddr::new(ip, port), PROBE_TIMEOUT) {
+        Ok(_) => true,
+        Err(e) => e.kind() == std::io::ErrorKind::ConnectionRefused,
+    }
+}
+
+/// The best address among `candidates` that this machine can actually reach.
+///
+/// "Best" means the same thing it means everywhere else — highest link class,
+/// then fastest — but only among addresses on a subnet `local` is attached to.
+/// Falls back to the plain best when nothing is demonstrably shared, because a
+/// peer that has not reported its subnets should be dialled optimistically
+/// rather than declared unreachable.
+///
+/// This exists because "the peer's best address" and "the peer's best address
+/// *from here*" are different questions, and only the second one can be
+/// dialled. A DGX Spark answers on several point-to-point links; picking by
+/// class alone returns whichever sorts last among equals, which is a coin flip.
+#[must_use]
+pub fn best_reachable<'a>(
+    candidates: &'a [NodeAddress],
+    local: &[NodeAddress],
+) -> Option<&'a NodeAddress> {
+    let usable = || candidates.iter().filter(|a| a.class.usable_for_cluster());
+    usable()
+        .filter(|a| on_local_subnet(&a.addr, local))
+        .max_by_key(|a| (a.class.rank(), a.speed_mbps.unwrap_or(0)))
+        .or_else(|| usable().max_by_key(|a| (a.class.rank(), a.speed_mbps.unwrap_or(0))))
+}
+
+/// Why a rendezvous address was rejected, phrased for someone who has to fix it.
+#[must_use]
+pub fn explain(target: &str, local: &[NodeAddress]) -> String {
+    let mut links: Vec<String> = local
+        .iter()
+        .filter(|a| a.prefix_len > 0)
+        .map(|a| format!("{}/{} on {}", a.addr, a.prefix_len, a.iface))
+        .collect();
+    links.sort();
+    links.dedup();
+    if links.is_empty() {
+        return format!(
+            "this node cannot reach the rendezvous address {target}, and reports \
+             no subnets of its own to compare it against"
+        );
+    }
+    format!(
+        "this node cannot reach the rendezvous address {target}. It is attached to {}. \
+         The head offered an address on a link this machine is not on -- a DGX Spark \
+         carries several point-to-point RoCE links, and only one of them reaches here.",
+        links.join(", ")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use atlasctl_protocol::fleet::LinkClass;
+
+    fn addr(a: &str, prefix: u8, iface: &str) -> NodeAddress {
+        NodeAddress {
+            iface: iface.to_owned(),
+            addr: a.to_owned(),
+            class: LinkClass::Roce,
+            speed_mbps: Some(200_000),
+            rdma: true,
+            prefix_len: prefix,
+        }
+    }
+
+    /// The real topology that produced the hang. Both machines carry two RoCE
+    /// ports; only one pair is on a shared link.
+    fn peer_links() -> Vec<NodeAddress> {
+        vec![
+            addr("10.10.10.10", 30, "enp1s0f0np0"),
+            addr("10.10.10.17", 30, "enp1s0f1np1"),
+        ]
+    }
+
+    #[test]
+    fn the_head_address_on_the_shared_link_is_reachable() {
+        // 10.10.10.9/30 and 10.10.10.10/30 are the same network.
+        assert!(on_local_subnet("10.10.10.9", &peer_links()));
+    }
+
+    /// The failure as it happened: the head offered its address on its *other*
+    /// RoCE port, which this machine is not attached to.
+    #[test]
+    fn the_head_address_on_a_different_link_is_not_reachable() {
+        assert!(!on_local_subnet("10.10.10.13", &peer_links()));
+    }
+
+    #[test]
+    fn an_address_on_the_second_shared_link_is_reachable() {
+        // 10.10.10.17/30 covers .16-.19, so .18 is its peer.
+        assert!(on_local_subnet("10.10.10.18", &peer_links()));
+    }
+
+    /// A beacon reports a host address with no subnet. Treating that as /32
+    /// would say "shares a link with nothing"; /24 would say the opposite.
+    /// Neither is known, so it is skipped.
+    #[test]
+    fn an_unknown_prefix_never_claims_to_share_a_link() {
+        let unknown = vec![addr("10.10.10.10", 0, "")];
+        assert!(!on_local_subnet("10.10.10.9", &unknown));
+        assert!(!on_local_subnet("10.10.10.10", &unknown));
+    }
+
+    #[test]
+    fn a_nonsense_prefix_is_refused_rather_than_shifted() {
+        // `u32 << 32` is undefined-ish territory; the guard keeps it out.
+        let bad = vec![addr("10.10.10.10", 33, "x"), addr("10.10.10.10", 0, "y")];
+        assert!(!on_local_subnet("10.10.10.9", &bad));
+    }
+
+    #[test]
+    fn a_malformed_address_is_not_reachable() {
+        assert!(!on_local_subnet("not-an-address", &peer_links()));
+        assert!(!on_local_subnet("", &peer_links()));
+        let bad_local = vec![addr("nonsense", 30, "x")];
+        assert!(!on_local_subnet("10.10.10.9", &bad_local));
+    }
+
+    #[test]
+    fn a_host_route_matches_only_itself() {
+        let host = vec![addr("10.10.10.1", 32, "dummy0")];
+        assert!(on_local_subnet("10.10.10.1", &host));
+        assert!(!on_local_subnet("10.10.10.2", &host));
+    }
+
+    #[test]
+    fn a_wider_subnet_covers_its_hosts() {
+        let lan = vec![addr("192.168.68.68", 22, "wlP9s9")];
+        assert!(on_local_subnet("192.168.68.73", &lan));
+        assert!(!on_local_subnet("192.168.99.1", &lan));
+    }
+
+    mod explaining {
+        use super::super::*;
+        use super::{addr, peer_links};
+
+        /// The message has to be enough for somebody to fix it without reading
+        /// the source, so it names both the address and what this node has.
+        #[test]
+        fn it_names_the_address_and_this_nodes_links() {
+            let msg = explain("10.10.10.13", &peer_links());
+            assert!(msg.contains("10.10.10.13"), "{msg}");
+            assert!(msg.contains("10.10.10.10/30 on enp1s0f0np0"), "{msg}");
+            assert!(msg.contains("10.10.10.17/30 on enp1s0f1np1"), "{msg}");
+        }
+
+        #[test]
+        fn a_node_with_no_known_subnets_says_so_rather_than_listing_nothing() {
+            let msg = explain("10.10.10.13", &[addr("10.10.10.10", 0, "")]);
+            assert!(msg.contains("no subnets of its own"), "{msg}");
+        }
+    }
+
+    mod probing {
+        use super::super::*;
+
+        /// Nothing listens on the rendezvous port until rank 0 starts, so a
+        /// refused connection is the expected answer from a healthy peer — and
+        /// the one that separates it from a link going nowhere.
+        #[test]
+        fn a_refused_connection_counts_as_reachable() {
+            // Loopback with nothing bound refuses immediately.
+            assert!(answers("127.0.0.1", 1));
+        }
+
+        #[test]
+        fn a_malformed_address_is_not_reachable() {
+            assert!(!answers("not-an-address", 29500));
+        }
+    }
+}
+
+#[cfg(test)]
+mod reachable_tests {
+    use super::*;
+    use atlasctl_protocol::fleet::LinkClass;
+
+    fn a(addr: &str, prefix: u8, iface: &str, class: LinkClass, speed: u32) -> NodeAddress {
+        NodeAddress {
+            iface: iface.to_owned(),
+            addr: addr.to_owned(),
+            class,
+            speed_mbps: Some(speed),
+            rdma: matches!(class, LinkClass::Roce | LinkClass::InfiniBand),
+            prefix_len: prefix,
+        }
+    }
+
+    /// The real pair: the peer answers on two RoCE links, and this machine is
+    /// attached to only one of them. Ranking by class alone is a coin flip
+    /// between equals — and it picked the wrong one.
+    #[test]
+    fn it_picks_the_peer_link_this_machine_is_on() {
+        let peer = vec![
+            a("10.10.10.10", 30, "enp1s0f0np0", LinkClass::Roce, 200_000),
+            a("10.10.10.17", 30, "enp1s0f1np1", LinkClass::Roce, 200_000),
+        ];
+        let mine = vec![
+            a("10.10.10.9", 30, "enp1s0f0np0", LinkClass::Roce, 200_000),
+            a("10.10.10.13", 30, "enp1s0f1np1", LinkClass::Roce, 200_000),
+        ];
+        assert_eq!(best_reachable(&peer, &mine).unwrap().addr, "10.10.10.10");
+    }
+
+    /// Sharing a subnet is a tiebreak between usable links, never a promotion:
+    /// a shared ethernet hop must not beat a shared RoCE one.
+    #[test]
+    fn a_faster_shared_link_still_wins() {
+        let peer = vec![
+            a("192.168.1.3", 24, "eth0", LinkClass::Ethernet, 1000),
+            a("10.10.10.10", 30, "enp1s0f0np0", LinkClass::Roce, 200_000),
+        ];
+        let mine = vec![
+            a("192.168.1.2", 24, "eth0", LinkClass::Ethernet, 1000),
+            a("10.10.10.9", 30, "enp1s0f0np0", LinkClass::Roce, 200_000),
+        ];
+        assert_eq!(best_reachable(&peer, &mine).unwrap().addr, "10.10.10.10");
+    }
+
+    /// A peer that has not reported subnets is dialled optimistically rather
+    /// than declared unreachable — it may well be routable.
+    #[test]
+    fn an_unknown_subnet_falls_back_to_the_plain_best() {
+        let peer = vec![a("10.9.9.9", 0, "", LinkClass::Roce, 200_000)];
+        let mine = vec![a("10.10.10.9", 30, "enp1s0f0np0", LinkClass::Roce, 200_000)];
+        assert_eq!(best_reachable(&peer, &mine).unwrap().addr, "10.9.9.9");
+    }
+
+    /// A bridge every machine happens to share must never be chosen.
+    #[test]
+    fn a_virtual_link_is_never_reachable_enough_to_use() {
+        let peer = vec![a("172.17.0.1", 16, "docker0", LinkClass::Virtual, 0)];
+        let mine = vec![a("172.17.0.1", 16, "docker0", LinkClass::Virtual, 0)];
+        assert!(best_reachable(&peer, &mine).is_none());
+    }
+
+    #[test]
+    fn no_addresses_yields_nothing() {
+        assert!(best_reachable(&[], &[]).is_none());
+    }
+}

--- a/crates/atlasctl-agent/src/server.rs
+++ b/crates/atlasctl-agent/src/server.rs
@@ -50,7 +50,7 @@ pub struct AgentState {
     ///
     /// `None` on an agent that cannot reach peers, which is answered plainly
     /// rather than by inventing a preview.
-    pub cluster: Option<Box<dyn crate::session::ClusterControl>>,
+    pub cluster: Option<std::sync::Arc<dyn crate::session::ClusterControl>>,
     /// Sampling a running launch, when this agent can.
     pub telemetry: Option<Box<dyn crate::session::LaunchTelemetry>>,
     /// Fleet changes pushed to every authenticated session.

--- a/crates/atlasctl-agent/src/session.rs
+++ b/crates/atlasctl-agent/src/session.rs
@@ -119,6 +119,19 @@ pub trait ClusterControl: Send + Sync {
     /// If no cluster is running, or a rank could not be stopped — and the
     /// error names which, because a rank left running holds a whole GPU.
     fn stop_cluster(&self) -> Result<Vec<atlasctl_protocol::msg::fleet::RankStarted>, String>;
+
+    /// Check a running cluster is still whole, and tear it down if it is not.
+    ///
+    /// The settle gate at commit is a liveness check by construction: weights
+    /// take minutes to load, so it cannot wait for readiness and only catches
+    /// a rank that dies immediately. A rank that dies four minutes in — during
+    /// model build, say — passed that gate, and the survivors then hold their
+    /// GPUs indefinitely serving nothing, because a half cluster waits at a
+    /// rendezvous that will never complete.
+    ///
+    /// Returns a description of what it tore down, or `None` when the cluster
+    /// is whole or absent.
+    fn supervise(&self) -> Option<String>;
 }
 
 /// A single client connection.

--- a/crates/atlasctl-agent/src/transport.rs
+++ b/crates/atlasctl-agent/src/transport.rs
@@ -71,4 +71,8 @@ pub trait RankTransport: Send + Sync {
 
     /// Stop a container this rank started. Failures are the driver's to ignore.
     fn stop(&self, node: NodeId, addr: SocketAddr, container: &str);
+
+    /// Mark a rank dead, so a test can exercise supervision.
+    #[cfg(test)]
+    fn kill_for_test(&self, _node: NodeId) {}
 }

--- a/crates/atlasctl-core/src/docker/collective.rs
+++ b/crates/atlasctl-core/src/docker/collective.rs
@@ -19,6 +19,19 @@ pub trait CollectiveEnv: Send + Sync {
     /// Solo launches never call this: a single rank has nobody to rendezvous
     /// with, and injecting fabric tuning would be noise at best.
     fn cluster_env(&self) -> BTreeMap<String, String>;
+
+    /// Pin the collective to one link, named the way this backend names it.
+    ///
+    /// The caller supplies an interface and, when there is one, the RDMA device
+    /// behind it — both read from the system, neither guessed. Which variables
+    /// carry that is the backend's business: only it knows whether the answer
+    /// is `NCCL_*`, `RCCL_*`, `GLOO_*` or nothing at all, and putting those
+    /// names in the caller is how a vendor-neutral module stops being one.
+    ///
+    /// Empty when the link cannot be identified — a routed rendezvous has no
+    /// single local interface, and naming one would be the guess this exists
+    /// to avoid.
+    fn bind_interface(&self, iface: &str, rdma_device: Option<&str>) -> BTreeMap<String, String>;
 }
 
 /// NCCL over RoCEv2, tuned for GB10-class nodes.
@@ -32,9 +45,28 @@ pub trait CollectiveEnv: Send + Sync {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct NcclRoce;
 
+impl NcclRoce {
+    /// Interface selector.
+    const SOCKET_IFNAME: &'static str = "NCCL_SOCKET_IFNAME";
+    /// RDMA device selector.
+    const IB_HCA: &'static str = "NCCL_IB_HCA";
+}
+
 impl CollectiveEnv for NcclRoce {
     fn name(&self) -> &'static str {
         "nccl-roce"
+    }
+
+    fn bind_interface(&self, iface: &str, rdma_device: Option<&str>) -> BTreeMap<String, String> {
+        if iface.is_empty() {
+            return BTreeMap::new();
+        }
+        let mut out = BTreeMap::new();
+        out.insert(Self::SOCKET_IFNAME.to_owned(), iface.to_owned());
+        if let Some(dev) = rdma_device {
+            out.insert(Self::IB_HCA.to_owned(), dev.to_owned());
+        }
+        out
     }
 
     fn cluster_env(&self) -> BTreeMap<String, String> {
@@ -74,6 +106,10 @@ pub struct NoCollectiveEnv;
 impl CollectiveEnv for NoCollectiveEnv {
     fn name(&self) -> &'static str {
         "none"
+    }
+
+    fn bind_interface(&self, _: &str, _: Option<&str>) -> BTreeMap<String, String> {
+        BTreeMap::new()
     }
 
     fn cluster_env(&self) -> BTreeMap<String, String> {

--- a/crates/atlasctl-protocol/src/fleet.rs
+++ b/crates/atlasctl-protocol/src/fleet.rs
@@ -261,6 +261,20 @@ pub struct NodeAddress {
     pub iface: String,
     /// The address itself.
     pub addr: String,
+    /// Prefix length of the subnet it sits on.
+    ///
+    /// Kept, not discarded. A DGX Spark carries four RoCE ports on separate
+    /// point-to-point /30s, and which of them reaches a given peer is decided
+    /// entirely by this number — a host address alone cannot answer it. The
+    /// first version of this struct dropped the prefix on the grounds that a
+    /// peer address is a host address, and the result was a cluster that chose
+    /// a rendezvous address on a link the worker was not attached to and hung
+    /// at the NCCL barrier until somebody read the logs.
+    ///
+    /// Defaulted for the wire so an older peer that does not send it is
+    /// understood as "unknown subnet" rather than refused.
+    #[serde(default)]
+    pub prefix_len: u8,
     /// What kind of link this is.
     pub class: LinkClass,
     /// Negotiated speed in Mb/s, when the kernel reports one.

--- a/crates/atlasctl-protocol/src/fleet/tests.rs
+++ b/crates/atlasctl-protocol/src/fleet/tests.rs
@@ -100,6 +100,8 @@ fn addr(iface: &str, addr: &str, class: LinkClass, speed: Option<u32>) -> NodeAd
         class,
         speed_mbps: speed,
         rdma: matches!(class, LinkClass::Roce | LinkClass::InfiniBand),
+        // Point-to-point, like the RoCE links on a real Spark.
+        prefix_len: 30,
     }
 }
 

--- a/crates/atlasctl/src/commands/agent.rs
+++ b/crates/atlasctl/src/commands/agent.rs
@@ -121,7 +121,7 @@ pub fn run(args: &AgentRunArgs) -> Result<()> {
         atlasctl_agent::identity::Identity::load_or_create(&config_dir)?,
         pins.clone(),
         atlasctl_agent::discovery::local_display_name(),
-        addresses,
+        addresses.clone(),
         launchability,
         String::new(),
     )
@@ -150,7 +150,12 @@ pub fn run(args: &AgentRunArgs) -> Result<()> {
             Box::new(NvidiaDevices),
             Box::new(atlasctl_core::docker::collective::NcclRoce),
             Arc::clone(&runner),
-            can_launch.clone(),
+            crate::rankservice::RankEnvironment {
+                can_launch: can_launch.clone(),
+                local_addresses: addresses.clone(),
+                reachability: Box::new(atlasctl_agent::rendezvous::TcpProbe),
+                rdma_devices: atlasctl_agent::fabric::linux::rdma_devices_by_interface(),
+            },
         ));
 
     let state = Arc::new(AgentState {

--- a/crates/atlasctl/src/commands/agent.rs
+++ b/crates/atlasctl/src/commands/agent.rs
@@ -158,6 +158,20 @@ pub fn run(args: &AgentRunArgs) -> Result<()> {
             },
         ));
 
+    // Built before the state so the supervisor task can hold the same driver:
+    // a rank that dies after commit has to be noticed by something, and the
+    // session only exists while a browser is connected.
+    let cluster = Arc::new(atlasctl_agent::clusterdriver::ClusterDriver::new(
+        Arc::clone(&fleet) as Arc<dyn atlasctl_agent::fleet::FleetView>,
+        Arc::clone(&renderer),
+        Arc::new(crate::peertransport::PeerTransport::new(
+            Arc::clone(&identity),
+            pins.clone(),
+            rt.handle().clone(),
+        )),
+        atlasctl_agent::peer::DEFAULT_PEER_PORT,
+    ));
+
     let state = Arc::new(AgentState {
         registry: crate::commands::registry_set()?,
         launcher: Box::new(DockerLauncher::new(
@@ -177,18 +191,33 @@ pub fn run(args: &AgentRunArgs) -> Result<()> {
                 crate::httpscrape::HttpScraper,
             )),
         ))),
-        cluster: Some(Box::new(atlasctl_agent::clusterdriver::ClusterDriver::new(
-            Arc::clone(&fleet) as Arc<dyn atlasctl_agent::fleet::FleetView>,
-            Arc::clone(&renderer),
-            Arc::new(crate::peertransport::PeerTransport::new(
-                Arc::clone(&identity),
-                pins.clone(),
-                rt.handle().clone(),
-            )),
-            atlasctl_agent::peer::DEFAULT_PEER_PORT,
-        ))),
+        cluster: Some(Arc::clone(&cluster) as Arc<dyn atlasctl_agent::session::ClusterControl>),
         events: events.clone(),
     });
+
+    use atlasctl_agent::session::ClusterControl as _;
+
+    // Watch the cluster stay whole. The settle gate at commit only catches a
+    // rank that dies immediately; weights take minutes to load, so a rank that
+    // dies during model build passes it and leaves its peers holding GPUs and
+    // serving nothing.
+    {
+        let cluster = Arc::clone(&cluster);
+        rt.spawn(async move {
+            let mut tick = tokio::time::interval(std::time::Duration::from_secs(20));
+            tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                tick.tick().await;
+                let cluster = Arc::clone(&cluster);
+                // Asking a peer dials the network, so it must not run on the
+                // async runtime's worker threads.
+                let torn = tokio::task::spawn_blocking(move || cluster.supervise()).await;
+                if let Ok(Some(why)) = torn {
+                    eprintln!("cluster: {why}");
+                }
+            }
+        });
+    }
 
     eprintln!("atlasctl agent listening on 127.0.0.1:{}", args.port);
     // Client mode is a different kind of agent, not a broken one, so it does

--- a/crates/atlasctl/src/rankservice/mod.rs
+++ b/crates/atlasctl/src/rankservice/mod.rs
@@ -224,11 +224,13 @@ impl LocalRankService {
         else {
             return Vec::new();
         };
-        let mut out = vec![("NCCL_SOCKET_IFNAME".to_owned(), iface.clone())];
-        if let Some(dev) = self.rdma_devices.get(&iface) {
-            out.push(("NCCL_IB_HCA".to_owned(), dev.clone()));
-        }
-        out
+        // Which variables carry this is the collective backend's business.
+        // Naming them here would put a vendor's vocabulary in a module that is
+        // supposed to have none, which is how the abstraction erodes.
+        self.collective
+            .bind_interface(&iface, self.rdma_devices.get(&iface).map(String::as_str))
+            .into_iter()
+            .collect()
     }
 
     /// Whether this machine can reach the rendezvous address.

--- a/crates/atlasctl/src/rankservice/mod.rs
+++ b/crates/atlasctl/src/rankservice/mod.rs
@@ -24,6 +24,7 @@
 use anyhow::{Context, Result, bail};
 use atlasctl_agent::cluster::{PrepareReply, RankAssignment, RefusalReason};
 use atlasctl_agent::rank::RankService;
+use atlasctl_agent::rendezvous;
 use atlasctl_core::chain::UserConfig;
 use atlasctl_core::docker::collective::CollectiveEnv;
 use atlasctl_core::docker::profile::{DeviceProfile, LaunchProfile};
@@ -32,6 +33,7 @@ use atlasctl_core::host::HostSnapshot;
 use atlasctl_core::io::ProcessRunner;
 use atlasctl_core::registry::{RecipeRef, RegistrySet};
 use atlasctl_core::settings;
+use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 
 /// A rendered rank, held between prepare and commit.
@@ -39,6 +41,26 @@ struct Reservation {
     epoch: String,
     recipe: String,
     plan: atlasctl_core::docker::LaunchPlan,
+}
+
+/// What this machine can do, as opposed to what it ships.
+///
+/// Grouped rather than passed loose: these three are one question — whether
+/// this node can take a rank at all, and whether it can reach the rendezvous
+/// it would be given — and a constructor that takes them separately reads as
+/// nine unrelated arguments.
+pub struct RankEnvironment {
+    /// Why this machine cannot run models, when it cannot.
+    pub can_launch: Result<(), String>,
+    /// This machine's own addresses, with their subnets.
+    pub local_addresses: Vec<atlasctl_protocol::fleet::NodeAddress>,
+    /// How to ask the network about an address subnet arithmetic cannot place.
+    pub reachability: Box<dyn rendezvous::Reachability>,
+    /// Which RDMA device backs each of this machine's interfaces.
+    ///
+    /// Injected rather than read at render time so the mapping is fixed for
+    /// the life of the agent and a test can supply its own.
+    pub rdma_devices: BTreeMap<String, String>,
 }
 
 /// Serves rank requests from this machine's own recipe inventory.
@@ -51,6 +73,13 @@ pub struct LocalRankService {
     runner: Arc<dyn ProcessRunner>,
     /// Why this machine cannot run models, when it cannot.
     can_launch: Result<(), String>,
+    /// This machine's own addresses, for judging whether a rendezvous address
+    /// is one it can actually reach.
+    local_addresses: Vec<atlasctl_protocol::fleet::NodeAddress>,
+    /// How to ask the network about an address subnet arithmetic cannot place.
+    reachability: Box<dyn rendezvous::Reachability>,
+    /// Which RDMA device backs each of this machine's interfaces.
+    rdma_devices: BTreeMap<String, String>,
     reserved: Mutex<Option<Reservation>>,
 }
 
@@ -70,7 +99,7 @@ impl LocalRankService {
         devices: Box<dyn DeviceProfile>,
         collective: Box<dyn CollectiveEnv>,
         runner: Arc<dyn ProcessRunner>,
-        can_launch: Result<(), String>,
+        env: RankEnvironment,
     ) -> Self {
         Self {
             registry,
@@ -79,7 +108,10 @@ impl LocalRankService {
             devices,
             collective,
             runner,
-            can_launch,
+            can_launch: env.can_launch,
+            local_addresses: env.local_addresses,
+            reachability: env.reachability,
+            rdma_devices: env.rdma_devices,
             reserved: Mutex::new(None),
         }
     }
@@ -148,6 +180,24 @@ impl LocalRankService {
         )
         .with_context(|| format!("rendering rank {} of {}", a.rank, a.recipe))?;
 
+        // Pin the collective to the link the plan actually chose.
+        //
+        // Nothing set NCCL_SOCKET_IFNAME or NCCL_IB_HCA, on the reasoning that
+        // guessing a NIC name produces a launch that looks fine and silently
+        // uses the wrong fabric. That is true of guessing -- but leaving them
+        // unset does not avoid the guess, it delegates it to NCCL, which on a
+        // machine with four RoCE ports picked the one that reaches nobody and
+        // died at `ibv_modify_qp` with `Connection timed out`.
+        //
+        // This is not a guess. The rendezvous address is on exactly one of this
+        // machine's interfaces, and that interface is backed by exactly one
+        // RDMA device. Both are read from the system, not assumed.
+        if let Placement::Rank { .. } = placement {
+            for (k, v) in self.collective_binding(&a.master_addr) {
+                plan.docker.env.insert(k, v);
+            }
+        }
+
         // The agent removes a container by name before it starts one, and on
         // stop, so it owns this lifecycle already. Auto-remove therefore buys
         // nothing and costs the only evidence there is: a rank that dies takes
@@ -156,6 +206,38 @@ impl LocalRankService {
         // container was gone before anyone could read it.
         plan.docker.auto_remove = false;
         Ok(plan)
+    }
+
+    /// The interface and RDMA device carrying a given address, as NCCL wants
+    /// them named.
+    ///
+    /// Empty when the address is not on a directly-attached subnet: a routed
+    /// rendezvous has no single local interface to name, and inventing one
+    /// would be the guess this exists to avoid.
+    fn collective_binding(&self, master_addr: &str) -> Vec<(String, String)> {
+        let Some(iface) = self
+            .local_addresses
+            .iter()
+            .filter(|a| a.prefix_len > 0 && !a.iface.is_empty())
+            .find(|a| rendezvous::shares_network(&a.addr, a.prefix_len, master_addr))
+            .map(|a| a.iface.clone())
+        else {
+            return Vec::new();
+        };
+        let mut out = vec![("NCCL_SOCKET_IFNAME".to_owned(), iface.clone())];
+        if let Some(dev) = self.rdma_devices.get(&iface) {
+            out.push(("NCCL_IB_HCA".to_owned(), dev.clone()));
+        }
+        out
+    }
+
+    /// Whether this machine can reach the rendezvous address.
+    ///
+    /// Directly-attached first because it is exact and free; a routed probe
+    /// only for addresses subnet arithmetic cannot account for.
+    fn can_reach(&self, addr: &str, port: u16) -> bool {
+        rendezvous::on_local_subnet(addr, &self.local_addresses)
+            || self.reachability.answers(addr, port)
     }
 
     /// Whether the container runtime is answering here.
@@ -211,6 +293,16 @@ impl RankService for LocalRankService {
 
         if !self.docker_ok() {
             return refuse(RefusalReason::DockerUnavailable);
+        }
+
+        // Checked here, where a refusal costs a second and names the problem.
+        // After commit the same fact is a silent hang: the rank starts, waits
+        // at the collective barrier, and retries until somebody reads the logs.
+        if !self.can_reach(&assignment.master_addr, assignment.master_port) {
+            return refuse(RefusalReason::RendezvousUnreachable(rendezvous::explain(
+                &assignment.master_addr,
+                &self.local_addresses,
+            )));
         }
 
         // Rendering is the last check, and it is the strongest one: it proves

--- a/crates/atlasctl/src/rankservice/tests.rs
+++ b/crates/atlasctl/src/rankservice/tests.rs
@@ -23,6 +23,27 @@ fn host() -> atlasctl_core::host::HostSnapshot {
     }
 }
 
+/// A network in which nothing is routable beyond the local links.
+struct NeverAnswers;
+
+impl atlasctl_agent::rendezvous::Reachability for NeverAnswers {
+    fn answers(&self, _: &str, _: u16) -> bool {
+        false
+    }
+}
+
+/// This machine's own link, sharing a /30 with the fixture rendezvous address.
+fn local_link() -> atlasctl_protocol::fleet::NodeAddress {
+    atlasctl_protocol::fleet::NodeAddress {
+        iface: "enp1s0f0np0".to_owned(),
+        addr: "10.0.0.2".to_owned(),
+        class: atlasctl_protocol::fleet::LinkClass::Roce,
+        speed_mbps: Some(200_000),
+        rdma: true,
+        prefix_len: 30,
+    }
+}
+
 fn node() -> NodeId {
     NodeId::parse(&"ab".repeat(32)).expect("64 hex chars")
 }
@@ -35,7 +56,24 @@ fn service(runner: &Arc<RecordingRunner>, can_launch: Result<(), String>) -> Loc
         Box::new(NvidiaDevices),
         Box::new(atlasctl_core::docker::collective::NcclRoce),
         Arc::clone(runner) as Arc<dyn ProcessRunner>,
-        can_launch,
+        RankEnvironment {
+            can_launch,
+            // On the same /30 as the fixtures' rendezvous address, which is
+            // what a real head would offer: an address on a link this node is
+            // attached to.
+            local_addresses: vec![local_link()],
+            // Nothing answers. The address that broke the real cluster is one
+            // of this host's own interfaces, so a live probe would report it
+            // reachable and the refusal test would pass for the wrong reason.
+            reachability: Box::new(NeverAnswers),
+            // The real pair's mapping: each RoCE port has its own device.
+            rdma_devices: [
+                ("enp1s0f0np0".to_owned(), "rocep1s0f0".to_owned()),
+                ("enp1s0f1np1".to_owned(), "rocep1s0f1".to_owned()),
+            ]
+            .into_iter()
+            .collect(),
+        },
     )
 }
 
@@ -306,4 +344,119 @@ fn a_container_removed_after_dying_reports_not_alive() {
         !svc.alive("atlas-x")
             .expect("a missing container is an answer")
     );
+}
+
+/// The failure that hung a real two-node launch.
+///
+/// A DGX Spark carries several point-to-point RoCE links. The head offered its
+/// address on one this machine is not attached to, and the rank started, waited
+/// at the collective barrier, and retried `Connection timed out` every second
+/// while the operator saw two healthy containers and no server.
+///
+/// It is a refusal now, at prepare, before anything starts.
+#[test]
+fn a_rendezvous_address_on_a_link_this_node_lacks_is_refused() {
+    let runner = Arc::new(RecordingRunner::new());
+    let svc = service(&runner, Ok(()));
+    let mut a = agreeing(&svc, 1);
+    // The fixture node is on 10.0.0.2/30; this is the head's *other* link.
+    a.master_addr = "10.10.10.13".to_owned();
+
+    let PrepareReply::Refused { reason } = svc.prepare("e1", &a) else {
+        panic!("an unreachable rendezvous must be refused, not reserved");
+    };
+    assert!(reason.contains("10.10.10.13"), "{reason}");
+    assert!(
+        reason.contains("10.0.0.2/30"),
+        "must name this node's links: {reason}"
+    );
+    assert!(
+        svc.commit("e1").is_err(),
+        "a refused prepare must reserve nothing"
+    );
+}
+
+/// The address on the shared link still works — the check must not refuse
+/// everything.
+#[test]
+fn a_rendezvous_address_on_the_shared_link_is_accepted() {
+    let runner = Arc::new(RecordingRunner::new());
+    let svc = service(&runner, Ok(()));
+    let mut a = agreeing(&svc, 1);
+    a.master_addr = "10.0.0.1".to_owned();
+    assert_eq!(svc.prepare("e1", &a), PrepareReply::Prepared);
+}
+
+/// The collective has to be told which link to use, or it picks one itself.
+///
+/// Nothing set NCCL_SOCKET_IFNAME or NCCL_IB_HCA, on the reasoning that
+/// guessing a NIC name silently uses the wrong fabric. True of guessing — but
+/// leaving them unset delegates the guess to NCCL, which on a machine with four
+/// RoCE ports chose the one that reaches nobody and died at `ibv_modify_qp`
+/// with `Connection timed out`, then took the process with it via
+/// `CUDA_ERROR_ILLEGAL_ADDRESS`.
+mod collective_binding {
+    use super::*;
+
+    #[test]
+    fn a_rank_pins_the_collective_to_the_rendezvous_link() {
+        let runner = Arc::new(RecordingRunner::new());
+        let svc = service(&runner, Ok(()));
+        let mut a = agreeing(&svc, 1);
+        a.master_addr = "10.0.0.1".to_owned(); // the fixture's shared /30
+
+        let (cmd, _) = svc.render(&a).expect("renders");
+        assert!(
+            cmd.contains("NCCL_SOCKET_IFNAME=enp1s0f0np0"),
+            "must name the interface carrying the rendezvous: {cmd}"
+        );
+        assert!(
+            cmd.contains("NCCL_IB_HCA=rocep1s0f0"),
+            "must name that interface's own RDMA device: {cmd}"
+        );
+        assert!(
+            !cmd.contains("rocep1s0f1"),
+            "the other port must not appear: {cmd}"
+        );
+    }
+
+    /// A solo launch has no collective, so pinning one would be noise that
+    /// also constrains a single-node server for no reason.
+    #[test]
+    fn a_solo_launch_pins_nothing() {
+        let recipe = atlasctl_core::registry::RegistrySet::builtin_only()
+            .resolve(&atlasctl_core::registry::RecipeRef::parse(
+                "qwen3.6-35b-a3b-fp8-bf16head",
+            ))
+            .expect("a shipped solo recipe");
+        let plan = atlasctl_core::docker::translate::translate(
+            &recipe,
+            &BTreeMap::new(),
+            &atlasctl_core::chain::UserConfig::default(),
+            &host(),
+            &atlasctl_core::docker::translate::Placement::Solo,
+            &atlasctl_core::docker::translate::LaunchContext {
+                profile: &ROOTLESS_V1,
+                devices: &NvidiaDevices,
+                collective: &atlasctl_core::docker::collective::NcclRoce,
+            },
+        )
+        .expect("translates");
+        assert!(!plan.docker.env.contains_key("NCCL_SOCKET_IFNAME"));
+        assert!(!plan.docker.env.contains_key("NCCL_IB_HCA"));
+    }
+
+    /// A routed rendezvous has no single local interface to name, and inventing
+    /// one would be exactly the guess this avoids.
+    #[test]
+    fn a_rendezvous_off_every_local_subnet_pins_nothing() {
+        let runner = Arc::new(RecordingRunner::new());
+        let svc = service(&runner, Ok(()));
+        let mut a = agreeing(&svc, 1);
+        a.master_addr = "203.0.113.7".to_owned();
+
+        let (cmd, _) = svc.render(&a).expect("renders");
+        assert!(!cmd.contains("NCCL_SOCKET_IFNAME"), "{cmd}");
+        assert!(!cmd.contains("NCCL_IB_HCA"), "{cmd}");
+    }
 }


### PR DESCRIPTION
A two-node launch hung at the NCCL barrier forever. Three bugs, each hidden behind the last, all the same mistake: treating one of several point-to-point links as interchangeable with the others.

A DGX Spark carries four RoCE ports on separate `/30`s. On the real pair, dgx1's `enp1s0f0np0` (10.10.10.9) reaches spark-43fa; its `enp1s0f1np1` (10.10.10.13) reaches somewhere else entirely.

```
enp1s0f0np0  10.10.10.9/30   ←→  10.10.10.10/30  enp1s0f0np0   (shared)
enp1s0f1np1  10.10.10.13/30      10.10.10.17/30  enp1s0f1np1   (different links)
```

## 1. The prefix was discarded

The fabric probe stripped it — *"a peer address is a host address, and keeping `/30` around would only invite someone to parse it again later."* That prefix is the only thing that says which link reaches whom.

It is kept now, and peers report their address tables over the authenticated channel — a beacon carries whatever address the multicast arrived from, with no subnet at all.

## 2. The head picked by link class alone

With two RoCE ports that is a coin flip, and it lost. It now prefers a link every worker shares.

**Existing tests caught my first attempt choosing a docker bridge** — every machine has `172.17.0.1`, so it "shares a subnet" with everything. Sharing a subnet is a tiebreak between *usable* links, never a promotion.

The same bug sat in the dial path: `preferred_address` uses `max_by_key`, which returns the **last** maximum on ties — invisible while a peer had one address, wrong the moment it reported two.

## 3. Nothing pinned NCCL's data path

A test asserted `NCCL_IB_HCA` must never be set, because *"guessing a NIC name would produce a launch that looks fine and silently uses the wrong fabric."*

True of guessing — but leaving it unset does not avoid the guess, it **delegates it to NCCL**, which chose `rocep1s0f1`:

```
NCCL WARN Call to ibv_modify_qp failed with 110 Connection timed out, on dev rocep1s0f1:1
→ Prefill start error: NCCL error in ncclBroadcast
→ CUDA_ERROR_ILLEGAL_ADDRESS
```

The rank now derives both variables from the link the plan chose: the rendezvous address is on exactly one local interface, and `/sys/class/infiniband` says exactly one RDMA device backs it. Read, not assumed. A solo launch pins nothing, and a routed rendezvous with no single local interface pins nothing — that would be the guess.

## Plus: a rank refuses an unreachable rendezvous

Without it the failure is not a refusal at all — the rank starts, waits at the barrier, and retries until somebody reads the logs.

```
rank 1 spark-43fa: REFUSED — this node cannot reach the rendezvous address
  10.10.10.13. It is attached to 10.10.10.10/30 on enp1s0f0np0,
  10.10.10.17/30 on enp1s0f1np1.
```

## One thing the tests caught about themselves

My first reachability check probed real TCP, and the refusal test **passed for the wrong reason** — the address that broke the cluster is one of this host's own interfaces, so a live probe found it. Unmocked I/O in a unit test. The probe is injected now and the fixtures use a network where nothing answers.

## Verified end to end

168 GB DeepSeek-V4-Flash-NVFP4, expert-parallel across two GB10 Sparks, driven through the agent:

```
rank 0 spark-256a: PREPARED
rank 1 spark-43fa: PREPARED
STARTED (6.1s)
SERVING: nvidia/DeepSeek-V4-Flash-NVFP4 after 3.8 min
INFERENCE OK: 80 tokens in 8.4s (9.5 tok/s)
STOPPED: both ranks
```

436 tests, clippy clean, every file under the 500-line cap.

## Known gap, not fixed here

In an earlier run rank 0 died ~4 minutes in — long after the 5-second settle gate — leaving **rank 1 orphaned holding a GPU**. The gate is a liveness check by construction (weights take minutes; it cannot wait for readiness), so nothing currently notices a rank that dies after commit. Worth a follow-up.
---

**Update (second commit): the gap named above is now closed.**

The settle gate at commit is a liveness check by construction — weights take minutes to load, so it cannot wait for readiness and only catches a rank that dies immediately. A rank that dies four minutes in passes it, and that is exactly what happened: rank 0 failed during model build while rank 1 stayed up, then held a GPU indefinitely waiting at a rendezvous that would never complete. Nothing noticed; it took a manual `stop_cluster`.

The agent now re-checks every twenty seconds that the cluster it started is still whole, and tears it down when it is not.

- **A rank that cannot be asked counts as dead.** If that is wrong, tearing down is the cheap mistake; the alternative is a survivor serving nothing.
- **The roster is read under the lock and the lock released before any peer is dialled**, so supervision cannot block a stop the operator asked for.

Two tests: a rank dying after commit takes the cluster with it and names what died, and supervising an idle agent touches no machine at all.

438 tests, clippy clean.
