### PR TITLE
fix(release): the manifest check blocked the repair it was meant to protect

### DIFF
--- a/scripts/check-version-sync.py
+++ b/scripts/check-version-sync.py
@@ -166,8 +166,15 @@ def main() -> int:
             else:
                 print(f"ok   {rel} [{table}] {name} {required}")
 
-    # The release branch legitimately has manifest entries ahead of the
-    # manifests for a moment, so this half is a check, never a fix.
+    # Only on a normal tree. On the release branch release-please has already
+    # written the new versions into the Cargo manifests while
+    # .release-please-manifest.json still records the released-from versions —
+    # it is updated when the release is actually cut, not when the PR is
+    # prepared. Failing there would block the very repair this script exists to
+    # perform, which is exactly what it did on the first attempt.
+    if fix:
+        return bad | check_release_config()
+
     manifest_file = ROOT / ".release-please-manifest.json"
     for path, recorded in json.loads(manifest_file.read_text()).items():
         target = (ROOT / path / "Cargo.toml") if path != "." else (ROOT / "Cargo.toml")


### PR DESCRIPTION
**#49's repair worked. My own check then failed the job anyway.**

On the release branch, all five requirements were rewritten correctly:

```
fix  Cargo.toml [workspace.dependencies] atlas-recipes-data 0.1.3 -> 0.2.0
fix  Cargo.toml [workspace.dependencies] atlasctl-core      0.1.3 -> 0.1.4
fix  Cargo.toml [workspace.dependencies] atlasctl-protocol  0.1.3 -> 0.2.0
fix  Cargo.toml [workspace.dependencies] atlasctl-agent     0.1.3 -> 0.1.4
fix  crates/atlasctl/Cargo.toml [dependencies] atlasctl-protocol 0.1.3 -> 0.2.0
```

and then:

```
::error::.release-please-manifest.json records crates/atlasctl-protocol as 0.1.3
         but crates/atlasctl-protocol/Cargo.toml is 0.2.0
```

## That is not drift, it is the expected state

release-please writes the new versions into the Cargo manifests when it **prepares** the PR, and updates `.release-please-manifest.json` when the release is actually **cut**. Between those two points they disagree by design.

I had written precisely that in a comment — *"the release branch legitimately has manifest entries ahead of the manifests, so this half is a check, never a fix"* — and then let the check fail anyway. The comment was right; the code didn't follow it.

## Fix

That half is skipped under `--fix`, which only the release job uses. On a normal tree it still runs, where a stale manifest entry **is** real drift and worth failing over — it is what split the versions in the first place (#47, #48).

## Verified

Reproduced the release-branch state exactly — packages bumped and split, requirements stale, JSON manifest at the released-from versions:

```
--fix → exit=0
repaired tree resolves
```

438 tests, clippy clean.
