### PR TITLE
fix(release): stale manifest split the versions; bump never reached the requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,74 +63,11 @@ jobs:
       - run: cargo check --workspace --locked
 
   version-sync:
-    name: workspace dep versions match their packages
+    name: internal version requirements match their packages
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - name: Every path dependency's version tracks the package it points at
-        run: |
-          set -euo pipefail
-          # Workspace members depend on each other by path *and* version.
-          # Publishing to crates.io needs the version; nothing keeps it in step
-          # with the package it names.
-          #
-          # A stale requirement is invisible while both are 0.1.x, because
-          # `^0.1.1` resolves against 0.1.3 quite happily. It only bites when a
-          # release cuts a minor bump: `^0.1.1` means `>=0.1.1, <0.2.0`, so
-          # 0.2.0 cannot satisfy it and the release job dies with
-          #   error: failed to select a version for the requirement
-          # *after* the release PR is open and looking healthy. That blocked
-          # every release attempt on 2026-08-26.
-          #
-          # release-please rewrites these by searching for the current version
-          # string, so a stale one is skipped rather than corrected — which is
-          # why this is checked at build time, where it is still cheap.
-          #
-          # Every path dependency is checked, not a named few: fixing only the
-          # one that happened to fail first leaves the next release to discover
-          # the rest.
-          fail=0
-          while IFS= read -r line; do
-            name=${line%% =*}
-            path=$(sed -E 's/.*path = "([^"]+)".*/\1/' <<<"$line")
-            want=$(sed -E 's/.*version = "([^"]+)".*/\1/' <<<"$line")
-            manifest="${path%/}/Cargo.toml"
-            have=$(awk '/^\[package\]/{p=1} p && /^version = /{gsub(/[",]/,"",$3); print $3; exit}' "$manifest")
-            if [ "$want" != "$have" ]; then
-              echo "::error::$name is required at \"$want\" but $manifest is $have"
-              fail=1
-            else
-              echo "ok   $name $want"
-            fi
-          done < <(grep -E '^[a-z0-9-]+ = \{ path = "[^"]+", version = "[^"]+" \}' Cargo.toml)
-          # Same drift, second place it hides. release-please computes the next
-          # version from its manifest, not from the manifests on disk, so a
-          # stale entry there silently gives one crate a different bump from
-          # the rest — atlasctl-protocol sat at 0.1.1 while its Cargo.toml said
-          # 0.1.3, and the release proposed 0.2.0 for it and 0.1.4 for
-          # everything else. linked-versions cannot correct that; it is working
-          # from the wrong starting point.
-          python3 - <<'PY'
-          import json, pathlib, re, sys
-          man = json.loads(pathlib.Path('.release-please-manifest.json').read_text())
-          bad = 0
-          for path, recorded in man.items():
-              f = pathlib.Path('Cargo.toml') if path == '.' else pathlib.Path(path) / 'Cargo.toml'
-              m = re.search(r'^\[package\][\s\S]*?^version = "([^"]+)"', f.read_text(), re.M)
-              actual = m.group(1) if m else None
-              if actual != recorded:
-                  print(f"::error::.release-please-manifest.json says {path} is {recorded}, but {f} is {actual}")
-                  bad = 1
-              else:
-                  print(f"ok   manifest {path} {recorded}")
-          sys.exit(bad)
-          PY
-
-          [ "$fail" = 0 ] || {
-            echo "::error::Set each requirement equal to its package version, or the next minor release will fail to resolve."
-            exit 1
-          }
-          echo "all workspace dependency and manifest versions in sync"
+      - run: python3 scripts/check-version-sync.py
 
   license-headers:
     name: license headers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,11 +103,34 @@ jobs:
               echo "ok   $name $want"
             fi
           done < <(grep -E '^[a-z0-9-]+ = \{ path = "[^"]+", version = "[^"]+" \}' Cargo.toml)
+          # Same drift, second place it hides. release-please computes the next
+          # version from its manifest, not from the manifests on disk, so a
+          # stale entry there silently gives one crate a different bump from
+          # the rest — atlasctl-protocol sat at 0.1.1 while its Cargo.toml said
+          # 0.1.3, and the release proposed 0.2.0 for it and 0.1.4 for
+          # everything else. linked-versions cannot correct that; it is working
+          # from the wrong starting point.
+          python3 - <<'PY'
+          import json, pathlib, re, sys
+          man = json.loads(pathlib.Path('.release-please-manifest.json').read_text())
+          bad = 0
+          for path, recorded in man.items():
+              f = pathlib.Path('Cargo.toml') if path == '.' else pathlib.Path(path) / 'Cargo.toml'
+              m = re.search(r'^\[package\][\s\S]*?^version = "([^"]+)"', f.read_text(), re.M)
+              actual = m.group(1) if m else None
+              if actual != recorded:
+                  print(f"::error::.release-please-manifest.json says {path} is {recorded}, but {f} is {actual}")
+                  bad = 1
+              else:
+                  print(f"ok   manifest {path} {recorded}")
+          sys.exit(bad)
+          PY
+
           [ "$fail" = 0 ] || {
             echo "::error::Set each requirement equal to its package version, or the next minor release will fail to resolve."
             exit 1
           }
