### PR TITLE
feat(telemetry): measure ISL and OSL

### DIFF
--- a/crates/atlasctl-agent/src/launchstats.rs
+++ b/crates/atlasctl-agent/src/launchstats.rs
@@ -50,6 +50,14 @@ pub struct LaunchStats {
     pub accept_rate: Option<f64>,
     /// Share of prefix-cache lookups that hit, 0..1.
     pub prefix_hit_rate: Option<f64>,
+    /// Mean prompt tokens per request completed in the window.
+    ///
+    /// `None` when no request completed: a mean over nothing is undefined, and
+    /// 0 would assert that the traffic carried no prompt — a measurement nobody
+    /// made. See `metrics::mean_per_request` for the bias this knowingly has.
+    pub isl_mean: Option<f64>,
+    /// Mean generated tokens per request completed in the window, likewise.
+    pub osl_mean: Option<f64>,
     /// Seconds the rates were measured over, so the page can say how fresh
     /// they are rather than implying they are instantaneous.
     pub window_s: Option<f64>,
@@ -122,6 +130,10 @@ impl LaunchSampler {
                     rate_of(previous, &current, "atlas_generation_tokens_total", secs);
                 out.prompt_tokens_per_s =
                     rate_of(previous, &current, "atlas_prompt_tokens_total", secs);
+                // Per-request means over the SAME interval as the rates, so the
+                // window caption already on screen describes them too.
+                out.isl_mean = mean_over(previous, &current, "atlas_prompt_tokens_total");
+                out.osl_mean = mean_over(previous, &current, "atlas_generation_tokens_total");
             }
         }
         *slot = Some((now, current));
@@ -142,6 +154,20 @@ fn rate_of(previous: &Scrape, current: &Scrape, name: &str, secs: f64) -> Option
     metrics::rate(previous.get(name)?, current.get(name)?, secs)
 }
 
