### PR TITLE
fix(release): repair the requirements release-please leaves stale

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,29 +115,39 @@ jobs:
       - if: steps.co.outcome == 'success'
         uses: dtolnay/rust-toolchain@stable
       - if: steps.co.outcome == 'success'
-        name: repair the lock if release-please left it behind
+        name: repair what release-please leaves behind
         run: |
           set -eu
-          if cargo metadata --locked --format-version 1 >/dev/null 2>&1; then
-            echo "release PR lock already matches its manifests"
+          # release-please bumps `[package] version` and never rewrites the
+          # requirements pointing at it, so on the release branch they are
+          # stale by construction: atlasctl asks for `^0.1.3` while
+          # atlasctl-protocol has become 0.2.0, and nothing resolves. That
+          # failed every release attempt on 2026-08-26.
+          #
+          # Repairing it here rather than fighting release-please also makes a
+          # split release harmless — each requirement gets the version of the
+          # crate it actually names, whether or not the crates moved together.
+          python3 scripts/check-version-sync.py --fix
+
+          # The lock follows from the manifests, so it is regenerated after
+          # them, not before. --workspace resolves workspace members only, so
+          # external dependencies stay exactly as pinned and --locked keeps its
+          # meaning.
+          cargo metadata --locked --format-version 1 >/dev/null 2>&1 || cargo update --workspace
+
+          if git diff --quiet -- Cargo.lock '*Cargo.toml'; then
+            echo "release PR already consistent; nothing to repair"
             exit 0
           fi
-          echo "::warning::release-please left Cargo.lock behind its manifests; repairing"
-          # --workspace resolves workspace members only, so external
-          # dependencies stay exactly as pinned and --locked keeps its meaning.
-          cargo update --workspace
-          # If the lock check failed but resolving workspace members changed
-          # nothing, the cause is something other than version drift and this
-          # job must not paper over it.
-          if git diff --quiet -- Cargo.lock; then
-            echo "::error::Cargo.lock failed --locked but resolving the workspace changed nothing."
-            echo "::error::Something other than release-please version drift is wrong here."
-            exit 1
-          fi
+
+          # Whatever was repaired, the result has to actually resolve — this is
+          # the last point before publishing where that is cheap to find out.
+          cargo metadata --locked --format-version 1 >/dev/null
+
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add Cargo.lock
-          git commit -m "chore: sync Cargo.lock with the versions release-please wrote"
+          git add Cargo.lock Cargo.toml crates/*/Cargo.toml
+          git commit -m "chore: sync manifests and lock with the versions release-please wrote"
           git push origin HEAD:release-please--branches--main
 
   # A pull request opened by the default GITHUB_TOKEN does not trigger

--- a/scripts/check-version-sync.py
+++ b/scripts/check-version-sync.py
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 """Every internal version requirement must equal the package it points at.
 
+With ``--fix``, rewrites them instead of complaining. The release workflow uses
+that: release-please bumps ``[package] version`` and never touches the
+requirements pointing at it, so on the release branch they are stale by
+construction. Repairing them there is the same job as repairing the lock, and
+it makes a split release harmless — each requirement gets the version of the
+crate it actually names, whether or not the crates moved together.
+
 Workspace members depend on each other by path *and* version, because
 publishing to crates.io needs the version. Nothing in cargo keeps that
 requirement in step with the package it names.
@@ -116,7 +123,26 @@ def check_release_config() -> int:
     return bad
 
 
+def rewrite_requirement(manifest: pathlib.Path, name: str, old: str, new: str) -> bool:
+    """Point one requirement at a new version, in place.
+
+    Line-oriented and anchored on the dependency name, because rewriting the
+    file through a TOML serialiser would reformat and strip comments — and the
+    comments here are load-bearing.
+    """
+    lines = manifest.read_text().splitlines(keepends=True)
+    needle = f'version = "{old}"'
+    for i, line in enumerate(lines):
+        stripped = line.lstrip()
+        if stripped.startswith(f"{name} ") and needle in line:
+            lines[i] = line.replace(needle, f'version = "{new}"', 1)
+            manifest.write_text("".join(lines))
+            return True
+    return False
+
+
 def main() -> int:
+    fix = "--fix" in sys.argv
     manifests = [ROOT / "Cargo.toml", *sorted(ROOT.glob("crates/*/Cargo.toml"))]
     bad = 0
 
