### PR TITLE
fix(doctor): an unreadable interface list is not a machine with no addresses

### DIFF
--- a/crates/atlasctl/src/commands/doctor.rs
+++ b/crates/atlasctl/src/commands/doctor.rs
@@ -142,13 +142,20 @@ fn check_reachable() -> Finding {
     #[cfg(not(target_os = "macos"))]
     let fabric = atlasctl_agent::fabric::linux::LinuxFabric::new();
 
-    let addrs = fabric
-        .addresses()
-        .unwrap_or_default()
-        .into_iter()
-        .map(|a| (a.iface, a.addr))
-        .collect::<Vec<_>>();
-    doctor_checks::reachable(&addrs)
+    // NOT `unwrap_or_default()`. An enumeration that failed is not a machine
+    // with no addresses, and the advice for the two is unrelated — telling
+    // someone to plug in a network cable because `/sys/class/net` could not be
+    // listed sends them to fix the wrong thing.
+    match fabric.addresses() {
+        Ok(list) => {
+            let addrs = list
+                .into_iter()
+                .map(|a| (a.iface, a.addr))
+                .collect::<Vec<_>>();
+            doctor_checks::reachable(&addrs)
+        }
+        Err(e) => doctor_checks::unreadable_interfaces(&format!("{e:#}")),
+    }
 }
 
 #[cfg(test)]

--- a/crates/atlasctl/src/commands/doctor_checks.rs
+++ b/crates/atlasctl/src/commands/doctor_checks.rs
@@ -121,6 +121,22 @@ pub fn reachable(addresses: &[(String, String)]) -> Finding {
     }
 }
 
+/// The interfaces could not be READ, which is not the same as there being none.
+///
+/// The distinction matters because the remedies are unrelated: "connect this
+/// machine to a network" is useless advice to someone whose `/sys/class/net`
+/// could not be listed. Collapsing an error into an empty list is the same
+/// mistake as rendering an absent metric as zero — it turns "we do not know"
+/// into a confident claim.
+#[must_use]
+pub fn unreadable_interfaces(why: &str) -> Finding {
+    Finding::bad(
+        "network",
+        &format!("this machine's network interfaces could not be read: {why}"),
+        &["Whether another machine could reach this one is unknown, not no."],
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -171,6 +187,28 @@ mod tests {
             "the operator needs to know what it breaks, not just that it is: {}",
             f.line
         );
+    }
+
+    /// "Could not look" and "looked and found none" are different facts with
+    /// unrelated remedies. Reporting the first as the second is the same
+    /// mistake as rendering an absent metric as zero.
+    #[test]
+    fn an_unreadable_interface_list_is_not_reported_as_having_no_addresses() {
+        let f = unreadable_interfaces("permission denied reading /sys/class/net");
+        assert!(f.problem);
+        assert!(f.line.contains("could not be read"), "{}", f.line);
+        assert!(
+            f.line.contains("permission denied"),
+            "the cause is the useful part: {}",
+            f.line
+        );
+        // The remedy for an empty list must not appear here.
+        assert!(
+            !f.line.contains("Connect this machine"),
+            "plugging in a cable does not fix an unreadable /sys: {}",
+            f.line
+        );
+        assert!(f.line.contains("unknown, not no"), "{}", f.line);
     }
 
     #[test]


### PR DESCRIPTION
The network check called `fabric.addresses().unwrap_or_default()`, so an
enumeration that **failed** became an empty list and was reported as:

```
network:  PROBLEM — no address another machine could dial
          Only loopback or virtual interfaces are up.
          Connect this machine to the network you want the fleet on.
```

Those are different facts with unrelated remedies. Telling someone to plug in a
cable because `/sys/class/net` could not be listed sends them to fix the wrong
thing — and does it with the confidence of a diagnosis.

It is the same mistake this codebase spends real effort avoiding elsewhere:
collapsing "we do not know" into a definite claim, the shape of rendering an
absent metric as zero.

## Worth recording

I wrote this two waves ago while adding these very checks, in the same session
where I fixed the same class in `iostrip`, `aggregate` and `mean_per_request`.
The rule is easy to state and easy to break in the next function.

## What it says now

The error surfaces with its cause, and says plainly that reachability is
**unknown, not no**.

1 test, asserting the empty-list remedy never appears in the error case.
654 workspace tests pass, clippy clean.