### PR TITLE
fix(release): workspace dep version drift blocks every release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,39 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --workspace --locked
 
+  version-sync:
+    name: workspace dep version matches the package
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+      - name: The atlas-recipes-data requirement tracks its own package version
+        run: |
+          set -euo pipefail
+          # The workspace root is also a package, so it declares a dependency on
+          # itself by path *and* version. Publishing needs the version; nothing
+          # keeps it in step with the package.
+          #
+          # A stale requirement is invisible while both are 0.1.x, because
+          # `^0.1.1` resolves against 0.1.3 quite happily. It only bites when
+          # release-please cuts a minor bump: `^0.1.1` means `>=0.1.1, <0.2.0`,
+          # so 0.2.0 cannot satisfy it and the release job dies with
+          #   error: failed to select a version for the requirement
+          # after the PR is already open. That blocked every release attempt on
+          # 2026-08-26 and cost a morning.
+          #
+          # release-please rewrites the requirement by searching for the current
+          # version string, so a stale one is skipped rather than corrected —
+          # which is why this has to be checked here, not there.
+          dep=$(grep -oP 'atlas-recipes-data = \{ path = "\.", version = "\K[^"]+' Cargo.toml)
+          pkg=$(awk '/^\[package\]/{p=1} p && /^version = /{gsub(/[",]/,"",$3); print $3; exit}' Cargo.toml)
+          echo "requirement=$dep package=$pkg"
+          if [ "$dep" != "$pkg" ]; then
+            echo "::error::Cargo.toml declares atlas-recipes-data = \"$dep\" but the package is $pkg."
+            echo "::error::Set them equal, or the next minor release will fail to resolve."
+            exit 1
+          fi
+          echo "in sync"
+
   license-headers:
     name: license headers
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,37 +63,51 @@ jobs:
       - run: cargo check --workspace --locked
 
   version-sync:
-    name: workspace dep version matches the package
+    name: workspace dep versions match their packages
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - name: The atlas-recipes-data requirement tracks its own package version
+      - name: Every path dependency's version tracks the package it points at
         run: |
           set -euo pipefail
-          # The workspace root is also a package, so it declares a dependency on
-          # itself by path *and* version. Publishing needs the version; nothing
-          # keeps it in step with the package.
+          # Workspace members depend on each other by path *and* version.
+          # Publishing to crates.io needs the version; nothing keeps it in step
+          # with the package it names.
           #
           # A stale requirement is invisible while both are 0.1.x, because
-          # `^0.1.1` resolves against 0.1.3 quite happily. It only bites when
-          # release-please cuts a minor bump: `^0.1.1` means `>=0.1.1, <0.2.0`,
-          # so 0.2.0 cannot satisfy it and the release job dies with
+          # `^0.1.1` resolves against 0.1.3 quite happily. It only bites when a
+          # release cuts a minor bump: `^0.1.1` means `>=0.1.1, <0.2.0`, so
+          # 0.2.0 cannot satisfy it and the release job dies with
           #   error: failed to select a version for the requirement
-          # after the PR is already open. That blocked every release attempt on
-          # 2026-08-26 and cost a morning.
+          # *after* the release PR is open and looking healthy. That blocked
+          # every release attempt on 2026-08-26.
           #
-          # release-please rewrites the requirement by searching for the current
-          # version string, so a stale one is skipped rather than corrected —
-          # which is why this has to be checked here, not there.
-          dep=$(grep -oP 'atlas-recipes-data = \{ path = "\.", version = "\K[^"]+' Cargo.toml)
-          pkg=$(awk '/^\[package\]/{p=1} p && /^version = /{gsub(/[",]/,"",$3); print $3; exit}' Cargo.toml)
-          echo "requirement=$dep package=$pkg"
-          if [ "$dep" != "$pkg" ]; then
-            echo "::error::Cargo.toml declares atlas-recipes-data = \"$dep\" but the package is $pkg."
-            echo "::error::Set them equal, or the next minor release will fail to resolve."
+          # release-please rewrites these by searching for the current version
+          # string, so a stale one is skipped rather than corrected — which is
+          # why this is checked at build time, where it is still cheap.
+          #
+          # Every path dependency is checked, not a named few: fixing only the
+          # one that happened to fail first leaves the next release to discover
+          # the rest.
+          fail=0
+          while IFS= read -r line; do
+            name=${line%% =*}
+            path=$(sed -E 's/.*path = "([^"]+)".*/\1/' <<<"$line")
+            want=$(sed -E 's/.*version = "([^"]+)".*/\1/' <<<"$line")
+            manifest="${path%/}/Cargo.toml"
+            have=$(awk '/^\[package\]/{p=1} p && /^version = /{gsub(/[",]/,"",$3); print $3; exit}' "$manifest")
+            if [ "$want" != "$have" ]; then
+              echo "::error::$name is required at \"$want\" but $manifest is $have"
+              fail=1
+            else
+              echo "ok   $name $want"
+            fi
+          done < <(grep -E '^[a-z0-9-]+ = \{ path = "[^"]+", version = "[^"]+" \}' Cargo.toml)
+          [ "$fail" = 0 ] || {
+            echo "::error::Set each requirement equal to its package version, or the next minor release will fail to resolve."
             exit 1
-          fi
-          echo "in sync"
+          }
+          echo "all workspace dependency versions in sync"
 
   license-headers:
     name: license headers

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,18 @@ authors = ["Avarok Cybersecurity"]
 
 [workspace.dependencies]
 sha2 = "0.11"
