### PR TITLE
fix(release): the already-published guard never fired

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -354,10 +354,33 @@ jobs:
             | python3 -c "import json,sys;print(next(p['version'] for p in json.load(sys.stdin)['packages'] if p['name']=='atlasctl'))")
           # atlasctl publishes last, so its presence means the whole workspace
           # went out. Makes a re-run after a fully successful publish a no-op.
-          if curl -fsSL "https://crates.io/api/v1/crates/atlasctl/$version" >/dev/null 2>&1; then
-            echo "atlasctl $version already published; workspace is already out"
-            exit 0
-          fi
+          #
+          # The User-Agent is REQUIRED, not politeness. crates.io answers a bare
+          # `curl` with 403 under its API data access policy, so this check used
+          # to fail every time and the guard never fired once: a re-run always
+          # fell through to `cargo publish`, which then died on the first crate
+          # that already existed, and `verify-published` reported the release
+          # had not shipped when in fact it had. That is exactly what v0.2.0 did.
+          ua='atlasctl-release (+https://github.com/Avarok-Cybersecurity/atlas-recipes)'
+          code=$(curl -sS -o /dev/null -w '%{http_code}' -A "$ua" \
+                   "https://crates.io/api/v1/crates/atlasctl/$version" || echo 000)
+          case "$code" in
+            200)
+              echo "atlasctl $version already published; workspace is already out"
+              exit 0
+              ;;
+            404)
+              echo "atlasctl $version is not on crates.io yet; publishing"
+              ;;
+            *)
+              # Neither "there" nor "not there". Publishing anyway is safe —
+              # crates.io refuses a duplicate — but say why the guard could not
+              # answer, so a 403 like the one above is visible next time rather
+              # than silently turning every re-run into a failure.
+              echo "::warning::crates.io answered $code for the published-version check; \
+              proceeding, and a duplicate will be refused by the registry"
+              ;;
+          esac
           cargo publish --workspace --locked
 
   wheels:


### PR DESCRIPTION
`v0.2.0` shipped on **every** channel and the release was reported as **failed**.

## What happened

The crates.io job's idempotency check is:

```bash
curl -fsSL "https://crates.io/api/v1/crates/atlasctl/$version"
```

crates.io answers a bare `curl` with **403** under its [API data access policy](https://crates.io/data-access), which requires a descriptive User-Agent. So the check returned non-zero *every single time*, the guard **never once fired**, and the job fell through to `cargo publish --workspace`:

```
error: crate atlasctl-core@0.1.4 already exists on crates.io index
```

`verify-published` believed that and declared the release hadn't shipped:

```
github-release   success
crates.io        failure
PyPI             success
smoke-install    success
::error::release v0.2.0 did not ship
```

Verified against the live registry:

| form | result for a version that **is** published |
|---|---|
| `curl -fsSL <url>` (as written) | **exit 22** — guard never fires |
| `curl -A '<ua>' <url>` | **HTTP 200** — guard fires |
| bare `curl`, body | `403 … you are in violation of our API data access policy` |

## Why it's worse than a red tick

Re-running a release is the documented recovery path for a partial publish. It **could not succeed** after any crate had gone out — so the failure mode the guard exists to handle is precisely the one that guaranteed it would fail. This release only needed a re-run because of the musl wheel bug (#54); the re-run then hit this.

## The fix

Send a User-Agent, and branch on the **status code** rather than curl's exit:

- `200` — already out, exit 0
- `404` — not there, publish
- anything else — warn *with the code* and publish anyway: crates.io refuses a duplicate so it's safe, and a silently inconclusive answer is exactly what hid this 403 for four releases

## Verified

Running the real step body against the live registry:

```
$ SIM_VERSION=0.1.4    → atlasctl 0.1.4 already published; workspace is already out
$ SIM_VERSION=99.99.99 → atlasctl 99.99.99 is not on crates.io yet; publishing
                         WOULD PUBLISH
```

## Note on the v0.2.0 release itself

Nothing is wrong with it. All five crates are on crates.io (`atlas-recipes-data` and `atlasctl-protocol` at 0.2.0, the rest at 0.1.4) and `pyatlasctl` 0.1.4 is on PyPI with all six wheel platforms plus an sdist. Only the *report* was wrong.