### PR TITLE
fix(release): the repair step threw away the manifest fix it had just made

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,16 @@ jobs:
           # Repairing it here rather than fighting release-please also makes a
           # split release harmless — each requirement gets the version of the
           # crate it actually names, whether or not the crates moved together.
+          # One list, shared by the "is there anything to do" test and the
+          # staging below. These were two separate literals, and
+          # .release-please-manifest.json was in neither — so --fix repaired
+          # the manifest, git add did not stage it, and the repair was thrown
+          # away while the job reported success. That is not a hypothetical:
+          # it is what happened to atlasctl-protocol on 2026-08-26, leaving the
+          # release PR recording 0.1.3 for a crate it was about to publish as
+          # 0.2.0.
+          REPAIRED=(.release-please-manifest.json Cargo.lock Cargo.toml crates/*/Cargo.toml)
+
           python3 scripts/check-version-sync.py --fix
 
           # The lock follows from the manifests, so it is regenerated after
@@ -135,7 +145,7 @@ jobs:
           # meaning.
           cargo metadata --locked --format-version 1 >/dev/null 2>&1 || cargo update --workspace
 
-          if git diff --quiet -- Cargo.lock '*Cargo.toml'; then
+          if git diff --quiet -- "${REPAIRED[@]}"; then
             echo "release PR already consistent; nothing to repair"
             exit 0
           fi
@@ -146,9 +156,14 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add Cargo.lock Cargo.toml crates/*/Cargo.toml
+          git add -- "${REPAIRED[@]}"
           git commit -m "chore: sync manifests and lock with the versions release-please wrote"
           git push origin HEAD:release-please--branches--main
+
+          # Prove the push fixed what it set out to fix. A repair that stages
+          # nothing looked exactly like a successful one, which is how the
+          # stale manifest survived a green job.
+          python3 scripts/check-version-sync.py
 
   # A pull request opened by the default GITHUB_TOKEN does not trigger
   # workflows, so the standing release PR gets no CI — which is how three


### PR DESCRIPTION
#52 taught `--fix` to repair a stale `.release-please-manifest.json` entry. It did — and then the release job discarded the repair and reported success.

## The bug

The step named the files it cared about in **two places**, and `.release-please-manifest.json` was in neither:

```bash
git diff --quiet -- Cargo.lock '*Cargo.toml'        # manifest-only change → "nothing to repair", exit 0
git add Cargo.lock Cargo.toml crates/*/Cargo.toml   # manifest never staged
```

So a run where only the manifest needed repair exited early, and a run that repaired other things committed everything *except* the manifest. **Both look identical to success.**

Observed today: run `32991222582`, job `sync the release PR's Cargo.lock` → `completed/success`, commit `04b6ac0` pushed, and `atlasctl-protocol` still recorded as `0.1.3` in a release PR about to publish it as `0.2.0`.

That combination is the dangerous one. crates.io would have accepted the publish; the *next* release would then compute from `0.1.3`, propose a version already taken, and fail permanently against an immutable version.

## The fix

This is the same mistake as staging only `Cargo.lock`, one file further along. So rather than add a third literal to keep in sync, there is now **one list**:

```bash
REPAIRED=(.release-please-manifest.json Cargo.lock Cargo.toml crates/*/Cargo.toml)
...
if git diff --quiet -- "${REPAIRED[@]}"; then ...
git add -- "${REPAIRED[@]}"
```

And a verification run of the plain check **after** the push:

```bash
python3 scripts/check-version-sync.py
```

A repair that stages nothing was indistinguishable from one that worked. That is precisely how a stale manifest survived a green job, so the job now proves it fixed what it set out to fix.

## Verified

Simulated the whole step against the real release branch (push suppressed):

```
=== BEFORE ===  "crates/atlasctl-protocol": "0.1.3"
=== AFTER  ===  "crates/atlasctl-protocol": "0.2.0"

commit 5c7786d chore: sync manifests and lock with the versions release-please wrote
 .release-please-manifest.json | 2 +-

ok   release manifest crates/atlasctl-protocol 0.2.0    ← post-push check passes
```

Also checked: `bash -n` on the extracted step, the array+glob expands to exactly the seven intended paths, and `git diff --quiet -- "${REPAIRED[@]}"` accepts them as a pathspec. Actions runs this step under `bash -e`, so the array is fine.