@@ -129,14 +155,19 @@ def main() -> int:
                 print(f"::error::{rel} [{table}] {name} points at {path}, which declares no version")
                 bad = 1
             elif required != actual:
-                print(
-                    f"::error::{rel} [{table}] requires {name} = \"{required}\" "
-                    f"but {target.relative_to(ROOT)} is {actual}"
-                )
-                bad = 1
+                if fix and rewrite_requirement(manifest, name, required, actual):
+                    print(f"fix  {rel} [{table}] {name} {required} -> {actual}")
+                else:
+                    print(
+                        f"::error::{rel} [{table}] requires {name} = \"{required}\" "
+                        f"but {target.relative_to(ROOT)} is {actual}"
+                    )
+                    bad = 1
             else:
                 print(f"ok   {rel} [{table}] {name} {required}")
 
+    # The release branch legitimately has manifest entries ahead of the
+    # manifests for a moment, so this half is a check, never a fix.
     manifest_file = ROOT / ".release-please-manifest.json"
     for path, recorded in json.loads(manifest_file.read_text()).items():
         target = (ROOT / path / "Cargo.toml") if path != "." else (ROOT / "Cargo.toml")
@@ -151,6 +182,9 @@ def main() -> int:
             print(f"ok   release manifest {path} {recorded}")
 
     bad |= check_release_config()
+
+    if fix and not bad:
+        return 0
 
     if bad:
         print(


### PR DESCRIPTION
**This is the fix that actually unblocks the release.** #46–#48 removed the accumulated drift; this stops it recurring on every release from now on.

## The thing release-please will not do

It bumps `[package] version` and **never rewrites the internal requirements pointing at it**. Confirmed in the release PR diff — `crates/atlasctl/Cargo.toml` gets its version bumped and its `atlasctl-protocol = { version = "0.1.3", ... }` left exactly as it was.

So on the release branch the requirements are stale *by construction*:

```
error: failed to select a version for the requirement `atlas-recipes-data = "^0.1.3"`
```

That is the same error that failed every release attempt today, and it will recur on every future release regardless of how carefully the checked-in versions are synced.

**The `x-release-please-version` annotations from #47 do not help.** The `rust` release-type already owns `Cargo.toml`, so the generic updater never runs on it. They are left in place as a statement of intent, but the work has to happen elsewhere.

## Where it belongs

The `sync the release PR's Cargo.lock` job already exists to repair what release-please leaves behind. The lock was only ever the second-order symptom — the manifests are the cause. `check-version-sync.py` grows a `--fix` mode and runs **before** the lock is regenerated, so the lock follows from repaired manifests instead of being patched around broken ones.

**It also makes the version split harmless.** Each requirement gets the version of the crate it actually names, so it no longer matters whether release-please moved the crates together. That is worth having independently of #48.

## Three things the step now gets right

- **Commits the manifests, not just the lock.** As written, `git add Cargo.lock` would have discarded every repair — the fix would have looked like it worked and changed nothing.
- **Regenerates the lock after the manifests**, not before.
- **Asserts the repaired tree resolves before pushing.** The last point where finding out is cheap.

## Verified against the real failure

Reproduced exactly what release-please proposes — split package versions, requirements untouched — then ran `--fix`:

```
fix  Cargo.toml [workspace.dependencies] atlas-recipes-data 0.1.3 -> 0.2.0
fix  Cargo.toml [workspace.dependencies] atlasctl-core      0.1.3 -> 0.1.4
fix  Cargo.toml [workspace.dependencies] atlasctl-protocol  0.1.3 -> 0.2.0
fix  Cargo.toml [workspace.dependencies] atlasctl-agent     0.1.3 -> 0.1.4
fix  crates/atlasctl/Cargo.toml [dependencies] atlasctl-protocol 0.1.3 -> 0.2.0
```

and all five crates then package cleanly at their own versions.

438 tests, clippy clean.