+/// Mean of `name` per request completed between the two scrapes.
+///
+/// Needs both counters from both scrapes: an engine that stopped exporting one
+/// of them mid-window yields nothing rather than a mean computed against a
+/// missing half.
+fn mean_over(previous: &Scrape, current: &Scrape, name: &str) -> Option<f64> {
+    metrics::mean_per_request(
+        previous.get(name)?,
+        current.get(name)?,
+        previous.get("atlas_requests_total")?,
+        current.get("atlas_requests_total")?,
+    )
+}
+
 /// Draft acceptance, read per label because the sum of accepts and rejects is
 /// a number with no meaning.
 fn accept_rate(s: &Scrape) -> Option<f64> {
@@ -157,10 +183,10 @@ mod tests {
     use std::sync::Mutex as StdMutex;
 
     /// Serves scripted bodies in order.
-    struct Scripted(StdMutex<Vec<String>>);
+    pub(super) struct Scripted(StdMutex<Vec<String>>);
 
     impl Scripted {
-        fn new(bodies: &[&str]) -> Box<Self> {
+        pub(super) fn new(bodies: &[&str]) -> Box<Self> {
             Box::new(Self(StdMutex::new(
                 bodies.iter().rev().map(|s| (*s).to_owned()).collect(),
             )))
@@ -277,5 +303,60 @@ mod tests {
         let s = LaunchSampler::new(Scripted::new(&[&body(1, 1)]));
         let out = s.sample(8888, Instant::now()).expect("samples");
         assert_eq!(out.accept_rate, None);
+    }
+}
+
+#[cfg(test)]
+mod isl_osl_tests {
+    use super::*;
+
+    /// Two scrapes an interval apart: 4 requests finished, carrying 2048 prompt
+    /// tokens and 512 generated ones between them.
+    #[test]
+    fn the_means_are_per_request_over_the_same_window_as_the_rates() {
+        let sampler = LaunchSampler::new(super::tests::Scripted::new(&[
+            "atlas_requests_total 10\natlas_requests_active 0\n\
+             atlas_generation_tokens_total 1000\natlas_prompt_tokens_total 5000\n",
+            "atlas_requests_total 14\natlas_requests_active 0\n\
+             atlas_generation_tokens_total 1512\natlas_prompt_tokens_total 7048\n",
+        ]));
+        let t0 = Instant::now();
+        let first = sampler.sample(9000, t0).expect("first");
+        // No previous sample: no window, so no rates and no means.
+        assert_eq!(first.isl_mean, None, "a first poll measures no interval");
+        assert_eq!(first.osl_mean, None);
+
+        let second = sampler
+            .sample(9000, t0 + Duration::from_secs(4))
+            .expect("second");
+        assert_eq!(
+            second.isl_mean,
+            Some(512.0),
+            "2048 prompt tokens / 4 requests"
+        );
+        assert_eq!(second.osl_mean, Some(128.0), "512 generated / 4 requests");
+        assert_eq!(second.window_s, Some(4.0));
+    }
+
+    /// Tokens moved but nothing finished. The mean is undefined, and zero would
+    /// claim the window's traffic carried no tokens.
+    #[test]
+    fn tokens_without_a_completed_request_report_nothing_not_zero() {
+        let sampler = LaunchSampler::new(super::tests::Scripted::new(&[
+            "atlas_requests_total 10\natlas_generation_tokens_total 1000\n\
+             atlas_prompt_tokens_total 5000\n",
+            "atlas_requests_total 10\natlas_generation_tokens_total 1400\n\
+             atlas_prompt_tokens_total 5600\n",
+        ]));
+        let t0 = Instant::now();
+        sampler.sample(9000, t0).expect("first");
+        let out = sampler
+            .sample(9000, t0 + Duration::from_secs(4))
+            .expect("second");
+        assert_eq!(out.isl_mean, None);
+        assert_eq!(out.osl_mean, None);
+        // The rates still exist: tokens per second is defined over the window
+        // whether or not a request happened to finish inside it.
+        assert!(out.decode_tokens_per_s.is_some());
     }
 }

--- a/crates/atlasctl-core/src/metrics.rs
+++ b/crates/atlasctl-core/src/metrics.rs
@@ -186,6 +186,41 @@ pub fn rate(previous: f64, current: f64, seconds: f64) -> Option<f64> {
     Some((current - previous) / seconds)
 }
 
+/// The mean of a per-request quantity over an interval: Δtotal ÷ Δrequests.
+///
+/// `None` rather than a number whenever the answer would be invented:
+///
+/// * no requests completed in the interval — a mean over nothing is undefined,
+///   and reporting 0 would say "requests in this window carried no tokens",
+///   which is a measurement nobody made;
+/// * either counter went backwards, which is a restart and tells us nothing
+///   about the interval it spans;
+/// * the result is not finite.
+///
+/// The value is APPROXIMATE and knowingly so: tokens accrue while a request is
+/// in flight, but `requests_total` only increments when it finishes, so a long
+/// request's tokens land in an earlier window than its completion. Over a
+/// steady stream the bias is small; over a handful of long requests it is not.
+/// That is why this is a mean labelled with its window rather than a per-request
+/// statistic, and why a percentile would need a histogram from the engine.
+#[must_use]
+pub fn mean_per_request(
+    prev_total: f64,
+    cur_total: f64,
+    prev_requests: f64,
+    cur_requests: f64,
+) -> Option<f64> {
+    if cur_total < prev_total || cur_requests < prev_requests {
+        return None;
+    }
+    let requests = cur_requests - prev_requests;
+    if requests <= 0.0 {
+        return None;
+    }
+    let mean = (cur_total - prev_total) / requests;
+    mean.is_finite().then_some(mean)
+}
+
 /// Estimate a quantile from cumulative histogram buckets.
 ///
 /// Linear interpolation within the containing bucket, which is what Prometheus
@@ -421,5 +456,38 @@ mod tests {
         fn a_rate_cannot_exceed_one_however_the_counters_disagree() {
             assert_eq!(accept_rate(9.0, 4.0), Some(1.0));
         }
+    }
+}
+
+#[cfg(test)]
+mod mean_tests {
+    use super::mean_per_request;
+
+    #[test]
+    fn a_mean_is_tokens_over_requests_in_the_same_interval() {
+        // 4 requests carried 2048 prompt tokens between them.
+        assert_eq!(mean_per_request(1000.0, 3048.0, 10.0, 14.0), Some(512.0));
+    }
+
+    /// The case that must never read as zero. No request finished, so nothing
+    /// was measured — and "0 tokens per request" is a claim about traffic that
+    /// did not happen.
+    #[test]
+    fn no_completed_requests_is_unknown_not_zero() {
+        assert_eq!(mean_per_request(1000.0, 1500.0, 10.0, 10.0), None);
+    }
+
+    /// A restart resets both counters. The interval spans two different engine
+    /// lifetimes and describes neither.
+    #[test]
+    fn a_counter_that_went_backwards_yields_nothing() {
+        assert_eq!(mean_per_request(1000.0, 5.0, 10.0, 14.0), None);
+        assert_eq!(mean_per_request(1000.0, 3048.0, 10.0, 2.0), None);
+    }
+
+    #[test]
+    fn a_non_finite_result_is_refused() {
+        assert_eq!(mean_per_request(0.0, f64::INFINITY, 0.0, 1.0), None);
+        assert_eq!(mean_per_request(0.0, f64::NAN, 0.0, 1.0), None);
     }
 }

--- a/crates/atlasctl-protocol/src/msg.rs
+++ b/crates/atlasctl-protocol/src/msg.rs
@@ -376,6 +376,19 @@ pub struct LaunchReading {
     pub accept_rate: Option<f64>,
     /// Share of prefix-cache lookups that hit, 0..1.
     pub prefix_hit_rate: Option<f64>,
+    /// Mean prompt tokens per request completed in the window (ISL).
+    ///
+    /// Absent when no request completed: a mean over nothing is undefined, and
+    /// 0 would assert that the traffic carried no prompt — a measurement nobody
+    /// made. A page must render that absence as absence, never as a zero.
+    ///
+    /// Defaulted, so a reading from an agent built before this existed decodes
+    /// as "did not say" rather than being refused.
+    #[serde(default)]
+    pub isl_mean: Option<f64>,
+    /// Mean generated tokens per request completed in the window (OSL).
+    #[serde(default)]
+    pub osl_mean: Option<f64>,
     /// Seconds the rates cover, so the page can say how fresh they are rather
     /// than implying they are instantaneous.
     pub window_s: Option<f64>,

--- a/crates/atlasctl/src/launchtelemetry/mod.rs
+++ b/crates/atlasctl/src/launchtelemetry/mod.rs
@@ -138,6 +138,8 @@ impl LaunchTelemetry for LocalLaunchTelemetry {
             ttft_p90_s: s.ttft_p90_s,
             accept_rate: s.accept_rate,
             prefix_hit_rate: s.prefix_hit_rate,
+            isl_mean: s.isl_mean,
+            osl_mean: s.osl_mean,
             window_s: s.window_s,
         })
     }


### PR DESCRIPTION
The control-plane design ships **ISL** and **OSL** as placeholders because
nothing emits them. The sampler already differences the counters it needs, so
this is a ratio of two deltas it was computing halves of already.

## Not derived in the browser, deliberately

A page differencing counters cannot see which requests were in flight, and the
design forbids client-side derivation for that reason. The agent is the only
place that samples both counters at the same instant.

## Absent is never zero

`mean_per_request` returns nothing rather than a number whenever the answer
would be invented:

- **no request completed in the window** — a mean over nothing is undefined, and
  `0` would assert the traffic carried no tokens, which is a measurement nobody
  made;
- **either counter went backwards** — a restart, so the interval spans two
  engine lifetimes and describes neither;
- the result is not finite.

## The bias is stated, not hidden

Tokens accrue while a request is in flight, but `requests_total` only increments
when it finishes — so a long request's tokens land in an earlier window than its
completion. Over a steady stream that is small; over a handful of long requests
it is not.

That is why this is a **mean labelled with its window**, not a per-request
statistic. A percentile would need a histogram from the engine, and inventing one
here would be worse than the placeholder it replaces.

## Compatibility

`LaunchReading.isl_mean`/`osl_mean` are `#[serde(default)]`, so a reading from an
agent built before this decodes as "did not say" rather than being refused.

## Verification

649 workspace tests pass (6 new), clippy clean under `-D warnings`, nothing over
the 500-line cap. The tests include the case that matters most: tokens moving
with no completed request reports **nothing**, while the tok/s rates still
report — those are defined over the window whether or not a request happened to
finish inside it.