### PR TITLE
fix(messages): strip source indentation baked into two operator-facing strings

### DIFF
--- a/crates/atlasctl-agent/src/daemon.rs
+++ b/crates/atlasctl-agent/src/daemon.rs
@@ -176,7 +176,9 @@ fn spawn_peer_listener(
             Ok(l) => l,
             Err(e) => {
                 eprintln!(
-                    "peer channel disabled: could not bind {port}: {e}\n                       other machines will not be able to reach this one"
+                    "peer channel disabled: could not bind {port}: {e}\n\
+                     other machines will not be able to reach this one, and this \
+                     one cannot be added to a fleet"
                 );
                 return;
             }

--- a/crates/atlasctl/src/commands/service.rs
+++ b/crates/atlasctl/src/commands/service.rs
@@ -115,7 +115,7 @@ fn join_fleet(join: &crate::joinarg::Join, grant_control: bool) -> Result<()> {
         ))
         .with_context(|| {
             format!(
-                "could not join {addr}. The code expires, and is good for one                  machine only — mint a fresh one if this is not the first try."
+                "could not join {addr}. The code expires, and is good for one machine only — mint a fresh one if this is not the first try."
             )
         })?;
 


### PR DESCRIPTION
Two messages carried a run of 18–23 literal spaces mid-sentence, from a string
literal wrapped across source lines without a continuation:

```
could not join 10.10.10.2. The code expires, and is good for one
                  machine only — mint a fresh one if this is not the first try.
```

Both render with a visible gap. The join one is read at the exact moment an
operator's pairing has just failed, which is the worst available moment to look
unfinished.

## Swept, not spotted

21 string literals in the workspace contain a run of five or more spaces, and 19
are deliberate column alignment (`"name:        {}"`). The two fixed here are the
only runs falling **mid-sentence** — lowercase, gap, lowercase — which is what
separates baked-in indentation from layout.

The peer-channel message also now says what the failure costs: other machines
cannot reach this one, and this one cannot be added to a fleet.

## Verified by compiling, not by reading

My first check was a Python simulation of Rust's `\`-continuation and it was
wrong about which whitespace survives — it reported a gap that the compiler does
not produce. The literals were then compiled and printed directly:

```
[peer channel disabled: could not bind 34334: address in use]
[other machines will not be able to reach this one, and this one cannot be added to a fleet]
double-space present: false
```

652 workspace tests pass, clippy clean.