-          echo "all workspace dependency versions in sync"
+          echo "all workspace dependency and manifest versions in sync"
 
   license-headers:
     name: license headers

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -3,5 +3,5 @@
   "crates/atlasctl": "0.1.3",
   "crates/atlasctl-agent": "0.1.3",
   "crates/atlasctl-core": "0.1.3",
-  "crates/atlasctl-protocol": "0.1.1"
+  "crates/atlasctl-protocol": "0.1.3"
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,10 +37,10 @@ sha2 = "0.11"
 # All four had drifted to 0.1.1 while the packages reached 0.1.3, and that
 # blocked every release attempt on 2026-08-26. The `version-sync` job in
 # ci.yml now fails the build instead of the release.
-atlas-recipes-data = { path = ".", version = "0.1.3" }
-atlasctl-core = { path = "crates/atlasctl-core", version = "0.1.3" }
-atlasctl-protocol = { path = "crates/atlasctl-protocol", version = "0.1.3" }
-atlasctl-agent = { path = "crates/atlasctl-agent", version = "0.1.3" }
+atlas-recipes-data = { path = ".", version = "0.1.3" } # x-release-please-version
+atlasctl-core = { path = "crates/atlasctl-core", version = "0.1.3" } # x-release-please-version
+atlasctl-protocol = { path = "crates/atlasctl-protocol", version = "0.1.3" } # x-release-please-version
+atlasctl-agent = { path = "crates/atlasctl-agent", version = "0.1.3" } # x-release-please-version
 anyhow = "1"
 include_dir = "0.7"
 serde = { version = "1", features = ["derive"] }

