### PR TITLE
fix(errors): a failure reply carries the cause, not only the attempt

### DIFF
--- a/crates/atlasctl-agent/src/daemon/peer_serve.rs
+++ b/crates/atlasctl-agent/src/daemon/peer_serve.rs
@@ -91,7 +91,7 @@ where
             PeerFrame::PreviewRank { assignment } => match ctx.rank.render(&assignment) {
                 Ok((command, unmapped)) => PeerFrame::RankPreviewed { command, unmapped },
                 Err(e) => PeerFrame::RankRefused {
-                    reason: e.to_string(),
+                    reason: format!("{e:#}"),
                 },
             },
             PeerFrame::Prepare { assignment, epoch } => PeerFrame::Prepared {
@@ -104,7 +104,7 @@ where
             PeerFrame::Commit { epoch } => match ctx.rank.commit(&epoch) {
                 Ok(container) => PeerFrame::Committed { epoch, container },
                 Err(e) => PeerFrame::RankRefused {
-                    reason: e.to_string(),
+                    reason: format!("{e:#}"),
                 },
             },
             PeerFrame::IsRankAlive { container } => PeerFrame::RankLiveness {

--- a/crates/atlasctl-agent/src/launcher/docker.rs
+++ b/crates/atlasctl-agent/src/launcher/docker.rs
@@ -63,7 +63,7 @@ impl DockerLauncher {
         .map_err(|e| AgentError::NotLaunchable {
             recipe: RecipeId::parse(&recipe.name)
                 .unwrap_or_else(|_| RecipeId::parse("unknown").expect("literal is a valid id")),
-            reason: e.to_string(),
+            reason: format!("{e:#}"),
         })?;
         // The agent removes a container by name before it starts one, and on
         // stop, so it owns this lifecycle already. Auto-remove therefore buys
@@ -110,7 +110,7 @@ impl Launcher for DockerLauncher {
             self.runner
                 .run(&plan.docker.to_argv())
                 .map_err(|e| AgentError::LaunchFailed {
-                    detail: e.to_string(),
+                    detail: format!("{e:#}"),
                 })?;
         if !out.success() {
             return Err(AgentError::LaunchFailed {
@@ -141,7 +141,7 @@ impl Launcher for DockerLauncher {
             .runner
             .run(&["docker".into(), "stop".into(), format!("atlas-{recipe}")])
             .map_err(|e| AgentError::LaunchFailed {
-                detail: e.to_string(),
+                detail: format!("{e:#}"),
             })?;
         if out.success() {
             Ok(())
@@ -164,7 +164,7 @@ impl Launcher for DockerLauncher {
                 "{{.Names}}\t{{.Status}}".into(),
             ])
             .map_err(|e| AgentError::DockerUnavailable {
-                detail: e.to_string(),
+                detail: format!("{e:#}"),
             })?;
         if !out.success() {
             return Err(AgentError::DockerUnavailable {

--- a/crates/atlasctl-agent/src/session/fleet.rs
+++ b/crates/atlasctl-agent/src/session/fleet.rs
@@ -134,7 +134,7 @@ impl Session<'_> {
                     node,
                     exchanged: false,
                     verification: None,
-                    detail: e.to_string(),
+                    detail: format!("{e:#}"),
                 }]
             }
         }
@@ -176,7 +176,7 @@ impl Session<'_> {
                     address: String::new(),
                     exchanged: false,
                     verification: None,
-                    detail: e.to_string(),
+                    detail: format!("{e:#}"),
                 }]
             }
         }
@@ -280,7 +280,7 @@ impl Session<'_> {
             Err(e) => vec![err(
                 Some(id),
                 AgentError::InvalidMessage {
-                    detail: e.to_string(),
+                    detail: format!("{e:#}"),
                 },
             )],
         }

--- a/crates/atlasctl-agent/src/session/fleet_fake.rs
+++ b/crates/atlasctl-agent/src/session/fleet_fake.rs
@@ -10,6 +10,8 @@
 //! needs a second machine and a TLS handshake. It does not fake the logic under
 //! test; every decision exercised through it is the real `Session`.
 
+use anyhow::Context as _;
+
 use crate::fleet::{FleetView, PairOutcome};
 use atlasctl_protocol::fleet::{NodeDescriptor, NodeId};
 use std::sync::Mutex;
@@ -95,7 +97,12 @@ impl RecordingFleet {
 
     fn exchange(&self) -> anyhow::Result<PairOutcome> {
         if *self.fail_exchange.lock().expect("poisoned") {
-            anyhow::bail!("nothing answered at that address");
+            // A CHAINED failure, because that is the shape a real one has: a
+            // resolver or connect error wrapped in the context that says what
+            // was being attempted. A fake that returns a single flat string
+            // cannot catch a reply that drops the cause.
+            return Err(anyhow::anyhow!("Name or service not known"))
+                .context("resolving not-a-host");
         }
         Ok(self.outcome.clone())
     }

--- a/crates/atlasctl-agent/src/session/pair_at_tests.rs
+++ b/crates/atlasctl-agent/src/session/pair_at_tests.rs
@@ -171,3 +171,38 @@ fn a_failed_attempt_spends_any_exchange_already_pending() {
     }
     assert!(fleet.keys_pinned().is_empty());
 }
+
+/// A failure reply must carry the CAUSE, not just the attempt.
+///
+/// `anyhow`'s `to_string()` renders only the outermost context, so a reply built
+/// from it says "resolving not-a-host" and drops "Name or service not known" —
+/// the half that tells the operator whether to fix a typo, a DNS server, or a
+/// firewall. `{e:#}` renders the chain.
+#[test]
+fn a_failure_detail_carries_the_cause_and_not_only_the_attempt() {
+    let f = Fixture::new();
+    let node = NodeId::from_bytes([7; 32]);
+    let fleet = RecordingFleet::new(node);
+    fleet.start_failing();
+    let mut s = session(&f, &fleet);
+
+    let out = s.handle(ClientMsg::PairPeerAt {
+        id: 1,
+        target: "not-a-host".to_owned(),
+        code: "12345678".to_owned(),
+    });
+
+    match &out[0] {
+        ServerMsg::PairAtResult { detail, .. } => {
+            assert!(
+                detail.contains("resolving not-a-host"),
+                "the attempt: {detail}"
+            );
+            assert!(
+                detail.contains("Name or service not known"),
+                "the cause is the half an operator can act on: {detail}"
+            );
+        }
+        other => panic!("expected a pair-at result, got {other:?}"),
+    }
+}


### PR DESCRIPTION
Nine replies built their detail with `e.to_string()`. On an `anyhow` error that
renders only the **outermost context** and drops the chain, so pairing against a
bad hostname told the operator:

```
resolving not a host!!
```

and kept to itself the half they can act on — typo, DNS server, or firewall.
With `{e:#}`:

```
resolving not a host!!: failed to lookup address information: Name or service not known
```

## How it was found

By probing a live agent over its own websocket, not by reading code. Six
malformed requests: an unknown `on` target, a local status, an unreachable
address, a malformed address, a short code, and a confirm with nothing pending.
**Five answered perfectly** — failing closed, naming the reason, never
fabricating an identity. The sixth answered with an attempt and no reason.

The same shape was in the relay's refusal reasons and the docker launcher's
failure details — the two places an operator is most likely to be reading an
error precisely because something they cannot see went wrong.

## The test

The fake fleet now fails with a **chained** error, because that is the shape a
real failure has; a fake returning one flat string cannot catch a reply that
drops the cause.

Verified by mutation (restoring `to_string()` fails the test with
`resolving not-a-host` and nothing after it), and re-confirmed against the live
agent that produced the original finding.

655 workspace tests pass, clippy clean.