### PR TITLE
feat(agent): report what accelerator a machine actually has

### DIFF
--- a/crates/atlasctl-agent/src/telemetry/mod.rs
+++ b/crates/atlasctl-agent/src/telemetry/mod.rs
@@ -43,6 +43,27 @@ pub fn probe(runner: &dyn ProcessRunner) -> TelemetryCaps {
     }
 }
 
+/// What this machine's accelerator calls itself, for display.
+///
+/// Already parsed out of the capability probe's own output — `name` is the
+/// first field of the query — so this costs one extra invocation at startup
+/// and no new vendor-specific code. The fleet showed an empty string here
+/// while the reading it came from said "NVIDIA GB10".
+///
+/// `None` when there is no accelerator, or when it declines to name itself.
+/// An empty string is not a name, and rendering one puts a separator with
+/// nothing after it in the interface.
+pub fn accelerator_name(runner: &dyn ProcessRunner) -> Option<String> {
+    let out = runner.run(&nvidia::argv()).ok()?;
+    if !out.success() {
+        return None;
+    }
+    nvidia::parse(out.stdout.lines().next().unwrap_or_default())
+        .name
+        .map(|n| n.trim().to_owned())
+        .filter(|n| !n.is_empty())
+}
+
 /// Take one device sample, reporting only what the capabilities allow.
 ///
 /// `busy` says whether the engine has work in flight, which is what makes a low

--- a/crates/atlasctl/src/commands/agent.rs
+++ b/crates/atlasctl/src/commands/agent.rs
@@ -139,6 +139,13 @@ pub fn run(args: &AgentRunArgs) -> Result<()> {
         .build()
         .context("starting the async runtime")?;
 
+    // Asked once at startup rather than sampled: a machine does not change
+    // what accelerator it has while the agent is running, and the fleet view
+    // showed an empty string here for every node while the reading it came
+    // from already said "NVIDIA GB10".
+    let accelerator =
+        atlasctl_agent::telemetry::accelerator_name(runner.as_ref()).unwrap_or_default();
+
     let pins = atlasctl_agent::identity::PinStore::new(&config_dir);
     // Shared by the listener, which admits a stranger only while it is open,
     // and by the browser verb that opens it. One window, or the gate and the
@@ -150,7 +157,7 @@ pub fn run(args: &AgentRunArgs) -> Result<()> {
         atlasctl_agent::discovery::local_display_name(),
         addresses.clone(),
         launchability,
-        String::new(),
+        accelerator.clone(),
     )
     .with_vitals(Box::new(vitals))
     .with_running(Box::new(atlasctl_agent::fleet::DockerRunning(Arc::clone(
@@ -194,7 +201,7 @@ pub fn run(args: &AgentRunArgs) -> Result<()> {
             Arc::clone(&identity),
             pins.clone(),
             rt.handle().clone(),
-            atlasctl_agent::peer::link::SelfIntro::new(can_launch.is_ok(), ""),
+            atlasctl_agent::peer::link::SelfIntro::new(can_launch.is_ok(), &accelerator),
         )),
         atlasctl_agent::peer::DEFAULT_PEER_PORT,
     ));
@@ -326,7 +333,7 @@ pub fn run(args: &AgentRunArgs) -> Result<()> {
                 peer_port: atlasctl_agent::peer::DEFAULT_PEER_PORT,
                 addresses: beacon_addrs,
                 can_launch: can_launch.is_ok(),
-                accelerator: String::new(),
+                accelerator: accelerator.clone(),
             },
         );
 


### PR DESCRIPTION
Every node advertised an **empty** accelerator — to the browser, to its peers, and in its beacon — while the reading it came from already said `NVIDIA GB10`.

The name is the first field of the capability probe's own query and was parsed into `Reading.name` all along. Nothing carried it further:

```rust
LocalFleet::new(…, launchability, String::new())   // ← accelerator
Beacon { …, accelerator: String::new() }
SelfIntro::new(can_launch.is_ok(), "")
```

## Why this was cheaper than it looked

I deferred this in #56 saying it needed a vendor-neutral name port, because the CI lint keeps `nvidia-smi` inside provider modules. That was true of *fetching* the name — but it was already fetched. The value was on the far side of the boundary and only had to be returned. No new vendor-specific code, and the lint is clean.

## Details

Asked **once at startup** rather than sampled: a machine does not change what accelerator it has while the agent is running.

An empty or absent name stays `None` rather than becoming `""`. A blank is not a name, and the fleet card writes `os · accelerator · agent` — an empty middle reads as a fault rather than as silence.

## Verified on this box

```
$ nvidia-smi --query-gpu=name --format=csv,noheader
NVIDIA GB10

# the local node, over the browser channel, as the PWA sees it:
  accelerator: "NVIDIA GB10"
  os         : "Linux"
  name       : "spark-256a"
```

Vendor-neutrality lint run locally with the exact CI command: clean.