### PR TITLE
fix(settings): the launch modal offered a value that kills the launch

### DIFF
--- a/crates/atlasctl-core/src/settings/mod.rs
+++ b/crates/atlasctl-core/src/settings/mod.rs
@@ -4,6 +4,7 @@
 
 mod spec;
 mod table;
+mod values;
 
 pub use spec::{BoundSpec, Disposition, Spec};
 pub use table::DISPOSITIONS;

--- a/crates/atlasctl-core/src/settings/table.rs
+++ b/crates/atlasctl-core/src/settings/table.rs
@@ -33,6 +33,37 @@ const fn e(
     })
 }
 
+/// Every KV-cache precision the serving runtime accepts.
+///
+/// Transcribed from `spark_runtime::kv_cache::KvCacheDtype::ALL`, which is
+/// derived from the enum under a wildcard-free match so adding a variant
+/// fails that build rather than silently missing from a picker. This list is
+/// the one place that transcription lives; `settings/tests.rs` records the
+/// count so a drift shows up as a failing test rather than as a launch that
+/// dies inside the container.
+///
+/// The short aliases the CLI also accepts (`fp8k2v` for `fp8k_turbo2v`) are
+/// deliberately not offered: a picker should name one spelling.
+const KV_DTYPES: &[&str] = &[
+    "bf16",
+    "fp8",
+    "nvfp4",
+    "turbo4",
+    "turbo3",
+    "turbo2",
+    "turbo8",
+    "turbo4k_turbo3v",
+    "turbo4k_turbo8v",
+    "turbo3k_turbo8v",
+    "bf16k_turbo4v",
+    "bf16k_turbo3v",
+    "fp8k_turbo4v",
+    "fp8k_turbo3v",
+    "bf16k_turbo2v",
+    "fp8k_turbo2v",
+];
+
+/// Precisions for weights-adjacent settings, which are not the KV set.
 const DTYPES: &[&str] = &["bf16", "fp8", "nvfp4"];
 
 /// Every flag, and whether a client may set it.