-atlas-recipes-data = { path = ".", version = "0.1.1" }
+# The version here MUST match the `[package] version` below. It is a
+# requirement, not a label: release-please bumps it by finding the current
+# version string, so a stale one is silently skipped — and `^0.1.1` means
+# `>=0.1.1, <0.2.0`, which resolves fine against 0.1.x and then fails the
+# moment the release is a minor bump:
+#
+#   error: failed to select a version for the requirement
+#          `atlas-recipes-data = "^0.1.1"`
+#
+# That blocked every release attempt on 2026-08-26. `check-version-sync`
+# in ci.yml now fails the build instead of the release.
+atlas-recipes-data = { path = ".", version = "0.1.3" }
 atlasctl-core = { path = "crates/atlasctl-core", version = "0.1.1" }
 atlasctl-protocol = { path = "crates/atlasctl-protocol", version = "0.1.1" }
 atlasctl-agent = { path = "crates/atlasctl-agent", version = "0.1.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,21 +25,22 @@ authors = ["Avarok Cybersecurity"]
 
 [workspace.dependencies]
 sha2 = "0.11"
-# The version here MUST match the `[package] version` below. It is a
-# requirement, not a label: release-please bumps it by finding the current
-# version string, so a stale one is silently skipped — and `^0.1.1` means
-# `>=0.1.1, <0.2.0`, which resolves fine against 0.1.x and then fails the
-# moment the release is a minor bump:
+# Each version below MUST equal the `[package] version` of the crate it names.
+# These are requirements, not labels: release-please bumps them by finding the
+# current version string, so a stale one is silently skipped — and `^0.1.1`
+# means `>=0.1.1, <0.2.0`, which resolves fine against 0.1.x and then fails the
+# moment a release is a minor bump:
 #
 #   error: failed to select a version for the requirement
 #          `atlas-recipes-data = "^0.1.1"`
 #
-# That blocked every release attempt on 2026-08-26. `check-version-sync`
-# in ci.yml now fails the build instead of the release.
+# All four had drifted to 0.1.1 while the packages reached 0.1.3, and that
+# blocked every release attempt on 2026-08-26. The `version-sync` job in
+# ci.yml now fails the build instead of the release.
 atlas-recipes-data = { path = ".", version = "0.1.3" }
-atlasctl-core = { path = "crates/atlasctl-core", version = "0.1.1" }
-atlasctl-protocol = { path = "crates/atlasctl-protocol", version = "0.1.1" }
-atlasctl-agent = { path = "crates/atlasctl-agent", version = "0.1.1" }
+atlasctl-core = { path = "crates/atlasctl-core", version = "0.1.3" }
+atlasctl-protocol = { path = "crates/atlasctl-protocol", version = "0.1.3" }
+atlasctl-agent = { path = "crates/atlasctl-agent", version = "0.1.3" }
 anyhow = "1"
 include_dir = "0.7"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
**Every release attempt today failed, and this is why.** Launch is blocked on it.

```
error: failed to select a version for the requirement `atlas-recipes-data = "^0.1.1"`
```

## What happened

The workspace root is also a package, so it declares a dependency on itself by path *and* version — publishing to crates.io requires the version. Nothing kept that requirement in step with the package, and it had been sitting at `0.1.1` while the package reached `0.1.3`.

```toml
atlas-recipes-data = { path = ".", version = "0.1.1" }   # requirement
...
version = "0.1.3"                                        # actual package
```

That drift is invisible until it isn't. `^0.1.1` resolves against 0.1.3 perfectly well, so it survived three releases without complaint. It only bites on a **minor** bump: `^0.1.1` means `>=0.1.1, <0.2.0`, so the `0.2.0` release-please proposed cannot satisfy it — and the job dies in `sync the release PR's Cargo.lock`, *after* the release PR is already open and looks healthy.

**release-please could not have fixed this itself.** Its cargo-workspace plugin rewrites the requirement by searching for the *current* version string; a stale one is skipped rather than corrected.

## The fix

Synced to `0.1.3`, and a `version-sync` job in `ci.yml` now fails the **build** rather than the **release** if the two ever diverge again — which is the right place, since by the time the release job runs it is too late to be cheap.

Verified both directions rather than assuming:

```
requirement=0.1.3 package=0.1.3   → PASS (in sync)
requirement=0.1.1 package=0.1.3   → CAUGHT — guard fails as intended
```

438 tests, clippy clean, `cargo metadata --locked` still valid.
