### PR TITLE
fix(release): linked-versions was grouping nothing

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,7 @@
   "release-type": "rust",
   "packages": {
     ".": {
-      "package-name": "atlasctl",
+      "package-name": "atlas-recipes-data",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
         "Cargo.toml",

--- a/scripts/check-version-sync.py
+++ b/scripts/check-version-sync.py
@@ -65,6 +65,57 @@ def path_dependencies(manifest: pathlib.Path):
                 yield table, name, path, version
 
 
+def linked_components(cfg: dict) -> list[str]:
+    """The components the linked-versions plugin claims to group."""
+    for plugin in cfg.get("plugins", []):
+        if isinstance(plugin, dict) and plugin.get("type") == "linked-versions":
+            return plugin.get("components", [])
+    return []
+
+
+def check_release_config() -> int:
+    """Every linked component must name a crate release-please can see.
+
+    A component that matches nothing is not an error to release-please — it is
+    silently ignored, and the group it was meant to join simply does not form.
+    That is how five crates ended up proposed at two different versions with
+    `linked-versions` sitting right there in the config looking correct:
+    `atlas-recipes-data` matched nothing, because path "." was registered under
+    the name `atlasctl`, which is also the name of a real crate one directory
+    down.
+    """
+    cfg_path = ROOT / "release-please-config.json"
+    cfg = json.loads(cfg_path.read_text())
+
+    known = set()
+    root_name = cfg.get("packages", {}).get(".", {}).get("package-name")
+    if root_name:
+        known.add(root_name)
+    for manifest in sorted(ROOT.glob("crates/*/Cargo.toml")):
+        with manifest.open("rb") as fh:
+            known.add(tomllib.load(fh)["package"]["name"])
+
+    # The name release-please uses for "." should be the crate that is there,
+    # or the component list cannot refer to both it and its namesake.
+    with (ROOT / "Cargo.toml").open("rb") as fh:
+        actual_root = tomllib.load(fh)["package"]["name"]
+    bad = 0
+    if root_name != actual_root:
+        print(
+            f"::error::release-please-config.json calls path \".\" {root_name!r}, "
+            f"but the crate there is {actual_root!r}"
+        )
+        bad = 1
+
+    for component in linked_components(cfg):
+        if component in known:
+            print(f"ok   linked component {component}")
+        else:
+            print(f"::error::linked-versions names {component!r}, which is no crate here")
+            bad = 1
+    return bad
+
+
 def main() -> int:
     manifests = [ROOT / "Cargo.toml", *sorted(ROOT.glob("crates/*/Cargo.toml"))]
     bad = 0
@@ -98,6 +149,8 @@ def main() -> int:
             bad = 1
         else:
             print(f"ok   release manifest {path} {recorded}")
+
+    bad |= check_release_config()
 
     if bad:
         print(


### PR DESCRIPTION
**The last piece of the release blocker.** #46 and #47 fixed the stale requirements; this fixes why the release was split across two versions in the first place.

## `linked-versions` was grouping nothing

```
atlas-recipes-data   0.2.0
atlasctl-protocol    0.2.0
atlasctl-core        0.1.4
atlasctl-agent       0.1.4
atlasctl             0.1.4
```

The plugin sits in the config looking correct. It matched nothing:

```json
"packages": { ".": { "package-name": "atlasctl" } }
```

The crate at `.` is **`atlas-recipes-data`**, and `atlasctl` is a real crate one directory down. So the component list named something release-please had never heard of, and something else that was ambiguous. **A component matching nothing is not an error to release-please** — it is ignored, and the group simply never forms.

Syncing the release manifest in #47 did not fix this, because the manifest was never the cause. Per-crate conventional-commit analysis was — a `feat` touching protocol earns a minor bump, `fix`-only crates earn a patch — and `linked-versions` is precisely the thing meant to override that.

## Why the split had to be fixed rather than tolerated

`cargo-workspace` bumps `[package] version` but **never rewrites the requirement pointing at it**. Confirmed in the diff: `crates/atlasctl/Cargo.toml` gets its version bumped and its `atlasctl-protocol = { version = "0.1.3", ... }` left untouched.

With versions unified, one release version is correct for every internal requirement, and the `x-release-please-version` annotations from #47 handle the rewrite. With them split, that same annotation would pin `atlasctl-core`'s requirement to 0.2.0 while the crate itself became 0.1.4 — strictly worse than the bug it fixes.

## Guard

`check-version-sync` now also asserts that the name given to path `.` is the crate actually there, and that every linked component names a real crate. Verified it reports both faults against the old config:

```
::error::release-please-config.json calls path "." 'atlasctl', but the crate there is 'atlas-recipes-data'
::error::linked-versions names 'atlas-recipes-data', which is no crate here
```

## Note

The GitHub Release title will now read `atlas-recipes-data` rather than `atlasctl`. The tag is unaffected (`include-component-in-tag: false`, so it stays `vX.Y.Z`). If the title matters, the fix is a `release-search-depth`-style rename rather than reintroducing a name that collides.

438 tests, clippy clean. All five crates package cleanly at 0.2.0 (verified in #47 by dry-running the exact post-release state).
