### PR TITLE
fix(cli): say why a join was refused, not which TLS alert arrived

### DIFF
--- a/crates/atlasctl-agent/src/peer/join.rs
+++ b/crates/atlasctl-agent/src/peer/join.rs
@@ -66,5 +66,36 @@ pub async fn dial_and_pair(
         (id, crate::pairing::binding_from_client(conn)?)
     };
 
-    run(&mut tls, Role::Initiator, identity, peer_id, code, binding).await
+    run(&mut tls, Role::Initiator, identity, peer_id, code, binding)
+        .await
+        .map_err(explain)
+}
+
+/// Turn a refusal into something the operator can act on.
+///
+/// The interesting failure is the one that arrives as a TLS alert. The other
+/// machine only admits an unpinned peer while a join window is open, so it
+/// hangs up during the handshake — before the code is ever offered — when the
+/// invitation has expired, has already been used, or was never minted. What
+/// reaches the operator without this is `received fatal alert: HandshakeFailure`
+/// or a bare broken pipe, on the machine being added, from someone who just
+/// pasted a command they did not write.
+///
+/// A *wrong* code fails later and differently, at key confirmation, and is left
+/// to say so itself.
+fn explain(e: anyhow::Error) -> anyhow::Error {
+    let text = format!("{e:#}");
+    let refused_at_handshake = text.contains("HandshakeFailure")
+        || text.contains("Broken pipe")
+        || text.contains("CertificateUnknown")
+        || text.contains("certificate")
+        || text.contains("connection closed");
+    if !refused_at_handshake {
+        return e;
+    }
+    e.context(concat!(
+        "that machine is not accepting a new member right now.\n",
+        "An invitation is good for one machine, once, and it expires. ",
+        "Mint a fresh one and run this again."
+    ))
 }


### PR DESCRIPTION
Verified the onboarding flow from #56 on real agents. Everything works:

```
$ mint over the browser channel   → {"code":"94164900","addresses":["10.10.10.9",…],"expires_in_s":600}
$ atlasctl peer add 127.0.0.1 --code 94164900
  Verification words:  57d8-b562
  Paired with spark-256a (238f-630c-e694-09a8).
# and on the inviting agent:
  paired with spark-256a (9307-10f6-e245-6350)
```

A running agent accepting a new machine — which was impossible before #56.

Both security properties hold, verified rather than assumed:

| case | result | pin written? |
|---|---|---|
| reuse a spent code | refused at the TLS handshake | **no** |
| stranger, no window open | refused at the TLS handshake | **no** |

## What this PR fixes

The refusals were right. The messages were not:

```
error: reading a peer frame length
  caused by: received fatal alert: HandshakeFailure

error: Broken pipe (os error 32)
```

That is read **on the machine being added**, by someone who just pasted a command they didn't write, and it says nothing about what to do.

The refusal happening at the handshake is the design working — the other machine admits an unpinned peer only while a join window is open, so it hangs up *before the code is ever offered*. Three situations arrive identically (expired, already used, never minted) and all three have the same remedy, so the message names the remedy rather than the mechanism:

```
error: that machine is not accepting a new member right now.
An invitation is good for one machine, once, and it expires. Mint a fresh one and run this again.
  caused by: Broken pipe (os error 32)
```

The underlying cause is kept as context, so the mechanism is still there for anyone debugging.

A **wrong** code fails later and differently — at key confirmation — and is deliberately left to say so itself rather than being swallowed into this one.

Verified after the change: a stale code gives the new message, a freshly minted one still pairs.