### PR TITLE
fix(agent): a control-only node must not tell peers it can launch

### DIFF
--- a/crates/atlasctl-agent/src/clusterdriver.rs
+++ b/crates/atlasctl-agent/src/clusterdriver.rs
@@ -462,6 +462,8 @@ impl ClusterDriver {
 #[cfg(test)]
 mod cases;
 #[cfg(test)]
+mod teardown;
+#[cfg(test)]
 mod tests;
 
 mod plan;

--- a/crates/atlasctl-agent/src/clusterdriver/cases.rs
+++ b/crates/atlasctl-agent/src/clusterdriver/cases.rs
@@ -103,6 +103,51 @@ fn a_commit_starts_every_rank_and_only_rank_zero_gets_an_endpoint() {
     assert!(started[0].rank == 0 && started[0].endpoint.is_some());
 }
 
+/// `assignment.settings` is a **sparse diff** — overrides only, not the
+/// effective settings. Reading it as the whole truth meant an operator who
+/// changed nothing produced an empty map, and the endpoint offered `:8000`
+/// while the model served on the `:8888` its recipe pins. The URL was the one
+/// thing on that screen the operator would actually paste somewhere.
+#[test]
+fn the_endpoint_uses_the_recipes_port_when_the_operator_overrode_nothing() {
+    let log = new_log();
+    let (d, _) = driver(ready_rank(&log), transport(&log));
+    let (epoch, _, may) = d
+        .prepare(&recipe(), &all_three(), node_id(1), &BTreeMap::new())
+        .expect("prepares");
+    assert!(may);
+
+    let started = d.commit(&epoch).expect("commits");
+    let endpoint = started[0].endpoint.as_deref().expect("rank 0 serves");
+    assert!(
+        endpoint.ends_with(":8888"),
+        "the endpoint ignored the recipe's own port: {endpoint}"
+    );
+}
+
+/// And an override still wins over the recipe, or the setting would do nothing.
+#[test]
+fn an_operators_port_override_still_beats_the_recipe() {
+    let log = new_log();
+    let (d, _) = driver(ready_rank(&log), transport(&log));
+    let mut settings = BTreeMap::new();
+    settings.insert(
+        "port".to_owned(),
+        atlasctl_protocol::settings::SettingValue::Int(9001),
+    );
+    let (epoch, _, may) = d
+        .prepare(&recipe(), &all_three(), node_id(1), &settings)
+        .expect("prepares");
+    assert!(may);
+
+    let started = d.commit(&epoch).expect("commits");
+    let endpoint = started[0].endpoint.as_deref().expect("rank 0 serves");
+    assert!(
+        endpoint.ends_with(":9001"),
+        "the operator's port was ignored: {endpoint}"
+    );
+}
+
 /// A half-started cluster waits forever on a rendezvous that never completes,
 /// and the operator sees a hang rather than an error.
 #[test]
@@ -245,215 +290,4 @@ fn the_head_prepares_itself_like_any_other_rank() {
     let head = ranks.iter().find(|r| r.rank == 0).expect("rank 0");
     assert!(!head.prepared);
     assert_eq!(head.reason, "docker is down");
-}
-
-#[test]
-fn a_started_cluster_can_be_stopped_on_every_machine() {
-    let log = new_log();
-    let (d, _) = driver(ready_rank(&log), transport(&log));
-    let (epoch, _, _) = d
-        .prepare(&recipe(), &all_three(), node_id(1), &BTreeMap::new())
-        .expect("prepares");
-    let started = d.commit(&epoch).expect("commits");
-
-    let stopped = d.stop_cluster().expect("stops");
-    assert_eq!(stopped.len(), started.len());
-
-    let c = calls(&log);
-    assert!(
-        c.contains(&"local.stop(head-container)".to_owned()),
-        "{c:?}"
-    );
-    for seed in [2u8, 3] {
-        let id = node_id(seed).short();
-        assert!(
-            c.iter().any(|x| x.starts_with(&format!("{id}.stop("))),
-            "{id} was never stopped: {c:?}"
-        );
-    }
-}
-
-/// An agent stops the cluster it started. Asking it to stop one it did not is
-/// how a page would use its local agent to reach machines it cannot authorize.
-#[test]
-fn stopping_without_having_started_anything_is_refused() {
-    let log = new_log();
-    let (d, _) = driver(ready_rank(&log), transport(&log));
-    let err = d.stop_cluster().expect_err("nothing was started");
-    assert!(err.contains("did not start a cluster"), "{err}");
-    assert!(calls(&log).is_empty(), "no machine may be contacted");
-}
-
-/// A cluster is stopped once. A second stop must not tear down a cluster
-/// started since.
-#[test]
-fn a_cluster_is_stopped_once() {
-    let log = new_log();
-    let (d, _) = driver(ready_rank(&log), transport(&log));
-    let (epoch, _, _) = d
-        .prepare(&recipe(), &all_three(), node_id(1), &BTreeMap::new())
-        .expect("prepares");
-    d.commit(&epoch).expect("commits");
-    d.stop_cluster().expect("stops");
-
-    let before = calls(&log).len();
-    assert!(d.stop_cluster().is_err(), "the cluster is already stopped");
-    assert_eq!(
-        calls(&log).len(),
-        before,
-        "no machine may be contacted again"
-    );
-}
-
-/// A rank left running holds a whole GPU, so giving up on the first failure
-/// would be the most expensive possible response to it.
-#[test]
-fn every_rank_is_attempted_even_when_one_refuses_to_stop() {
-    let log = new_log();
-    let (d, _) = driver(refusing_stop_rank(&log), transport(&log));
-    let (epoch, _, _) = d
-        .prepare(&recipe(), &all_three(), node_id(1), &BTreeMap::new())
-        .expect("prepares");
-    d.commit(&epoch).expect("commits");
-
-    let err = d.stop_cluster().expect_err("rank 0 could not be stopped");
-    assert!(err.contains("could not stop"), "{err}");
-
-    let c = calls(&log);
-    for seed in [2u8, 3] {
-        let id = node_id(seed).short();
-        assert!(
-            c.iter().any(|x| x.starts_with(&format!("{id}.stop("))),
-            "{id} must still be stopped: {c:?}"
-        );
-    }
-}
-
-/// The failure that real hardware found. `docker run -d` returned 0 for rank 0,
-/// so the commit reported success — and rank 0's container had already died a
-/// second later, leaving rank 1 running alone and waiting forever on a
-/// rendezvous that would never complete. The operator saw a hang, not an error.
-#[test]
-fn a_rank_that_dies_on_startup_fails_the_commit_and_stops_the_rest() {
-    let log = new_log();
-    let (d, _) = driver(dying_rank(&log), transport(&log));
-    let (epoch, _, _) = d
-        .prepare(&recipe(), &all_three(), node_id(1), &BTreeMap::new())
-        .expect("prepares");
-
-    let err = d.commit(&epoch).expect_err("rank 0 did not survive");
-    assert!(err.contains("stopped within"), "{err}");
-    assert!(
-        err.contains("spark-1"),
-        "the dead machine must be named: {err}"
-    );
-
-    // The peers that did start must not be left holding a GPU.
-    let c = calls(&log);
-    for seed in [2u8, 3] {
-        let id = node_id(seed).short();
-        assert!(
-            c.iter().any(|x| x.starts_with(&format!("{id}.stop("))),
-            "{id} must be stopped: {c:?}"
-        );
-    }
-}
-
-#[test]
-fn a_peer_that_dies_on_startup_fails_the_commit_too() {
-    let log = new_log();
-    let (d, _) = driver(ready_rank(&log), transport(&log).dying(node_id(3)));
-    let (epoch, _, _) = d
-        .prepare(&recipe(), &all_three(), node_id(1), &BTreeMap::new())
-        .expect("prepares");
-
-    let err = d.commit(&epoch).expect_err("rank 2 did not survive");
-    assert!(err.contains("spark-3"), "{err}");
-    assert!(
-        calls(&log).contains(&"local.stop(head-container)".to_owned()),
-        "rank 0 must be stopped too: {:?}",
-        calls(&log)
-    );
-}
-
-/// Every rank is checked, not just the first — a cluster is whole or absent.
-#[test]
-fn every_rank_is_asked_whether_it_survived() {
-    let log = new_log();
-    let (d, _) = driver(ready_rank(&log), transport(&log));
-    let (epoch, _, _) = d
-        .prepare(&recipe(), &all_three(), node_id(1), &BTreeMap::new())
-        .expect("prepares");
-    d.commit(&epoch).expect("commits");
-
-    let c = calls(&log);
-    assert!(
-        c.contains(&"local.alive(head-container)".to_owned()),
-        "{c:?}"
-    );
-    for seed in [2u8, 3] {
-        let id = node_id(seed).short();
-        assert!(
-            c.iter().any(|x| x.starts_with(&format!("{id}.alive("))),
-            "{id} was never asked: {c:?}"
-        );
-    }
-}
-
-/// A commit that failed its settling gate must leave no cluster behind to stop.
-#[test]
-fn a_cluster_that_failed_to_settle_is_not_recorded_as_running() {
-    let log = new_log();
-    let (d, _) = driver(dying_rank(&log), transport(&log));
-    let (epoch, _, _) = d
-        .prepare(&recipe(), &all_three(), node_id(1), &BTreeMap::new())
-        .expect("prepares");
-    let _ = d.commit(&epoch);
-
-    assert!(
-        d.stop_cluster().is_err(),
-        "nothing is running, so there is nothing to stop"
-    );
-}
-
-/// The gap the settle gate cannot close.
-///
-/// A rank that dies four minutes in — during model build — passed the
-/// five-second gate. Its peers then hold their GPUs indefinitely, waiting at a
-/// rendezvous that will never complete, and nothing notices.
-#[test]
-fn a_rank_that_dies_after_commit_tears_the_cluster_down() {
-    let log = new_log();
-    let (d, _) = driver(ready_rank(&log), transport(&log));
-    let (epoch, _, _) = d
-        .prepare(&recipe(), &all_three(), node_id(1), &BTreeMap::new())
-        .expect("prepares");
-    d.commit(&epoch).expect("commits");
-
-    // It was whole a moment ago.
-    assert!(d.supervise().is_none(), "a healthy cluster is left alone");
-
-    // Now rank 2 dies.
-    d.kill_for_test(node_id(2));
-    let why = d.supervise().expect("a dead rank must be noticed");
-    assert!(why.contains("spark-2"), "must name what died: {why}");
-
-    let c = calls(&log);
-    assert!(
-        c.contains(&"local.stop(head-container)".to_owned()),
-        "the survivors must be stopped: {c:?}"
-    );
-    assert!(
-        d.stop_cluster().is_err(),
-        "the cluster is gone, so there is nothing left to stop"
-    );
-}
-
-/// Supervising when nothing is running must not reach for the network.
-#[test]
-fn supervising_an_idle_agent_does_nothing() {
-    let log = new_log();
-    let (d, _) = driver(ready_rank(&log), transport(&log));
-    assert!(d.supervise().is_none());
-    assert!(calls(&log).is_empty(), "{:?}", calls(&log));
 }

--- a/crates/atlasctl-agent/src/clusterdriver/plan.rs
+++ b/crates/atlasctl-agent/src/clusterdriver/plan.rs
@@ -77,7 +77,7 @@ impl ClusterDriver {
         }
 
         Ok(Pending {
-            port: serve_port(&targets),
+            port: self.serve_port(recipe, &targets),
             epoch,
             targets,
         })
@@ -135,23 +135,44 @@ impl ClusterDriver {
     }
 }
 