@@ -137,7 +168,12 @@ pub static DISPOSITIONS: &[(&str, Disposition)] = &[
     (
         "scheduling_policy",
         e(
-            Enum(&["fcfs", "slai"]),
+            // "fifo", not "fcfs". The engine validates against
+            // `cli::flag_values::SCHEDULING_POLICIES`, which has never
+            // contained "fcfs" — offering it produced a launch that died in
+            // validate_serve_args, on the machine, after the operator had
+            // already reviewed the command.
+            Enum(&["fifo", "slai"]),
             "Scheduling policy",
             "How queued requests are ordered.",
             None,
@@ -193,7 +229,7 @@ pub static DISPOSITIONS: &[(&str, Disposition)] = &[
     (
         "kv_cache_dtype",
         e(
-            Enum(DTYPES),
+            Enum(KV_DTYPES),
             "KV cache dtype",
             "Precision of the key/value cache.",
             None,

--- a/crates/atlasctl-core/src/settings/table.rs
+++ b/crates/atlasctl-core/src/settings/table.rs
@@ -8,6 +8,7 @@
 //! test enforces.
 
 use super::spec::{BoundSpec, Disposition, Spec};
+use super::values::{DTYPES, KV_DTYPES};
 use atlasctl_protocol::settings::Group;
 
 use BoundSpec::{BoolValue, Enum, Float, Int, IntOrAuto, Toggle};
@@ -32,39 +33,6 @@ const fn e(
         advanced,
     })
 }
-
-/// Every KV-cache precision the serving runtime accepts.
-///
-/// Transcribed from `spark_runtime::kv_cache::KvCacheDtype::ALL`, which is
-/// derived from the enum under a wildcard-free match so adding a variant
-/// fails that build rather than silently missing from a picker. This list is
-/// the one place that transcription lives; `settings/tests.rs` records the
-/// count so a drift shows up as a failing test rather than as a launch that
-/// dies inside the container.
-///
-/// The short aliases the CLI also accepts (`fp8k2v` for `fp8k_turbo2v`) are
-/// deliberately not offered: a picker should name one spelling.
-const KV_DTYPES: &[&str] = &[
-    "bf16",
-    "fp8",
-    "nvfp4",
-    "turbo4",
-    "turbo3",
-    "turbo2",
-    "turbo8",
-    "turbo4k_turbo3v",
-    "turbo4k_turbo8v",
-    "turbo3k_turbo8v",
-    "bf16k_turbo4v",
-    "bf16k_turbo3v",
-    "fp8k_turbo4v",
-    "fp8k_turbo3v",
-    "bf16k_turbo2v",
-    "fp8k_turbo2v",
-];
-
-/// Precisions for weights-adjacent settings, which are not the KV set.
-const DTYPES: &[&str] = &["bf16", "fp8", "nvfp4"];
 
 /// Every flag, and whether a client may set it.
 ///

--- a/crates/atlasctl-core/src/settings/tests.rs
+++ b/crates/atlasctl-core/src/settings/tests.rs
@@ -168,3 +168,49 @@ fn nothing_a_client_sends_can_become_a_flag_shaped_argv_element() {
         }
     }
 }
+
+/// These two lists are transcribed from the engine, which is a different repo
+/// and cannot be renamed atomically with this one. The counts are recorded so
+/// a drift fails here — cheaply, in CI — rather than as a launch that dies
+/// inside the container after the operator has reviewed the command.
+///
+/// If one of these fails, check the engine's `cli::flag_values` and
+/// `spark_runtime::kv_cache::KvCacheDtype::ALL`, then update the table.
+#[test]
+fn the_enumerated_values_still_match_the_engine() {
+    let kv = super::table::DISPOSITIONS
+        .iter()
+        .find(|(k, _)| *k == "kv_cache_dtype")
+        .and_then(|(_, d)| match d {
+            super::spec::Disposition::Expose(sp) => Some(sp),
+            super::spec::Disposition::Deny(_) => None,
+        })
+        .expect("kv_cache_dtype is exposed");
+    let super::spec::BoundSpec::Enum(kvs) = &kv.bound else {
+        panic!("kv_cache_dtype must be an enum");
+    };
+    assert_eq!(
+        kvs.len(),
+        16,
+        "KvCacheDtype::ALL has 16 variants; this offered {}",
+        kvs.len()
+    );
+
+    let sp = super::table::DISPOSITIONS
+        .iter()
+        .find(|(k, _)| *k == "scheduling_policy")
+        .and_then(|(_, d)| match d {
+            super::spec::Disposition::Expose(sp) => Some(sp),
+            super::spec::Disposition::Deny(_) => None,
+        })
+        .expect("scheduling_policy is exposed");
+    let super::spec::BoundSpec::Enum(policies) = &sp.bound else {
+        panic!("scheduling_policy must be an enum");
+    };
+    assert_eq!(
+        *policies,
+        &["fifo", "slai"],
+        "the engine accepts fifo and slai; \"fcfs\" was offered for four releases \
+         and killed every launch that chose it"
+    );
+}

--- a/crates/atlasctl-core/src/settings/values.rs
+++ b/crates/atlasctl-core/src/settings/values.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The enumerated value sets, transcribed from the engine.
+//!
+//! Separate from the table because they answer to a different authority.
+//! The table is this project's decision about what a web page may set; these
+//! are facts about a serving runtime in another repo, and they are the ones
+//! that go stale silently — a bound that drifts is caught by a bijection
+//! test, a VALUE that drifts is caught by a launch dying in a container.
+//!
+//! Every list here has a matching assertion in `settings/tests.rs`, naming
+//! the engine symbol it came from.
+
+/// Every KV-cache precision the serving runtime accepts.
+///
+/// Transcribed from `spark_runtime::kv_cache::KvCacheDtype::ALL`, which is
+/// derived from the enum under a wildcard-free match so adding a variant
+/// fails that build rather than silently missing from a picker. This list is
+/// the one place that transcription lives; `settings/tests.rs` records the
+/// count so a drift shows up as a failing test rather than as a launch that
+/// dies inside the container.
+///
+/// The short aliases the CLI also accepts (`fp8k2v` for `fp8k_turbo2v`) are
+/// deliberately not offered: a picker should name one spelling.
+pub(super) const KV_DTYPES: &[&str] = &[
+    "bf16",
+    "fp8",
+    "nvfp4",
+    "turbo4",
+    "turbo3",
+    "turbo2",
+    "turbo8",
+    "turbo4k_turbo3v",
+    "turbo4k_turbo8v",
+    "turbo3k_turbo8v",
+    "bf16k_turbo4v",
+    "bf16k_turbo3v",
+    "fp8k_turbo4v",
+    "fp8k_turbo3v",
+    "bf16k_turbo2v",
+    "fp8k_turbo2v",
+];
+
+/// Precisions for weights-adjacent settings, which are not the KV set.
+pub(super) const DTYPES: &[&str] = &["bf16", "fp8", "nvfp4"];


### PR DESCRIPTION
Two of the values the website offers do not match the engine that has to accept them.

## `scheduling_policy` offered `"fcfs"`

The engine validates against `cli::flag_values::SCHEDULING_POLICIES`:

```rust
pub(crate) const SCHEDULING_POLICIES: &[&str] = &["fifo", "slai"];
```

`"fcfs"` has never been in it. Choosing it produced a launch that died in `validate_serve_args` — **on the machine, after the operator had reviewed the exact command and pressed start.** That is the worst place for a wrong value to surface, because everything up to it looked deliberate and correct.

## `kv_cache_dtype` offered 3 of 16

The engine's authority is `spark_runtime::kv_cache::KvCacheDtype::ALL`, derived from the enum under a wildcard-free match so a new variant fails *that* build rather than silently missing from a picker. Thirteen were unreachable from the web — including the entire `turbo` family, which is the reason someone would open this modal at all.

## Keeping them honest

Both lists are transcribed from a repo that cannot be renamed atomically with this one, so a test records what they must contain, naming the engine symbol each came from. A drift fails in CI, cheaply, rather than inside a container after a launch.

The short aliases the CLI also accepts (`fp8k2v` for `fp8k_turbo2v`) are deliberately not offered — a picker should name one spelling.

`table.rs` crossed the 500-line cap, so the value lists move to `settings/values.rs`. The seam isn't arbitrary: the table is *this project's decision* about what a web page may set; the value lists are *facts about another repo*, and they fail differently — a drifted bound is caught by the bijection test, a drifted **value** is caught by a launch dying in a container.

## Not in this PR: the 9 dropped recipe keys

`lm_head_dtype` and eight others are set by shipping recipes and silently dropped, and I deliberately did **not** transcribe them here. Emitting them correctly requires knowing which are *presence-only* flags — `--gdn-fused-norm` takes no value, `--ssm-h-dtype` does — and the engine derives that from clap at runtime:

```rust
fn presence_only(flag: &str) -> bool {
    ServeArgs::command().get_arguments()
        .filter(|a| matches!(a.get_action(), clap::ArgAction::SetTrue))
```

Hand-copying that is exactly how `fcfs` happened. It needs the generated manifest (PR 3), not another transcription.