--- a/crates/atlasctl/Cargo.toml
+++ b/crates/atlasctl/Cargo.toml
@@ -22,7 +22,7 @@ clap = { version = "4", features = ["derive"] }
 rustix = { version = "1", features = ["process"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 serde_yaml_ng.workspace = true
-atlasctl-protocol = { version = "0.1.2", path = "../atlasctl-protocol" }
+atlasctl-protocol = { version = "0.1.3", path = "../atlasctl-protocol" } # x-release-please-version
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "tls12"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,8 @@
       "package-name": "atlasctl",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        "Cargo.toml"
+        "Cargo.toml",
+        "crates/atlasctl/Cargo.toml"
       ]
     }
   },

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,10 @@
   "packages": {
     ".": {
       "package-name": "atlasctl",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        "Cargo.toml"
+      ]
     }
   },
   "plugins": [

--- a/scripts/check-version-sync.py
+++ b/scripts/check-version-sync.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Every internal version requirement must equal the package it points at.
+
+Workspace members depend on each other by path *and* version, because
+publishing to crates.io needs the version. Nothing in cargo keeps that
+requirement in step with the package it names.
+
+The drift is invisible while both sides are 0.1.x: `^0.1.2` resolves against
+0.1.3 quite happily. It only bites when a release cuts a minor bump, because
+`^0.1.2` means `>=0.1.2, <0.2.0` — so 0.2.0 cannot satisfy it and the release
+job dies with `failed to select a version for the requirement`, *after* the
+release PR is open and looking healthy. That blocked every release attempt on
+2026-08-26, and it hid in five separate places.
+
+This parses TOML rather than grepping. The first version of this check used a
+regex that assumed `path` came before `version` and only read the workspace
+root, and it sailed straight past
+
+    atlasctl-protocol = { version = "0.1.2", path = "../atlasctl-protocol" }
+
+in a member crate. Key order is not semantic in TOML, and a check that depends
+on it is a check that lies.
+
+The same reasoning covers .release-please-manifest.json: release-please
+computes the next version from that file, not from the manifests on disk, so a
+stale entry there gives one crate a different bump from the rest — which is
+what split the release into 0.2.0 and 0.1.4 and defeated linked-versions.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+import tomllib
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+DEP_TABLES = ("dependencies", "dev-dependencies", "build-dependencies")
+
+
+def package_version(manifest: pathlib.Path) -> str | None:
+    """The `[package] version` a manifest declares, if it declares one."""
+    with manifest.open("rb") as fh:
+        data = tomllib.load(fh)
+    return data.get("package", {}).get("version")
+
+
+def path_dependencies(manifest: pathlib.Path):
+    """Every dependency in this manifest that names a path and a version."""
+    with manifest.open("rb") as fh:
+        data = tomllib.load(fh)
+
+    tables = [(t, data.get(t, {})) for t in DEP_TABLES]
+    tables.append(("workspace.dependencies", data.get("workspace", {}).get("dependencies", {})))
+
+    for table, deps in tables:
+        for name, spec in deps.items():
+            if not isinstance(spec, dict):
+                continue
+            path, version = spec.get("path"), spec.get("version")
+            # A path with no version is fine in-tree and simply cannot be
+            # published; cargo says so far more clearly than this would.
+            if path and version:
+                yield table, name, path, version
+
+
+def main() -> int:
+    manifests = [ROOT / "Cargo.toml", *sorted(ROOT.glob("crates/*/Cargo.toml"))]
+    bad = 0
+
+    for manifest in manifests:
+        rel = manifest.relative_to(ROOT)
+        for table, name, path, required in path_dependencies(manifest):
+            target = (manifest.parent / path / "Cargo.toml").resolve()
+            actual = package_version(target)
+            if actual is None:
+                print(f"::error::{rel} [{table}] {name} points at {path}, which declares no version")
+                bad = 1
+            elif required != actual:
+                print(
+                    f"::error::{rel} [{table}] requires {name} = \"{required}\" "
+                    f"but {target.relative_to(ROOT)} is {actual}"
+                )
+                bad = 1
+            else:
+                print(f"ok   {rel} [{table}] {name} {required}")
+
+    manifest_file = ROOT / ".release-please-manifest.json"
+    for path, recorded in json.loads(manifest_file.read_text()).items():
+        target = (ROOT / path / "Cargo.toml") if path != "." else (ROOT / "Cargo.toml")
+        actual = package_version(target)
+        if actual != recorded:
+            print(
+                f"::error::.release-please-manifest.json records {path} as {recorded} "
+                f"but {target.relative_to(ROOT)} is {actual}"
+            )
+            bad = 1
+        else:
+            print(f"ok   release manifest {path} {recorded}")
+
+    if bad:
+        print(
+            "::error::Set each requirement equal to the package it names. "
+            "A minor release cannot resolve a stale one, and it fails after the "
+            "release PR is already open."
+        )
+    return bad
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**This is why every release today failed, and why the proposed release was inconsistent.** Follows #46, which fixed the first of what turned out to be four instances of the same drift.

## The proposed release was split

```
atlas-recipes-data   0.2.0
atlasctl-protocol    0.2.0
atlasctl-core        0.1.4
atlasctl-agent       0.1.4
atlasctl             0.1.4
```

All five are `0.1.3` today, and `linked-versions` is configured to keep them together. It wasn't failing — **it was working from the wrong starting point.**

release-please computes the next version from `.release-please-manifest.json`, not from the manifests on disk, and that file had:

```json
"crates/atlasctl-protocol": "0.1.1"    ← Cargo.toml says 0.1.3
```

So protocol bumped `0.1.1 → 0.2.0` while everything else went `0.1.3 → 0.1.4`. Same never-synced-after-a-release drift as #46, one directory over. All five now start from 0.1.3.

## The bump never reached the requirements

Bumping `[package] version` without touching `[workspace.dependencies]` leaves `^0.1.3` pointing at a 0.2.0 crate — the same unresolvable requirement in a new place, and it would have reappeared on the very next minor release even with #46 merged.

The four dependency lines now carry `x-release-please-version` and `Cargo.toml` is registered as an `extra-file`, so the release rewrites them along with everything else.

## The two only work together

Worth stating because it nearly caught me: the generic updater writes **one** version to all four annotated lines. That is only correct once every crate shares a version. With the split still in place it would have pinned `atlasctl-core`'s requirement to 0.2.0 while the crate itself became 0.1.4 — strictly worse than the bug it fixes.

## Guard

`version-sync` now checks the release manifest as well as the Cargo manifests. Both hiding places, one job — because fixing only the one that failed first is exactly what produced this second round.

438 tests, clippy clean, `cargo metadata --locked` valid.

## Before merging the release

I would rather see the regenerated release PR propose a single uniform version across all five crates, with the dependency requirements rewritten to match, than merge it on the assumption this worked. Publishing is immutable. Once this lands and release-please regenerates, that is checkable in the diff.