-/// The port rank 0 will serve on, for the endpoint shown to the operator.
-///
-/// Read from rank 0's own settings, so it reflects what was actually planned
-/// rather than a guess made at display time.
-fn serve_port(targets: &[Target]) -> u16 {
-    targets
-        .iter()
-        .find(|t| t.assignment.rank == 0)
-        .and_then(|t| match t.assignment.settings.get("port") {
-            Some(SettingValue::Int(p)) => u16::try_from(*p).ok(),
-            _ => None,
-        })
-        .unwrap_or(DEFAULT_SERVE_PORT)
+impl ClusterDriver {
+    /// The port rank 0 will serve on, for the endpoint shown to the operator.
+    ///
+    /// Three layers, in the order that decides the answer:
+    ///
+    /// 1. What the operator set. `assignment.settings` holds **overrides only**
+    ///    — a sparse diff against the recipe, not the effective settings.
+    /// 2. What the recipe pins, asked of this machine's own copy.
+    /// 3. The serving runtime's default.
+    ///
+    /// Layer 2 was missing, and its absence was invisible in exactly the case
+    /// that matters: a recipe pinning `port: 8888` and an operator who did not
+    /// override it produced an empty settings map, so the endpoint told them
+    /// `:8000` while the model served on `:8888`. Reading a sparse diff as if
+    /// it were the whole truth is the same class of bug in either direction.
+    fn serve_port(&self, recipe: &RecipeId, targets: &[Target]) -> u16 {
+        if let Some(SettingValue::Int(p)) = targets
+            .iter()
+            .find(|t| t.assignment.rank == 0)
+            .and_then(|t| t.assignment.settings.get("port"))
+            && let Ok(p) = u16::try_from(*p)
+        {
+            return p;
+        }
+        // A recipe this machine cannot resolve is not worth failing a plan
+        // over here — the content hash above already refused that case, and
+        // this value only decorates a URL.
+        self.rank
+            .recipe_port(recipe.as_str())
+            .ok()
+            .flatten()
+            .unwrap_or(DEFAULT_SERVE_PORT)
+    }
 }
 
-/// The port a recipe serves on when it does not say otherwise.
+/// The port used when neither the operator nor the recipe names one.
 ///
-/// Not a silent fallback: it mirrors the recipe schema's own default, and it
-/// only ever decorates a URL shown to a human — nothing is launched from it.
+/// Not a silent fallback: it is the serving runtime's own default, it is only
+/// reached once both layers above have been asked, and it only ever decorates
+/// a URL shown to a human — nothing is launched from it.
 const DEFAULT_SERVE_PORT: u16 = 8000;

--- a/crates/atlasctl-agent/src/clusterdriver/teardown.rs
+++ b/crates/atlasctl-agent/src/clusterdriver/teardown.rs
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Taking a cluster down, and noticing when one takes itself down.
+//!
+//! Split from [`super::cases`] for size. These are the orderings after
+//! something is already running: a deliberate stop, a rank that dies on
+//! startup, and a rank that dies once the operator has been told it is up.
+
+use super::tests::*;
+use super::*;
+
+#[test]
+fn a_started_cluster_can_be_stopped_on_every_machine() {
+    let log = new_log();
+    let (d, _) = driver(ready_rank(&log), transport(&log));
+    let (epoch, _, _) = d
+        .prepare(&recipe(), &all_three(), node_id(1), &BTreeMap::new())
+        .expect("prepares");
+    let started = d.commit(&epoch).expect("commits");
+
+    let stopped = d.stop_cluster().expect("stops");
+    assert_eq!(stopped.len(), started.len());
+
+    let c = calls(&log);
+    assert!(
+        c.contains(&"local.stop(head-container)".to_owned()),
+        "{c:?}"
+    );
+    for seed in [2u8, 3] {
+        let id = node_id(seed).short();
+        assert!(
+            c.iter().any(|x| x.starts_with(&format!("{id}.stop("))),
+            "{id} was never stopped: {c:?}"
+        );
+    }
+}
+
+/// An agent stops the cluster it started. Asking it to stop one it did not is
+/// how a page would use its local agent to reach machines it cannot authorize.
+#[test]
+fn stopping_without_having_started_anything_is_refused() {
+    let log = new_log();
+    let (d, _) = driver(ready_rank(&log), transport(&log));
+    let err = d.stop_cluster().expect_err("nothing was started");
+    assert!(err.contains("did not start a cluster"), "{err}");
+    assert!(calls(&log).is_empty(), "no machine may be contacted");
+}
+
+/// A cluster is stopped once. A second stop must not tear down a cluster
+/// started since.
+#[test]
+fn a_cluster_is_stopped_once() {
+    let log = new_log();
+    let (d, _) = driver(ready_rank(&log), transport(&log));
+    let (epoch, _, _) = d
+        .prepare(&recipe(), &all_three(), node_id(1), &BTreeMap::new())
+        .expect("prepares");
+    d.commit(&epoch).expect("commits");
+    d.stop_cluster().expect("stops");
+
+    let before = calls(&log).len();
+    assert!(d.stop_cluster().is_err(), "the cluster is already stopped");
+    assert_eq!(
+        calls(&log).len(),
+        before,
+        "no machine may be contacted again"
+    );
+}
+
+/// A rank left running holds a whole GPU, so giving up on the first failure
+/// would be the most expensive possible response to it.
+#[test]
+fn every_rank_is_attempted_even_when_one_refuses_to_stop() {
+    let log = new_log();
+    let (d, _) = driver(refusing_stop_rank(&log), transport(&log));
+    let (epoch, _, _) = d
+        .prepare(&recipe(), &all_three(), node_id(1), &BTreeMap::new())
+        .expect("prepares");
+    d.commit(&epoch).expect("commits");
+
+    let err = d.stop_cluster().expect_err("rank 0 could not be stopped");
+    assert!(err.contains("could not stop"), "{err}");
+
+    let c = calls(&log);
+    for seed in [2u8, 3] {
+        let id = node_id(seed).short();
+        assert!(
+            c.iter().any(|x| x.starts_with(&format!("{id}.stop("))),
+            "{id} must still be stopped: {c:?}"
+        );
+    }
+}
+
+/// The failure that real hardware found. `docker run -d` returned 0 for rank 0,
+/// so the commit reported success — and rank 0's container had already died a
+/// second later, leaving rank 1 running alone and waiting forever on a
+/// rendezvous that would never complete. The operator saw a hang, not an error.
+#[test]
+fn a_rank_that_dies_on_startup_fails_the_commit_and_stops_the_rest() {
+    let log = new_log();
+    let (d, _) = driver(dying_rank(&log), transport(&log));
+    let (epoch, _, _) = d
+        .prepare(&recipe(), &all_three(), node_id(1), &BTreeMap::new())
+        .expect("prepares");
+
+    let err = d.commit(&epoch).expect_err("rank 0 did not survive");
+    assert!(err.contains("stopped within"), "{err}");
+    assert!(
+        err.contains("spark-1"),
+        "the dead machine must be named: {err}"
+    );
+
+    // The peers that did start must not be left holding a GPU.
+    let c = calls(&log);
+    for seed in [2u8, 3] {
+        let id = node_id(seed).short();
+        assert!(
+            c.iter().any(|x| x.starts_with(&format!("{id}.stop("))),
+            "{id} must be stopped: {c:?}"
+        );
+    }
+}
+
+#[test]
+fn a_peer_that_dies_on_startup_fails_the_commit_too() {
+    let log = new_log();
+    let (d, _) = driver(ready_rank(&log), transport(&log).dying(node_id(3)));
+    let (epoch, _, _) = d
+        .prepare(&recipe(), &all_three(), node_id(1), &BTreeMap::new())
+        .expect("prepares");
+
+    let err = d.commit(&epoch).expect_err("rank 2 did not survive");
+    assert!(err.contains("spark-3"), "{err}");
+    assert!(
+        calls(&log).contains(&"local.stop(head-container)".to_owned()),
+        "rank 0 must be stopped too: {:?}",
+        calls(&log)
+    );
+}
+
+/// Every rank is checked, not just the first — a cluster is whole or absent.
+#[test]
+fn every_rank_is_asked_whether_it_survived() {
+    let log = new_log();
+    let (d, _) = driver(ready_rank(&log), transport(&log));
+    let (epoch, _, _) = d
+        .prepare(&recipe(), &all_three(), node_id(1), &BTreeMap::new())
+        .expect("prepares");
+    d.commit(&epoch).expect("commits");
+
+    let c = calls(&log);
+    assert!(
+        c.contains(&"local.alive(head-container)".to_owned()),
+        "{c:?}"
+    );
+    for seed in [2u8, 3] {
+        let id = node_id(seed).short();
+        assert!(
+            c.iter().any(|x| x.starts_with(&format!("{id}.alive("))),
+            "{id} was never asked: {c:?}"
+        );
+    }
+}
+
+/// A commit that failed its settling gate must leave no cluster behind to stop.
+#[test]
+fn a_cluster_that_failed_to_settle_is_not_recorded_as_running() {
+    let log = new_log();
+    let (d, _) = driver(dying_rank(&log), transport(&log));
+    let (epoch, _, _) = d
+        .prepare(&recipe(), &all_three(), node_id(1), &BTreeMap::new())
+        .expect("prepares");
+    let _ = d.commit(&epoch);
+
+    assert!(
+        d.stop_cluster().is_err(),
+        "nothing is running, so there is nothing to stop"
+    );
+}
+
+/// The gap the settle gate cannot close.
+///
+/// A rank that dies four minutes in — during model build — passed the
+/// five-second gate. Its peers then hold their GPUs indefinitely, waiting at a
+/// rendezvous that will never complete, and nothing notices.
+#[test]
+fn a_rank_that_dies_after_commit_tears_the_cluster_down() {
+    let log = new_log();
+    let (d, _) = driver(ready_rank(&log), transport(&log));
+    let (epoch, _, _) = d
+        .prepare(&recipe(), &all_three(), node_id(1), &BTreeMap::new())
+        .expect("prepares");
+    d.commit(&epoch).expect("commits");
+
+    // It was whole a moment ago.
+    assert!(d.supervise().is_none(), "a healthy cluster is left alone");
+
+    // Now rank 2 dies.
+    d.kill_for_test(node_id(2));
+    let why = d.supervise().expect("a dead rank must be noticed");
+    assert!(why.contains("spark-2"), "must name what died: {why}");
+
+    let c = calls(&log);
+    assert!(
+        c.contains(&"local.stop(head-container)".to_owned()),
+        "the survivors must be stopped: {c:?}"
+    );
+    assert!(
+        d.stop_cluster().is_err(),
+        "the cluster is gone, so there is nothing left to stop"
+    );
+}
+
+/// Supervising when nothing is running must not reach for the network.
+#[test]
+fn supervising_an_idle_agent_does_nothing() {
+    let log = new_log();
+    let (d, _) = driver(ready_rank(&log), transport(&log));
+    assert!(d.supervise().is_none());
+    assert!(calls(&log).is_empty(), "{:?}", calls(&log));
+}

--- a/crates/atlasctl-agent/src/clusterdriver/tests.rs
+++ b/crates/atlasctl-agent/src/clusterdriver/tests.rs
@@ -68,6 +68,8 @@ pub(super) struct FixtureRank {
     commit: Result<String, String>,
     stop: Result<(), String>,
     alive: bool,
+    /// What this machine's copy of the recipe pins, as `recipe_port` answers.
+    recipe_port: Option<u16>,
 }
 
 impl FixtureRank {
@@ -78,6 +80,9 @@ impl FixtureRank {
             commit: Ok("head-container".to_owned()),
             stop: Ok(()),
             alive: true,
+            // The flagship recipes pin 8888, which is the case that made the
+            // endpoint wrong: an operator who overrides nothing.
+            recipe_port: Some(8888),
         }
     }
     fn note(&self, what: String) {
@@ -92,6 +97,9 @@ impl RankService for FixtureRank {
     }
     fn content_hash(&self, _: &str) -> anyhow::Result<String> {
         Ok("hash".to_owned())
+    }
+    fn recipe_port(&self, _: &str) -> anyhow::Result<Option<u16>> {
+        Ok(self.recipe_port)
     }
     fn prepare(&self, epoch: &str, a: &RankAssignment) -> PrepareReply {
         self.note(format!("local.prepare(rank={})", a.rank));
@@ -213,36 +221,30 @@ pub(super) fn ready_rank(log: &Log) -> FixtureRank {
 
 /// This machine, refusing to be a rank.
 pub(super) fn refusing_rank(log: &Log, why: &str) -> FixtureRank {
+    // Built by difference from the ready fixture, so a new field on the
+    // service does not have to be restated in four places to compile.
     FixtureRank {
-        log: Arc::clone(log),
         prepare: PrepareReply::Refused {
             reason: why.to_owned(),
         },
         commit: Err("was never prepared".to_owned()),
-        stop: Ok(()),
-        alive: true,
+        ..FixtureRank::ready(log)
     }
 }
 
 /// This machine, unable to stop what it started.
 pub(super) fn refusing_stop_rank(log: &Log) -> FixtureRank {
     FixtureRank {
-        log: Arc::clone(log),
-        prepare: PrepareReply::Prepared,
-        commit: Ok("head-container".to_owned()),
         stop: Err("the container runtime is not answering".to_owned()),
-        alive: true,
+        ..FixtureRank::ready(log)
     }
 }
 
 /// This machine, whose container dies moments after it starts.
 pub(super) fn dying_rank(log: &Log) -> FixtureRank {
     FixtureRank {
-        log: Arc::clone(log),
-        prepare: PrepareReply::Prepared,
-        commit: Ok("head-container".to_owned()),
-        stop: Ok(()),
         alive: false,
+        ..FixtureRank::ready(log)
     }
 }
 

--- a/crates/atlasctl-agent/src/daemon.rs
+++ b/crates/atlasctl-agent/src/daemon.rs
@@ -176,6 +176,7 @@ fn spawn_peer_poll(
                     sock,
                     id,
                     link,
+                    &crate::peer::link::SelfIntro::new(fleet.can_launch(), ""),
                     &fleet.local_addresses(),
                 )
                 .await

--- a/crates/atlasctl-agent/src/fleet/listing.rs
+++ b/crates/atlasctl-agent/src/fleet/listing.rs
@@ -23,6 +23,18 @@ use crate::fleet::FleetView;
 use anyhow::Result;
 use atlasctl_protocol::fleet::{Launchability, NodeAddress, NodeDescriptor, NodeId, PairingState};
 
+/// Turn a peer's own answer about itself into a launchability.
+///
+/// One function so the two places that decide this cannot drift, and so the
+/// wording an operator reads is the same whichever source supplied it.
+fn as_launchability(can_launch: bool) -> Launchability {
+    if can_launch {
+        Launchability::yes()
+    } else {
+        Launchability::no("this node reports it cannot run models")
+    }
+}
+
 impl FleetView for LocalFleet {
     fn nodes(&self) -> Vec<NodeDescriptor> {
         let mut out = vec![self.local_node()];
@@ -100,15 +112,20 @@ impl FleetView for LocalFleet {
                             |s| addresses_of(&s.beacon),
                         )
                     }),
-                launchability: sighting.map_or_else(
-                    || Launchability::no("not reachable right now"),
-                    |s| {
-                        if s.beacon.can_launch {
-                            Launchability::yes()
-                        } else {
-                            Launchability::no("this node reports it cannot run models")
-                        }
+                // Same precedence as everything else on this descriptor, and
+                // it was missing here: launchability came from the beacon
+                // alone. A paired machine on a network that filters multicast
+                // has no beacon — the case `peer add` exists for — so it
+                // reported "not reachable right now" and could not be given a
+                // rank, moments after completing an authenticated handshake.
+                launchability: report.map_or_else(
+                    || {
+                        sighting.map_or_else(
+                            || Launchability::no("not reachable right now"),
+                            |s| as_launchability(s.beacon.can_launch),
+                        )
                     },
+                    |r| as_launchability(r.can_launch),
                 ),
                 agent_version: String::new(),
                 accelerator: report.map_or_else(
@@ -138,11 +155,7 @@ impl FleetView for LocalFleet {
                     is_local: false,
                     pairing: PairingState::Discovered,
                     addresses: addresses_of(&s.beacon),
-                    launchability: if s.beacon.can_launch {
-                        Launchability::yes()
-                    } else {
-                        Launchability::no("this node reports it cannot run models")
-                    },
+                    launchability: as_launchability(s.beacon.can_launch),
                     agent_version: String::new(),
                     accelerator: s.beacon.accelerator.clone(),
                     vitals: None,

--- a/crates/atlasctl-agent/src/fleet/tests.rs
+++ b/crates/atlasctl-agent/src/fleet/tests.rs
@@ -202,6 +202,86 @@ fn a_beacon_claiming_it_cannot_launch_is_taken_at_its_word() {
     assert!(!peer.launchability.can_launch);
 }
 
+fn report(id: NodeId, name: &str, can_launch: bool) -> crate::peer::link::PeerReport {
+    crate::peer::link::PeerReport {
+        node: id,
+        name: name.to_owned(),
+        can_launch,
+        accelerator: "GB10".to_owned(),
+        vitals: None,
+        link: LinkClass::Roce,
+        addresses: vec![roce("10.10.10.10")],
+    }
+}
+
+/// Enterprise wifi filters multicast and the Spark links are point-to-point
+/// /30s, so a paired machine having no beacon is ordinary — it is the case
+/// `peer add` exists for. Launchability was read from the beacon alone, so
+/// such a machine reported "not reachable right now" and could not be given a
+/// rank, moments after completing an authenticated handshake with us.
+#[test]
+fn a_paired_peer_we_have_spoken_to_is_launchable_without_a_beacon() {
+    let t = Tmp::new("noboacon");
+    let f = fleet_at(&t.0);
+    let peer = Identity::generate();
+    record_pairing(
+        &PinStore::new(&t.0),
+        peer.id(),
+        &hex::encode(peer.public().as_bytes()),
+        DisplayName::new("spark-43fa"),
+        0,
+        None,
+    )
+    .expect("pin");
+    // No `observe`: nothing was ever heard on multicast.
+    f.record_report(report(peer.id(), "spark-43fa", true));
+
+    let listed = f
+        .nodes()
+        .into_iter()
+        .find(|n| n.id == peer.id())
+        .expect("listed");
+    assert_eq!(listed.pairing, PairingState::Paired);
+    assert!(
+        listed.launchability.can_launch,
+        "a peer we authenticated with was called unreachable: {:?}",
+        listed.launchability.reason
+    );
+}
+
+/// The authenticated channel outranks the beacon, and it has to: a beacon is
+/// unauthenticated, so believing it over something that proved it holds the
+/// pinned key would let anyone on the network decide whether a machine of ours
+/// is allowed to hold a rank.
+#[test]
+fn an_authenticated_report_outranks_a_beacon_that_disagrees() {
+    let t = Tmp::new("outrank");
+    let f = fleet_at(&t.0);
+    let peer = Identity::generate();
+    record_pairing(
+        &PinStore::new(&t.0),
+        peer.id(),
+        &hex::encode(peer.public().as_bytes()),
+        DisplayName::new("laptop"),
+        0,
+        None,
+    )
+    .expect("pin");
+    // The beacon says it can launch; the machine itself says it cannot.
+    f.observe(beacon(peer.id(), "laptop", true));
+    f.record_report(report(peer.id(), "laptop", false));
+
+    let listed = f
+        .nodes()
+        .into_iter()
+        .find(|n| n.id == peer.id())
+        .expect("listed");
+    assert!(
+        !listed.launchability.can_launch,
+        "a beacon overrode the machine's own authenticated answer"
+    );
+}
+
 #[test]
 fn pairing_refuses_a_code_of_the_wrong_shape_without_touching_the_network() {
     let t = Tmp::new("shape");

--- a/crates/atlasctl-agent/src/peer/cluster.rs
+++ b/crates/atlasctl-agent/src/peer/cluster.rs
@@ -12,7 +12,7 @@
 //! here skips them rather than mistaking one for an answer, bounded so that a
 //! peer sending nothing else cannot hold a phase open.
 
-use super::link::{DIAL_TIMEOUT, dial, exchange_hello};
+use super::link::{DIAL_TIMEOUT, SelfIntro, dial, exchange_hello};
 use super::wire::{PeerFrame, read_frame, write_frame};
 use crate::cluster::{PrepareReply, RankAssignment};
 use crate::identity::{Identity, PinStore};
@@ -68,10 +68,11 @@ pub async fn preview_rank(
     pins: PinStore,
     addr: SocketAddr,
     expect: NodeId,
+    intro: &SelfIntro,
     assignment: RankAssignment,
 ) -> Result<(String, Vec<String>)> {
     let mut tls = dial(identity, pins, addr, expect).await?;
-    exchange_hello(&mut tls, addr, &[]).await?;
+    exchange_hello(&mut tls, addr, intro, &[]).await?;
     write_frame(
         &mut tls,
         &PeerFrame::PreviewRank {
@@ -103,11 +104,12 @@ pub async fn prepare_rank(
     pins: PinStore,
     addr: SocketAddr,
     expect: NodeId,
+    intro: &SelfIntro,
     epoch: &str,
     assignment: RankAssignment,
 ) -> Result<PrepareReply> {
     let mut tls = dial(identity, pins, addr, expect).await?;
-    exchange_hello(&mut tls, addr, &[]).await?;
+    exchange_hello(&mut tls, addr, intro, &[]).await?;
     write_frame(
         &mut tls,
         &PeerFrame::Prepare {
@@ -144,10 +146,11 @@ pub async fn commit_rank(
     pins: PinStore,
     addr: SocketAddr,
     expect: NodeId,
+    intro: &SelfIntro,
     epoch: &str,
 ) -> Result<String> {
     let mut tls = dial(identity, pins, addr, expect).await?;
-    exchange_hello(&mut tls, addr, &[]).await?;
+    exchange_hello(&mut tls, addr, intro, &[]).await?;
     write_frame(
         &mut tls,
         &PeerFrame::Commit {
@@ -180,10 +183,11 @@ pub async fn abort_rank(
     pins: PinStore,
     addr: SocketAddr,
     expect: NodeId,
+    intro: &SelfIntro,
     epoch: &str,
 ) -> Result<()> {
     let mut tls = dial(identity, pins, addr, expect).await?;
-    exchange_hello(&mut tls, addr, &[]).await?;
+    exchange_hello(&mut tls, addr, intro, &[]).await?;
     write_frame(
         &mut tls,
         &PeerFrame::Abort {
@@ -209,10 +213,11 @@ pub async fn rank_alive(
     pins: PinStore,
     addr: SocketAddr,
     expect: NodeId,
+    intro: &SelfIntro,
     container: &str,
 ) -> Result<bool> {
     let mut tls = dial(identity, pins, addr, expect).await?;
-    exchange_hello(&mut tls, addr, &[]).await?;
+    exchange_hello(&mut tls, addr, intro, &[]).await?;
     write_frame(
         &mut tls,
         &PeerFrame::IsRankAlive {
@@ -242,10 +247,11 @@ pub async fn stop_rank(
     pins: PinStore,
     addr: SocketAddr,
     expect: NodeId,
+    intro: &SelfIntro,
     container: &str,
 ) -> Result<()> {
     let mut tls = dial(identity, pins, addr, expect).await?;
-    exchange_hello(&mut tls, addr, &[]).await?;
+    exchange_hello(&mut tls, addr, intro, &[]).await?;
     write_frame(
         &mut tls,
         &PeerFrame::StopRank {

--- a/crates/atlasctl-agent/src/peer/link.rs
+++ b/crates/atlasctl-agent/src/peer/link.rs
@@ -29,6 +29,35 @@ use std::time::Duration;
 /// How long to wait for a peer to answer before treating it as down.
 pub const DIAL_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// What this agent says about itself when it introduces itself.
+///
+/// Exists so the outbound hello cannot be written by hand at each call site.
+/// It was, and every one of them claimed `can_launch: true` — including the
+/// control-only agents whose entire purpose is to be unable to run a model. A
+/// value that must be constructed from the truth is harder to get wrong than a
+/// literal that must be remembered.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SelfIntro {
+    /// This node's display name.
+    pub name: String,
+    /// Whether this node can run a model. Never assumed.
+    pub can_launch: bool,
+    /// This node's accelerator tag, empty when it has none to report.
+    pub accelerator: String,
+}
+
+impl SelfIntro {
+    /// Describe this node. The name is derived; the capability must be supplied.
+    #[must_use]
+    pub fn new(can_launch: bool, accelerator: &str) -> Self {
+        Self {
+            name: crate::discovery::local_display_name().as_str().to_owned(),
+            can_launch,
+            accelerator: accelerator.to_owned(),
+        }
+    }
+}
+
 /// What a peer said when it introduced itself.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Hello {
@@ -123,6 +152,7 @@ pub async fn dial(
 pub async fn exchange_hello<S>(
     tls: &mut S,
     addr: SocketAddr,
+    intro: &SelfIntro,
     local: &[atlasctl_protocol::fleet::NodeAddress],
 ) -> Result<Hello>
 where
@@ -132,9 +162,9 @@ where
         tls,
         &PeerFrame::Hello {
             version: PEER_PROTOCOL_VERSION,
-            name: crate::discovery::local_display_name().as_str().to_owned(),
-            can_launch: true,
-            accelerator: String::new(),
+            name: intro.name.clone(),
+            can_launch: intro.can_launch,
+            accelerator: intro.accelerator.clone(),
             addresses: local.to_vec(),
         },
     )
@@ -186,10 +216,11 @@ pub async fn query(
     addr: SocketAddr,
     expect: NodeId,
     link: LinkClass,
+    intro: &SelfIntro,
     local: &[atlasctl_protocol::fleet::NodeAddress],
 ) -> Result<PeerReport> {
     let mut tls = dial(identity, pins, addr, expect).await?;
-    let hello = exchange_hello(&mut tls, addr, local).await?;
+    let hello = exchange_hello(&mut tls, addr, intro, local).await?;
 
     // Vitals are optional: an agent may be up and simply have nothing to say
     // about its hardware, which is not a failure.
@@ -325,6 +356,64 @@ mod tests {
             got,
             Some(("docker run rank1".to_owned(), vec!["mtp_gate".to_owned()]))
         );
+    }
+
+    /// The whole point of a control-only agent is that it cannot run a model.
+    /// Every outbound hello used to be written by hand with `can_launch: true`,
+    /// so such an agent introduced itself to every peer as able to launch.
+    #[tokio::test]
+    async fn a_control_only_agent_does_not_claim_it_can_launch() {
+        let (mut a, mut b) = tokio::io::duplex(1 << 16);
+        let intro = SelfIntro {
+            name: "laptop".to_owned(),
+            can_launch: false,
+            accelerator: String::new(),
+        };
+
+        let peer = tokio::spawn(async move {
+            let heard = read_frame(&mut b).await.unwrap();
+            // Answer so the exchange completes; the claim under test is ours.
+            write_frame(
+                &mut b,
+                &PeerFrame::Hello {
+                    version: PEER_PROTOCOL_VERSION,
+                    name: "spark".to_owned(),
+                    can_launch: true,
+                    accelerator: "gb10".to_owned(),
+                    addresses: Vec::new(),
+                },
+            )
+            .await
+            .unwrap();
+            heard
+        });
+
+        let addr: SocketAddr = "10.0.0.1:34334".parse().unwrap();
+        let theirs = exchange_hello(&mut a, addr, &intro, &[]).await.unwrap();
+        let ours = peer.await.unwrap();
+
+        match ours {
+            PeerFrame::Hello {
+                name, can_launch, ..
+            } => {
+                assert!(!can_launch, "a control-only agent claimed it can launch");
+                assert_eq!(name, "laptop");
+            }
+            other => panic!("expected a hello, got {other:?}"),
+        }
+        // And the peer's own claim is carried back untouched, which is what
+        // launchability is now derived from.
+        assert!(theirs.can_launch);
+        assert_eq!(theirs.accelerator, "gb10");
+    }
+
+    /// The name is derived, but the capability must be supplied — there is no
+    /// default, because the wrong default is the bug above.
+    #[test]
+    fn an_intro_reports_the_capability_it_was_given() {
+        assert!(!SelfIntro::new(false, "").can_launch);
+        assert!(SelfIntro::new(true, "gb10").can_launch);
+        assert_eq!(SelfIntro::new(true, "gb10").accelerator, "gb10");
     }
 
     /// A peer that only ever sends vitals must not hold the preview open.

--- a/crates/atlasctl-agent/src/rank.rs
+++ b/crates/atlasctl-agent/src/rank.rs
@@ -42,6 +42,19 @@ pub trait RankService: Send + Sync {
     /// If this machine does not have the recipe.
     fn content_hash(&self, recipe: &str) -> Result<String>;
 
+    /// The port this recipe serves on here, before any operator override.
+    ///
+    /// `None` when the recipe does not pin one, which is not an error — it
+    /// means the serving runtime's own default applies, and this agent does
+    /// not know that number.
+    ///
+    /// Asked of the machine rather than assumed, for the same reason the
+    /// content hash is: the answer lives in that machine's copy of the recipe.
+    ///
+    /// # Errors
+    /// If this machine does not have the recipe.
+    fn recipe_port(&self, recipe: &str) -> Result<Option<u16>>;
+
     /// Validate and reserve, starting nothing.
     ///
     /// A refusal here is the normal way a cluster launch fails, and the reason

--- a/crates/atlasctl-core/src/io/fs.rs
+++ b/crates/atlasctl-core/src/io/fs.rs
@@ -25,6 +25,13 @@ pub trait FileSystem: Send + Sync {
 
     /// List files directly under `dir` with the given extension, sorted.
     fn list_files(&self, dir: &Path, extension: &str) -> Result<Vec<PathBuf>>;
+
+    /// Delete a file. Removing something already absent is success.
+    ///
+    /// Idempotent on purpose: uninstalling twice, or uninstalling something a
+    /// half-finished install never wrote, must not fail. An error here would
+    /// leave the caller unable to tell "nothing to do" from "could not do it".
+    fn remove_file(&self, path: &Path) -> Result<()>;
 }
 
 /// The real implementation.
@@ -75,6 +82,14 @@ impl FileSystem for StdFileSystem {
         }
         out.sort();
         Ok(out)
+    }
+
+    fn remove_file(&self, path: &Path) -> Result<()> {
+        match std::fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e).with_context(|| format!("could not remove {}", path.display())),
+        }
     }
 }
 
@@ -153,6 +168,11 @@ mod mock {
                 .collect();
             out.sort();
             Ok(out)
+        }
+
+        fn remove_file(&self, path: &Path) -> Result<()> {
+            self.files.lock().expect("lock").remove(path);
+            Ok(())
         }
     }
 }

--- a/crates/atlasctl/src/cli.rs
+++ b/crates/atlasctl/src/cli.rs
@@ -84,6 +84,38 @@ pub enum AgentCmd {
     /// web page cannot know a code it did not cause a human to walk over and
     /// read.
     Pair(AgentPairArgs),
+    /// Install the agent so it starts on login and survives a reboot.
+    ///
+    /// A `systemd --user` unit on Linux, a LaunchAgent on macOS. Both run as
+    /// you, never as root: the agent already has docker access, and on Linux
+    /// that is root-equivalent, so a root-owned service on top would widen a
+    /// surface that is wide enough already.
+    Install(AgentInstallArgs),
+    /// Remove the background service. Leaves the binary and your pairings.
+    Uninstall,
+}
+
+/// `agent install` arguments.
+///
+/// These are written into the unit, so they are what the service uses on every
+/// future start — not just this one.
+#[derive(Args, Debug)]
+pub struct AgentInstallArgs {
+    /// Port the browser channel should listen on.
+    #[arg(long, default_value_t = atlasctl_agent::DEFAULT_PORT)]
+    pub port: u16,
+
+    /// Install as a control node: discover, pair and monitor, but never launch.
+    ///
+    /// For a laptop driving headless machines. Recorded in the unit, so the
+    /// machine stays control-only across a reboot rather than quietly becoming
+    /// something that runs models.
+    #[arg(long)]
+    pub client: bool,
+
+    /// Do not advertise on the network, and do not listen for other agents.
+    #[arg(long)]
+    pub no_discovery: bool,
 }
 
 /// `agent pair` arguments.

--- a/crates/atlasctl/src/commands/agent.rs
+++ b/crates/atlasctl/src/commands/agent.rs
@@ -168,6 +168,7 @@ pub fn run(args: &AgentRunArgs) -> Result<()> {
             Arc::clone(&identity),
             pins.clone(),
             rt.handle().clone(),
+            atlasctl_agent::peer::link::SelfIntro::new(can_launch.is_ok(), ""),
         )),
         atlasctl_agent::peer::DEFAULT_PEER_PORT,
     ));

--- a/crates/atlasctl/src/commands/mod.rs
+++ b/crates/atlasctl/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod peer;
 pub mod recipe;
 pub mod registry;
 pub mod run;
+pub mod service;
 
 use anyhow::Result;
 use atlasctl_core::io::StdFileSystem;

--- a/crates/atlasctl/src/commands/service.rs
+++ b/crates/atlasctl/src/commands/service.rs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Installing and removing the agent's background service.
+//!
+//! Split from [`super::agent`] for size. The decisions live in
+//! [`crate::service`], which is pure and tested; these two functions are the
+//! composition root — they discover this machine's paths and identity, hand
+//! the real filesystem and process runner in, and describe what happened.
+
+use anyhow::{Context, Result};
+
+/// Install the agent as a background service for this user.
+///
+/// # Errors
+/// If the platform has no supported supervisor, or a required step fails.
+pub fn install(args: &crate::cli::AgentInstallArgs) -> Result<()> {
+    let exe = std::env::current_exe().context("could not find this binary's own path")?;
+    let home = crate::hostinfo::home_dir()?;
+    let invocation = crate::service::plan::AgentInvocation {
+        exe,
+        port: args.port,
+        client: args.client,
+        discovery: !args.no_discovery,
+    };
+    let done = crate::service::install(
+        &atlasctl_core::io::StdFileSystem,
+        &atlasctl_core::io::StdProcessRunner,
+        &invocation,
+        &home,
+        uid_of(&home),
+    )?;
+
+    println!("agent installed and started");
+    println!("  unit: {}", done.unit_path.display());
+    println!("  port: {}", args.port);
+    if args.client {
+        println!("  mode: control only — it will not run a model here");
+    }
+    for s in &done.skipped {
+        // Surfaced, never swallowed: on a headless box a failed enable-linger
+        // is the difference between an agent that survives logout and one that
+        // does not, and only the operator can decide whether that matters.
+        println!("  note: {s}");
+    }
+    if done.skipped.iter().any(|s| s.contains("enable-linger")) {
+        println!(
+            "        without lingering the agent stops when you log out. Run\n\
+             \x20       `sudo loginctl enable-linger $USER` to keep it up on a headless machine."
+        );
+    }
+    println!("\nPair your browser with: atlasctl agent token");
+    Ok(())
+}
+
+/// Remove the background service.
+///
+/// # Errors
+/// If the platform has no supported supervisor, or the unit cannot be removed.
+pub fn uninstall() -> Result<()> {
+    let home = crate::hostinfo::home_dir()?;
+    let path = crate::service::uninstall(
+        &atlasctl_core::io::StdFileSystem,
+        &atlasctl_core::io::StdProcessRunner,
+        &home,
+        uid_of(&home),
+    )?;
+    println!("agent service removed ({})", path.display());
+    println!("the binary and your pairings are untouched; `atlasctl agent run` still works");
+    Ok(())
+}
+
+/// This user's id, which launchd needs in order to name a session.
+///
+/// Taken from the owner of the home directory rather than from `getuid`, so
+/// this needs no `libc` dependency — worth avoiding in a project that exists
+/// because of a supply-chain compromise, for a number used on exactly one
+/// platform. A home directory is owned by the user whose home it is.
+///
+/// Zero when it cannot be determined: only launchd reads it, and on macOS a
+/// home directory always has an owner, so the fallback is unreachable there.
+#[cfg(unix)]
+fn uid_of(home: &std::path::Path) -> u32 {
+    use std::os::unix::fs::MetadataExt;
+    std::fs::metadata(home).map(|m| m.uid()).unwrap_or(0)
+}
+
+#[cfg(not(unix))]
+fn uid_of(_home: &std::path::Path) -> u32 {
+    0
+}

--- a/crates/atlasctl/src/hostinfo.rs
+++ b/crates/atlasctl/src/hostinfo.rs
@@ -39,6 +39,20 @@ pub fn config_dir() -> Result<std::path::PathBuf> {
     Ok(std::path::PathBuf::from(base).join("atlasctl"))
 }
 
+/// This user's home directory.
+///
+/// Required, not defaulted: every path the service installer writes hangs off
+/// it, and guessing would put a unit file somewhere the supervisor does not
+/// look — which fails as "installed successfully, never starts".
+///
+/// # Errors
+/// If `HOME` is not set.
+pub fn home_dir() -> Result<std::path::PathBuf> {
+    std::env::var("HOME")
+        .map(std::path::PathBuf::from)
+        .context("HOME is not set, so there is nowhere to install a user service")
+}
+
 /// Where atlasctl caches registry clones.
 pub fn cache_dir() -> Result<std::path::PathBuf> {
     let base = std::env::var("XDG_CACHE_HOME")

--- a/crates/atlasctl/src/main.rs
+++ b/crates/atlasctl/src/main.rs
@@ -11,6 +11,7 @@ mod httpscrape;
 mod launchtelemetry;
 mod peertransport;
 mod rankservice;
+mod service;
 mod validate;
 
 use anyhow::Result;
@@ -50,6 +51,8 @@ fn run() -> Result<()> {
         Command::Agent(AgentCmd::Token(a)) => commands::agent::token(&a),
         Command::Agent(AgentCmd::Status) => commands::agent::status(),
         Command::Agent(AgentCmd::Pair(a)) => commands::agent::pair(&a),
+        Command::Agent(AgentCmd::Install(a)) => commands::service::install(&a),
+        Command::Agent(AgentCmd::Uninstall) => commands::service::uninstall(),
         Command::Peer(PeerCmd::List) => commands::peer::list(),
         Command::Peer(PeerCmd::Add(a)) => commands::peer::add(&a),
         Command::Peer(PeerCmd::Remove(a)) => commands::peer::remove(&a),

--- a/crates/atlasctl/src/peertransport.rs
+++ b/crates/atlasctl/src/peertransport.rs
@@ -11,6 +11,7 @@ use anyhow::Result;
 use atlasctl_agent::cluster::{PrepareReply, RankAssignment};
 use atlasctl_agent::identity::{Identity, PinStore};
 use atlasctl_agent::peer::cluster;
+use atlasctl_agent::peer::link::SelfIntro;
 use atlasctl_agent::transport::RankTransport;
 use atlasctl_protocol::fleet::NodeId;
 use std::future::Future;
@@ -22,6 +23,10 @@ pub struct PeerTransport {
     identity: Arc<Identity>,
     pins: PinStore,
     runtime: tokio::runtime::Handle,
+    /// How this agent introduces itself to a rank. Built once, from the same
+    /// launchability the rest of the agent reports, so a control-only head
+    /// cannot describe itself as able to run a model.
+    intro: SelfIntro,
 }
 
 impl std::fmt::Debug for PeerTransport {
@@ -33,11 +38,17 @@ impl std::fmt::Debug for PeerTransport {
 impl PeerTransport {
     /// Build a transport.
     #[must_use]
-    pub fn new(identity: Arc<Identity>, pins: PinStore, runtime: tokio::runtime::Handle) -> Self {
+    pub fn new(
+        identity: Arc<Identity>,
+        pins: PinStore,
+        runtime: tokio::runtime::Handle,
+        intro: SelfIntro,
+    ) -> Self {
         Self {
             identity,
             pins,
             runtime,
+            intro,
         }
     }
 
@@ -64,6 +75,7 @@ impl RankTransport for PeerTransport {
             self.pins.clone(),
             addr,
             node,
+            &self.intro,
             assignment.clone(),
         ))
     }
@@ -80,6 +92,7 @@ impl RankTransport for PeerTransport {
             self.pins.clone(),
             addr,
             node,
+            &self.intro,
             epoch,
             assignment.clone(),
         ))
@@ -97,6 +110,7 @@ impl RankTransport for PeerTransport {
             self.pins.clone(),
             addr,
             node,
+            &self.intro,
             epoch,
         ))
     }
@@ -107,6 +121,7 @@ impl RankTransport for PeerTransport {
             self.pins.clone(),
             addr,
             node,
+            &self.intro,
             epoch,
         ));
     }
@@ -117,6 +132,7 @@ impl RankTransport for PeerTransport {
             self.pins.clone(),
             addr,
             node,
+            &self.intro,
             container,
         ))
     }
@@ -127,6 +143,7 @@ impl RankTransport for PeerTransport {
             self.pins.clone(),
             addr,
             node,
+            &self.intro,
             container,
         ));
     }

--- a/crates/atlasctl/src/rankservice/mod.rs
+++ b/crates/atlasctl/src/rankservice/mod.rs
@@ -268,6 +268,17 @@ impl RankService for LocalRankService {
             .content_hash())
     }
 
+    fn recipe_port(&self, recipe: &str) -> Result<Option<u16>> {
+        let resolved = self
+            .registry
+            .resolve(&RecipeRef::parse(recipe))
+            .with_context(|| format!("this node does not ship recipe {recipe}"))?;
+        Ok(match resolved.defaults.get("port") {
+            Some(atlasctl_core::ScalarValue::Int(p)) => u16::try_from(*p).ok(),
+            _ => None,
+        })
+    }
+
     fn prepare(&self, epoch: &str, assignment: &RankAssignment) -> PrepareReply {
         let refuse = |r: RefusalReason| PrepareReply::Refused {
             reason: r.to_string(),

--- a/crates/atlasctl/src/service.rs
+++ b/crates/atlasctl/src/service.rs
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Installing the agent so it is there after a reboot.
+//!
+//! The website's whole premise is that a machine you own is reachable from a
+//! page you did not have to trust. That only holds if the agent is running, and
+//! an agent started by hand in a terminal stops being there the moment the
+//! terminal closes — which is not a fleet, it is a demo.
+//!
+//! Everything with a decision in it lives in [`plan`], which is pure. This file
+//! is the I/O: write the unit, run the commands, report what happened. Both the
+//! filesystem and the process runner are injected, so the orderings that matter
+//! — reload before enable, disable before delete — are tested without a
+//! systemd anywhere near the test.
+//!
+//! **This does not raise privilege.** The unit is a `systemd --user` unit and
+//! the plist a LaunchAgent; both run as the installing user. Nothing here is
+//! written to a system path and nothing asks for root. That is deliberate: the
+//! agent already has docker access, which on Linux is root-equivalent, and a
+//! root-owned service on top of that would widen a surface that is quite wide
+//! enough.
+
+pub mod plan;
+
+#[cfg(test)]
+mod tests;
+
+use anyhow::{Context, Result};
+use atlasctl_core::io::{FileSystem, ProcessRunner};
+use plan::{AgentInvocation, ServiceKind, ServicePlan};
+use std::path::PathBuf;
+
+/// What an install did, so the caller can describe it rather than guess.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Installed {
+    /// Where the unit was written.
+    pub unit_path: PathBuf,
+    /// Which supervisor now owns the agent.
+    pub kind: ServiceKind,
+    /// Steps that were allowed to fail and did, with the reason.
+    ///
+    /// Reported rather than swallowed: on a headless machine a failed
+    /// `enable-linger` is the difference between an agent that survives logout
+    /// and one that does not, and the operator can only act on it if they are
+    /// told.
+    pub skipped: Vec<String>,
+}
+
+/// Install the agent as a background service for the current user.
+///
+/// # Errors
+/// If the unit cannot be written, or a required activation step fails.
+pub fn install(
+    fs: &dyn FileSystem,
+    runner: &dyn ProcessRunner,
+    agent: &AgentInvocation,
+    home: &std::path::Path,
+    uid: u32,
+) -> Result<Installed> {
+    let kind = ServiceKind::detect()?;
+    let p = plan::plan(kind, agent, home, uid);
+
+    let parent = p
+        .unit_path
+        .parent()
+        .context("the unit path has no directory")?;
+    fs.create_dir_all(parent)?;
+    fs.write_atomic(&p.unit_path, &p.unit_body)?;
+
+    for argv in &p.activate {
+        let out = runner.run(argv)?;
+        if !out.success() {
+            // The unit is left on disk on purpose. It is the evidence for why
+            // the step failed, and deleting it would turn a diagnosable
+            // failure into "the install did nothing".
+            anyhow::bail!(
+                "`{}` failed: {}",
+                argv.join(" "),
+                first_line(&out.stderr, &out.stdout)
+            );
+        }
+    }
+
+    let mut skipped = Vec::new();
+    for argv in &p.best_effort {
+        match runner.run(argv) {
+            Ok(out) if out.success() => {}
+            Ok(out) => skipped.push(format!(
+                "{}: {}",
+                argv.join(" "),
+                first_line(&out.stderr, &out.stdout)
+            )),
+            Err(e) => skipped.push(format!("{}: {e}", argv.join(" "))),
+        }
+    }
+
+    Ok(Installed {
+        unit_path: p.unit_path,
+        kind: p.kind,
+        skipped,
+    })
+}
+
+/// Remove the service. Removing one that is not installed is success.
+///
+/// # Errors
+/// If the platform is unsupported or the unit cannot be deleted.
+pub fn uninstall(
+    fs: &dyn FileSystem,
+    runner: &dyn ProcessRunner,
+    home: &std::path::Path,
+    uid: u32,
+) -> Result<PathBuf> {
+    let kind = ServiceKind::detect()?;
+    // The invocation does not affect where the unit lives or how it is torn
+    // down, and inventing one here would be a fabricated value in a production
+    // path. These are the fields the teardown never reads.
+    let p = teardown_plan(kind, home, uid);
+
+    // Stop it before deleting the file: a supervisor asked to disable a unit
+    // whose file has already gone can refuse, leaving the service running with
+    // nothing on disk to stop it with.
+    for argv in &p.deactivate {
+        // A service that was never installed makes this fail, and that is the
+        // ordinary case for `uninstall` run twice.
+        let _ = runner.run(argv);
+    }
+    fs.remove_file(&p.unit_path)?;
+
+    if p.kind == ServiceKind::Systemd {
+        let _ = runner.run(&[
+            "systemctl".to_owned(),
+            "--user".to_owned(),
+            "daemon-reload".to_owned(),
+        ]);
+    }
+    Ok(p.unit_path)
+}
+
+/// A plan built for teardown, where the agent's flags are irrelevant.
+fn teardown_plan(kind: ServiceKind, home: &std::path::Path, uid: u32) -> ServicePlan {
+    plan::plan(
+        kind,
+        &AgentInvocation {
+            exe: PathBuf::from("atlasctl"),
+            port: 0,
+            client: false,
+            discovery: true,
+        },
+        home,
+        uid,
+    )
+}
+
+/// The first useful line of a failed command, for a message worth reading.
+fn first_line(stderr: &str, stdout: &str) -> String {
+    for s in [stderr, stdout] {
+        if let Some(l) = s.lines().map(str::trim).find(|l| !l.is_empty()) {
+            return l.to_owned();
+        }
+    }
+    "no output".to_owned()
+}

--- a/crates/atlasctl/src/service/plan.rs
+++ b/crates/atlasctl/src/service/plan.rs
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! What installing the agent as a background service consists of.
+//!
+//! Pure. Rendering the unit file and choosing the argv sequences happens here,
+//! with no filesystem and no processes, because that is the part with rules in
+//! it — the paths, the flags the service is started with, the order the
+//! commands have to run in. [`super`] does the I/O.
+//!
+//! Splitting it this way is what makes the interesting failure testable: an
+//! install that writes a unit naming the wrong binary, or one that enables a
+//! service before reloading the daemon that would notice it exists.
+
+use anyhow::{Result, bail};
+use std::path::{Path, PathBuf};
+
+/// The name the service is known by on both platforms.
+pub const SERVICE_NAME: &str = "atlasctl-agent";
+
+/// Reverse-DNS label launchd wants.
+pub const LAUNCHD_LABEL: &str = "io.atlasinference.atlasctl-agent";
+
+/// How this machine supervises background processes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServiceKind {
+    /// `systemd --user`, on Linux.
+    Systemd,
+    /// A launchd LaunchAgent, on macOS.
+    Launchd,
+}
+
+impl ServiceKind {
+    /// What this build targets.
+    ///
+    /// Windows is deliberately absent rather than guessed at: it needs a
+    /// Scheduled Task at logon, not a service, because session 0 cannot reach
+    /// Docker Desktop's per-user named pipe.
+    ///
+    /// # Errors
+    /// On a platform with no supported supervisor.
+    pub fn detect() -> Result<Self> {
+        if cfg!(target_os = "linux") {
+            Ok(Self::Systemd)
+        } else if cfg!(target_os = "macos") {
+            Ok(Self::Launchd)
+        } else {
+            bail!(
+                "installing a background service is not supported on this platform yet.\n\
+                 Run `atlasctl agent run` and keep the terminal open, or supervise it \
+                 with whatever this machine already uses."
+            )
+        }
+    }
+}
+
+/// How the agent should be started when the service brings it up.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentInvocation {
+    /// Absolute path to the atlasctl binary.
+    pub exe: PathBuf,
+    /// Port the browser channel listens on.
+    pub port: u16,
+    /// Whether this machine runs as a control node only.
+    pub client: bool,
+    /// Whether to advertise on, and listen to, the network.
+    pub discovery: bool,
+}
+
+impl AgentInvocation {
+    /// The argv the supervisor will execute.
+    ///
+    /// The port is always written out even when it matches the default. A unit
+    /// file outlives the binary that wrote it, so a later change to the default
+    /// must not silently move an installed service to a different port.
+    #[must_use]
+    pub fn argv(&self) -> Vec<String> {
+        let mut v = vec![
+            self.exe.display().to_string(),
+            "agent".to_owned(),
+            "run".to_owned(),
+            "--port".to_owned(),
+            self.port.to_string(),
+        ];
+        if self.client {
+            v.push("--client".to_owned());
+        }
+        if !self.discovery {
+            v.push("--no-discovery".to_owned());
+        }
+        v
+    }
+}
+
+/// Everything an install or uninstall has to do.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServicePlan {
+    /// Which supervisor.
+    pub kind: ServiceKind,
+    /// Where the unit or plist is written.
+    pub unit_path: PathBuf,
+    /// Its contents.
+    pub unit_body: String,
+    /// Commands to run after writing it, in order.
+    pub activate: Vec<Vec<String>>,
+    /// Commands whose failure is expected and must not fail the install.
+    ///
+    /// Separated rather than flagged inline: an install that reports success
+    /// after a step that actually failed is worse than one that never ran the
+    /// step, so "may fail" has to be a property of the plan a reader can see.
+    pub best_effort: Vec<Vec<String>>,
+    /// Commands to run before removing it, in order.
+    pub deactivate: Vec<Vec<String>>,
+}
+
+/// Plan an install for this machine.
+///
+/// `home` and `uid` are passed rather than read so this stays pure; the caller
+/// owns discovering them.
+///
+/// # Errors
+/// If the platform has no supported supervisor.
+pub fn plan(kind: ServiceKind, agent: &AgentInvocation, home: &Path, uid: u32) -> ServicePlan {
+    match kind {
+        ServiceKind::Systemd => systemd(agent, home),
+        ServiceKind::Launchd => launchd(agent, home, uid),
+    }
+}
+
+fn systemd(agent: &AgentInvocation, home: &Path) -> ServicePlan {
+    let unit = format!("{SERVICE_NAME}.service");
+    let unit_path = home.join(".config/systemd/user").join(&unit);
+    let exec = shell_words(&agent.argv());
+
+    // MemoryMax, not MemoryHigh: this is a forever-process with docker access,
+    // and a hard ceiling that kills it is easier to notice than a soft one that
+    // silently throttles it into looking hung.
+    let unit_body = format!(
+        "# Written by `atlasctl agent install`. Edits here are NOT kept:\n\
+         # reinstalling overwrites this file. Put local changes in a drop-in\n\
+         # under {SERVICE_NAME}.service.d/ instead.\n\
+         [Unit]\n\
+         Description=Atlas agent — the local control plane the website talks to\n\
+         Documentation=https://atlasinference.io/control.html\n\
+         After=network-online.target\n\
+         Wants=network-online.target\n\
+         \n\
+         [Service]\n\
+         Type=simple\n\
+         ExecStart={exec}\n\
+         Restart=on-failure\n\
+         RestartSec=5\n\
+         MemoryMax=256M\n\
+         # The agent re-adopts containers it already started, so a restart does\n\
+         # not orphan a running model.\n\
+         KillMode=mixed\n\
+         \n\
+         [Install]\n\
+         WantedBy=default.target\n"
+    );
+
+    let sc = |args: &[&str]| {
+        let mut v = vec!["systemctl".to_owned(), "--user".to_owned()];
+        v.extend(args.iter().map(|s| (*s).to_owned()));
+        v
+    };
+
+    ServicePlan {
+        kind: ServiceKind::Systemd,
+        unit_path,
+        unit_body,
+        // daemon-reload first: enabling a unit systemd has not read yet fails,
+        // and it fails in a way that reads like the unit was never written.
+        activate: vec![sc(&["daemon-reload"]), sc(&["enable", "--now", &unit])],
+        // A headless box logs nobody in, so without lingering the service stops
+        // the moment the installing session ends. It is also exactly the call
+        // that is unavailable in a container, so it cannot be required.
+        best_effort: vec![vec!["loginctl".to_owned(), "enable-linger".to_owned()]],
+        deactivate: vec![sc(&["disable", "--now", &unit])],
+    }
+}
+
+fn launchd(agent: &AgentInvocation, home: &Path, uid: u32) -> ServicePlan {
+    let unit_path = home
+        .join("Library/LaunchAgents")
+        .join(format!("{LAUNCHD_LABEL}.plist"));
+    let args = agent
+        .argv()
+        .iter()
+        .map(|a| format!("    <string>{}</string>", xml_escape(a)))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let logs = home
+        .join("Library/Logs")
+        .join(format!("{SERVICE_NAME}.log"));
+    let log = xml_escape(&logs.display().to_string());
+
+    let unit_body = format!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+         <!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \
+         \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n\
+         <plist version=\"1.0\">\n\
+         <dict>\n\
+         \x20 <key>Label</key>\n\
+         \x20 <string>{LAUNCHD_LABEL}</string>\n\
+         \x20 <key>ProgramArguments</key>\n\
+         \x20 <array>\n{args}\n\
+         \x20 </array>\n\
+         \x20 <key>RunAtLoad</key>\n\
+         \x20 <true/>\n\
+         \x20 <key>KeepAlive</key>\n\
+         \x20 <dict><key>SuccessfulExit</key><false/></dict>\n\
+         \x20 <key>StandardOutPath</key>\n\
+         \x20 <string>{log}</string>\n\
+         \x20 <key>StandardErrorPath</key>\n\
+         \x20 <string>{log}</string>\n\
+         </dict>\n\
+         </plist>\n"
+    );
+
+    let target = format!("gui/{uid}");
+    let path = unit_path.display().to_string();
+    ServicePlan {
+        kind: ServiceKind::Launchd,
+        unit_path: unit_path.clone(),
+        unit_body,
+        activate: vec![vec![
+            "launchctl".to_owned(),
+            "bootstrap".to_owned(),
+            target.clone(),
+            path,
+        ]],
+        best_effort: Vec::new(),
+        deactivate: vec![vec![
+            "launchctl".to_owned(),
+            "bootout".to_owned(),
+            format!("{target}/{LAUNCHD_LABEL}"),
+        ]],
+    }
+}
+
+/// Quote an argv for a systemd `ExecStart=` line.
+///
+/// systemd splits `ExecStart` on whitespace itself, so a path containing a
+/// space has to be quoted or the unit silently invokes the wrong binary.
+fn shell_words(argv: &[String]) -> String {
+    argv.iter()
+        .map(|a| {
+            if a.is_empty() || a.contains(|c: char| c.is_whitespace() || c == '"' || c == '\\') {
+                format!("\"{}\"", a.replace('\\', "\\\\").replace('"', "\\\""))
+            } else {
+                a.clone()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Escape a value for the plist, which is XML.
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}

--- a/crates/atlasctl/src/service/tests.rs
+++ b/crates/atlasctl/src/service/tests.rs
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The orderings and the quoting, which are what actually break.
+//!
+//! No systemd and no filesystem: both are injected, so every case below is the
+//! real code path with recording doubles in place of the machine.
+
+use super::plan::{AgentInvocation, ServiceKind, plan};
+use super::*;
+use anyhow::Result;
+use atlasctl_core::io::process::Output;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+/// Records every argv, and can be told which ones fail.
+struct Recorder {
+    calls: Mutex<Vec<String>>,
+    fail: Vec<String>,
+}
+
+impl Recorder {
+    fn new() -> Self {
+        Self {
+            calls: Mutex::new(Vec::new()),
+            fail: Vec::new(),
+        }
+    }
+    fn failing(what: &str) -> Self {
+        Self {
+            calls: Mutex::new(Vec::new()),
+            fail: vec![what.to_owned()],
+        }
+    }
+    fn calls(&self) -> Vec<String> {
+        self.calls.lock().expect("lock").clone()
+    }
+}
+
+impl ProcessRunner for Recorder {
+    fn run(&self, argv: &[String]) -> Result<Output> {
+        let line = argv.join(" ");
+        self.calls.lock().expect("lock").push(line.clone());
+        let failed = self.fail.iter().any(|f| line.contains(f.as_str()));
+        Ok(Output {
+            status: i32::from(failed),
+            stdout: String::new(),
+            stderr: if failed {
+                "Interactive authentication required.\n".to_owned()
+            } else {
+                String::new()
+            },
+        })
+    }
+    fn run_streaming(&self, _: &[String]) -> Result<i32> {
+        unreachable!("the installer never streams")
+    }
+}
+
+/// A filesystem that records writes and removals.
+#[derive(Default)]
+struct Files {
+    written: Mutex<Vec<(PathBuf, String)>>,
+    removed: Mutex<Vec<PathBuf>>,
+    dirs: Mutex<Vec<PathBuf>>,
+}
+
+impl Files {
+    fn body(&self) -> String {
+        self.written
+            .lock()
+            .expect("lock")
+            .first()
+            .map(|(_, b)| b.clone())
+            .unwrap_or_default()
+    }
+}
+
+impl FileSystem for Files {
+    fn read_to_string(&self, _: &Path) -> Result<String> {
+        anyhow::bail!("the installer never reads")
+    }
+    fn write_atomic(&self, path: &Path, contents: &str) -> Result<()> {
+        self.written
+            .lock()
+            .expect("lock")
+            .push((path.to_path_buf(), contents.to_owned()));
+        Ok(())
+    }
+    fn exists(&self, _: &Path) -> bool {
+        false
+    }
+    fn create_dir_all(&self, path: &Path) -> Result<()> {
+        self.dirs.lock().expect("lock").push(path.to_path_buf());
+        Ok(())
+    }
+    fn list_files(&self, _: &Path, _: &str) -> Result<Vec<PathBuf>> {
+        Ok(Vec::new())
+    }
+    fn remove_file(&self, path: &Path) -> Result<()> {
+        self.removed.lock().expect("lock").push(path.to_path_buf());
+        Ok(())
+    }
+}
+
+fn agent() -> AgentInvocation {
+    AgentInvocation {
+        exe: PathBuf::from("/home/o/.local/bin/atlasctl"),
+        port: 34333,
+        client: false,
+        discovery: true,
+    }
+}
+
+fn home() -> PathBuf {
+    PathBuf::from("/home/o")
+}
+
+// ---- the pure plan -------------------------------------------------------
+
+/// systemd refuses to enable a unit it has not read. Enabling before the
+/// reload fails in a way that reads like the unit was never written at all.
+#[test]
+fn systemd_reloads_before_it_enables() {
+    let p = plan(ServiceKind::Systemd, &agent(), &home(), 1000);
+    let order: Vec<String> = p.activate.iter().map(|a| a.join(" ")).collect();
+    let reload = order.iter().position(|c| c.contains("daemon-reload"));
+    let enable = order.iter().position(|c| c.contains("enable"));
+    assert!(reload < enable, "reload must come first: {order:?}");
+}
+
+/// The port is written even when it equals today's default. A unit file
+/// outlives the binary that wrote it, so a later change to the default must
+/// not silently move an installed service to a different port.
+#[test]
+fn the_unit_pins_the_port_explicitly() {
+    let p = plan(ServiceKind::Systemd, &agent(), &home(), 1000);
+    assert!(
+        p.unit_body.contains("--port 34333"),
+        "the unit did not pin the port:\n{}",
+        p.unit_body
+    );
+}
+
+/// A control-only install must stay control-only across a reboot. Dropping the
+/// flag would silently promote a laptop into a machine that runs models.
+#[test]
+fn a_control_only_install_carries_the_flag_into_the_unit() {
+    let a = AgentInvocation {
+        client: true,
+        ..agent()
+    };
+    let p = plan(ServiceKind::Systemd, &a, &home(), 1000);
+    assert!(p.unit_body.contains("--client"), "{}", p.unit_body);
+
+    let normal = plan(ServiceKind::Systemd, &agent(), &home(), 1000);
+    assert!(!normal.unit_body.contains("--client"));
+}
+
+/// systemd splits ExecStart on whitespace itself, so an unquoted path with a
+/// space in it invokes a different binary — or nothing.
+#[test]
+fn a_path_with_a_space_is_quoted_in_execstart() {
+    let a = AgentInvocation {
+        exe: PathBuf::from("/home/My User/bin/atlasctl"),
+        ..agent()
+    };
+    let p = plan(ServiceKind::Systemd, &a, &home(), 1000);
+    let exec = p
+        .unit_body
+        .lines()
+        .find(|l| l.starts_with("ExecStart="))
+        .expect("ExecStart");
+    assert!(
+        exec.contains("\"/home/My User/bin/atlasctl\""),
+        "unquoted path in {exec}"
+    );
+}
+
+/// The plist is XML, so an argument carrying a metacharacter must not be able
+/// to close a tag and rewrite the rest of the document.
+#[test]
+fn plist_arguments_are_xml_escaped() {
+    let a = AgentInvocation {
+        exe: PathBuf::from("/o/<a&b>/atlasctl"),
+        ..agent()
+    };
+    let p = plan(ServiceKind::Launchd, &a, &home(), 501);
+    assert!(p.unit_body.contains("&lt;a&amp;b&gt;"), "{}", p.unit_body);
+    assert!(
+        !p.unit_body.contains("/o/<a&b>/"),
+        "raw metacharacters reached the plist"
+    );
+}
+
+/// linger is what keeps the agent alive on a headless box after the installing
+/// session ends — and it is exactly the call that is unavailable in a
+/// container, so it can never be a required step.
+#[test]
+fn lingering_is_best_effort_not_required() {
+    let p = plan(ServiceKind::Systemd, &agent(), &home(), 1000);
+    let required: Vec<String> = p.activate.iter().map(|a| a.join(" ")).collect();
+    assert!(
+        !required.iter().any(|c| c.contains("enable-linger")),
+        "linger must not be able to fail an install: {required:?}"
+    );
+    assert!(
+        p.best_effort
+            .iter()
+            .any(|a| a.join(" ").contains("enable-linger"))
+    );
+}
+
+// ---- the I/O half --------------------------------------------------------
+
+#[cfg(target_os = "linux")]
+#[test]
+fn a_successful_install_writes_the_unit_then_activates_it() {
+    let fs = Files::default();
+    let r = Recorder::new();
+    let out = install(&fs, &r, &agent(), &home(), 1000).expect("installs");
+
+    assert_eq!(
+        out.unit_path,
+        home().join(".config/systemd/user/atlasctl-agent.service")
+    );
+    assert!(fs.body().contains("ExecStart="));
+    assert!(out.skipped.is_empty());
+    let calls = r.calls();
+    assert!(calls[0].contains("daemon-reload"), "{calls:?}");
+    assert!(calls[1].contains("enable --now"), "{calls:?}");
+}
+
+/// A failed linger is reported, not swallowed: on a headless machine it is the
+/// difference between an agent that survives logout and one that does not, and
+/// the operator can only act on it if they are told.
+#[cfg(target_os = "linux")]
+#[test]
+fn a_failed_best_effort_step_is_reported_but_still_installs() {
+    let fs = Files::default();
+    let r = Recorder::failing("enable-linger");
+    let out = install(&fs, &r, &agent(), &home(), 1000).expect("still installs");
+    assert_eq!(out.skipped.len(), 1);
+    assert!(
+        out.skipped[0].contains("enable-linger"),
+        "{:?}",
+        out.skipped
+    );
+    assert!(
+        out.skipped[0].contains("Interactive authentication required"),
+        "the reason must survive: {:?}",
+        out.skipped
+    );
+}
+
+/// A required step failing must fail the install, and must say which step.
+#[cfg(target_os = "linux")]
+#[test]
+fn a_failed_required_step_fails_the_install_and_names_itself() {
+    let fs = Files::default();
+    let r = Recorder::failing("enable --now");
+    let e = install(&fs, &r, &agent(), &home(), 1000).expect_err("must fail");
+    let msg = format!("{e:#}");
+    assert!(msg.contains("enable --now"), "{msg}");
+    // The unit stays on disk: it is the evidence for why the step failed.
+    assert_eq!(fs.written.lock().expect("lock").len(), 1);
+}
+
+/// A supervisor asked to disable a unit whose file has already gone can
+/// refuse, leaving the service running with nothing on disk to stop it with.
+#[cfg(target_os = "linux")]
+#[test]
+fn uninstall_stops_the_service_before_deleting_its_unit() {
+    let fs = Files::default();
+    let r = Recorder::new();
+    let path = uninstall(&fs, &r, &home(), 1000).expect("uninstalls");
+
+    assert_eq!(
+        path,
+        home().join(".config/systemd/user/atlasctl-agent.service")
+    );
+    assert!(r.calls()[0].contains("disable --now"), "{:?}", r.calls());
+    assert_eq!(*fs.removed.lock().expect("lock"), vec![path]);
+}
+
+/// Uninstalling twice, or uninstalling something a half-finished install never
+/// wrote, is the ordinary case and must not be an error.
+#[cfg(target_os = "linux")]
+#[test]
+fn uninstalling_something_that_was_never_installed_succeeds() {
+    let fs = Files::default();
+    let r = Recorder::failing("disable");
+    uninstall(&fs, &r, &home(), 1000).expect("must not fail");
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -85,6 +85,36 @@ verify_attestation() {
     fi
 }
 
+# Put the agent behind this machine's own supervisor, so the website has
+# something to talk to after a reboot rather than only while a terminal is open.
+#
+# Never fatal. A container with no user systemd bus is a normal place to install
+# atlasctl, and the CLI works fully without an agent — so a failure here is a
+# note, not an error. ATLASCTL_NO_AGENT=1 skips it for anyone who would rather
+# decide when a background process with docker access starts running.
+install_agent() {
+    # The binary's path is passed rather than read from a variable another
+    # function happened to set: install.sh runs under `set -eu` piped from the
+    # network, and an unset global there fails at the least helpful moment.
+    exe="$1"
+    if [ -n "${ATLASCTL_NO_AGENT:-}" ]; then
+        info "skipping the background agent (ATLASCTL_NO_AGENT is set)."
+        info "start it yourself later with: $BIN_NAME agent install"
+        return
+    fi
+    info "installing the background agent"
+    if "$exe" agent install >/dev/null 2>&1; then
+        info "the agent is running and will start on login."
+        info "pair your browser with: $BIN_NAME agent token"
+        return
+    fi
+    warn "could not install the agent as a service on this machine."
+    warn "atlasctl itself is installed and works. To run the agent by hand:"
+    warn "    $BIN_NAME agent run"
+    warn "or, to see why the service install failed:"
+    warn "    $BIN_NAME agent install"
+}
+
 check_docker() {
     if ! command -v docker >/dev/null 2>&1; then
         warn "docker was not found. \`atlasctl run\` needs it; \`atlasctl list\` and"
@@ -201,6 +231,7 @@ main() {
 
     check_docker
     check_sparkrun
+    install_agent "$dir/$BIN_NAME"
 
     info "done. Try:"
     info "    $BIN_NAME list"


### PR DESCRIPTION
Control-only mode — an agent on a machine that cannot run models, driving headless boxes over the LAN — had two defects that only matter together.

## The claim

Every **outbound** peer hello was written by hand at its call site with `can_launch: true` and an empty accelerator — seven of them, across `link.rs` and the six rank verbs in `cluster.rs`. A control-only agent therefore introduced itself to every peer as able to run a model.

The inbound direction was already honest: `serve_query` takes the real flag. So the lie was ours alone, and `PeerReport::can_launch` — populated from the peer's answer — was correct but read by nobody.

Replaced with `SelfIntro`, built from the same launchability the rest of the agent reports. The name is derived; **the capability must be supplied**. No default, because the wrong default is this bug.

## The precedence

`listing.rs` opens by stating its own rule:

> 1. A **peer report** — something holding the key we pinned, said over the authenticated channel — wins outright.
> 2. A **beacon sighting** places a machine and nothing more.

That rule was applied to `addresses`, `accelerator` and `vitals` — but not to `launchability`, which read the beacon alone. Two consequences:

- **A paired machine with no beacon reported `not reachable right now`** and could not be given a rank, moments after completing an authenticated handshake with us. Having no beacon is ordinary: enterprise wifi filters multicast, and the Spark fabric links are point-to-point `/30`s where multicast reaches exactly one peer. It is the case `peer add` exists for — and it is exactly the control-only setup.
- **An unauthenticated beacon outranked the machine's own authenticated answer**, so anyone on the network could decide whether a machine of ours was allowed to hold a rank.

Launchability now follows the documented precedence: report → beacon → not reachable, through one shared function so the two sites cannot drift and the operator reads the same wording either way.

## Why both, or neither

Fixing either half alone would be worse than fixing neither. Trusting reports while still claiming `can_launch: true` would make **every** control-only agent report itself launchable to its peers — turning a display gap into a scheduling one.

## Tests

Four new, each failing before this change:

| test | what it pins |
|---|---|
| `a_control_only_agent_does_not_claim_it_can_launch` | the outbound hello carries the real flag; the peer's answer is carried back untouched |
| `an_intro_reports_the_capability_it_was_given` | there is no default capability |
| `a_paired_peer_we_have_spoken_to_is_launchable_without_a_beacon` | the multicast-filtered case |
| `an_authenticated_report_outranks_a_beacon_that_disagrees` | a beacon cannot override the machine itself |

`cargo test --workspace` green (207 in `atlasctl-agent`), `fmt --check` clean, clippy clean, no file over the 500-line cap, no new vendor-specific literals outside provider modules.