### PR TITLE
fix(protocol): name the relay in its own refusal

### DIFF
--- a/crates/atlasctl-agent/src/daemon/peer_serve.rs
+++ b/crates/atlasctl-agent/src/daemon/peer_serve.rs
@@ -196,7 +196,11 @@ async fn relay_control(
     let local = ctx.identity.id();
     let refused = |detail: String| ControlRep::Refused {
         by: local,
-        error: AgentError::RelayRefused { node, detail },
+        error: AgentError::RelayRefused {
+            node,
+            via: Some(local),
+            detail,
+        },
     };
 
     // R2 — the requester's grant, re-read NOW, checked here as well as at

--- a/crates/atlasctl-agent/src/daemon/peer_serve_tests.rs
+++ b/crates/atlasctl-agent/src/daemon/peer_serve_tests.rs
@@ -371,9 +371,10 @@ async fn an_ungranted_sender_cannot_ask_for_a_forward() {
     match rep {
         ControlRep::Refused {
             by,
-            error: AgentError::RelayRefused { node, detail },
+            error: AgentError::RelayRefused { node, via, detail },
         } => {
             assert_eq!(by, r.local);
+            assert_eq!(via, Some(r.local), "the relay names itself in the error");
             assert_eq!(node, target, "the refusal names the TARGET");
             assert!(
                 detail.contains("peer grant-control"),
@@ -407,9 +408,10 @@ async fn a_relay_refuses_to_reach_a_node_it_has_not_itself_pinned() {
     match rep {
         ControlRep::Refused {
             by,
-            error: AgentError::RelayRefused { node, detail },
+            error: AgentError::RelayRefused { node, via, detail },
         } => {
             assert_eq!(by, r.local);
+            assert_eq!(via, Some(r.local), "the relay names itself in the error");
             assert_eq!(node, stranger);
             assert!(detail.contains("not a peer"), "got {detail}");
         }

--- a/crates/atlasctl-agent/src/daemon/relay_harness.rs
+++ b/crates/atlasctl-agent/src/daemon/relay_harness.rs
@@ -322,6 +322,7 @@ pub(super) async fn spawn_fake_peer(
                                 by: local,
                                 error: atlasctl_protocol::msg::AgentError::RelayRefused {
                                     node,
+                                    via: Some(local),
                                     detail: "a terminal peer received a forward".to_owned(),
                                 },
                             },

--- a/crates/atlasctl-agent/src/daemon/relay_tests.rs
+++ b/crates/atlasctl-agent/src/daemon/relay_tests.rs
@@ -175,10 +175,17 @@ async fn a_fabricated_vouch_writes_no_pin_and_is_refused_at_the_relay() {
     match rep {
         ControlRep::Refused {
             by,
-            error: AgentError::RelayRefused { node, detail },
+            error: AgentError::RelayRefused { node, via, detail },
         } => {
             assert_eq!(by, relay.id(), "the honest relay refuses under R3");
             assert_eq!(node, phantom);
+            assert_eq!(
+                via,
+                Some(relay.id()),
+                "the error itself must name the relay: `by` is dropped when \
+                 this becomes a browser frame, so attribution that lives only \
+                 there sends the operator to the target instead"
+            );
             assert!(detail.contains("not a peer"), "got {detail}");
         }
         other => panic!("expected the relay's R3 refusal, got {other:?}"),
@@ -358,5 +365,64 @@ async fn the_relay_emits_only_a_terminal_frame_at_the_target() {
             matches!(f, crate::peer::wire::PeerFrame::Control { .. }),
             "the ONLY control frame a relay may emit is the terminal one: {f:?}"
         );
+    }
+}
+
+/// The origin cannot reach the RELAY at all — a distinct failure from the
+/// relay's own leg failing (covered above), and the one the browser most
+/// often shows, because a laptop that has moved networks still holds the
+/// relay's stale address.
+///
+/// Both refusals say `RelayRefused` and both name the TARGET in `node`, so
+/// the only thing separating "go look at dgx1" from "go look at dgx2" is
+/// `via`. This path builds the error on the ORIGIN, where `ControlRep` never
+/// exists and `by` therefore cannot carry the blame.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_relay_the_origin_cannot_dial_is_named_in_the_refusal() {
+    let origin = agent("dead-origin", "macbook", "127.0.0.1");
+    let mut relay = agent("dead-relay", "dgx1", "127.0.0.2");
+    pin(&origin, &relay, false);
+    pin(&relay, &origin, true);
+    let port = {
+        let launcher = std::sync::Arc::clone(&relay.launcher);
+        spawn_serving(&mut relay, 0, Duration::from_secs(5), Box::new(launcher))
+    }
+    .await;
+    poll(&origin, &relay).await;
+
+    let ghost = agent("dead-ghost", "dgx2", "127.0.0.3");
+    origin
+        .fleet
+        .record_vouches(relay.id(), vec![claim(ghost.id(), Vec::new(), true)]);
+
+    // A port nothing is listening on: bound to learn a free number, then
+    // dropped. The route still resolves through the relay — it is only the
+    // dial that fails, which is exactly the operator's situation.
+    let dead = {
+        let l = tokio::net::TcpListener::bind("127.0.0.2:0")
+            .await
+            .expect("bind to learn a free port");
+        l.local_addr().expect("port").port()
+    };
+    assert_ne!(dead, port, "the dead port must not be the relay's live one");
+
+    let err = driver(&origin, dead)
+        .control(ghost.id(), status())
+        .expect_err("nothing is listening; the dial cannot succeed");
+    match err {
+        AgentError::RelayRefused { node, via, detail } => {
+            assert_eq!(node, ghost.id(), "`node` stays the target");
+            assert_eq!(
+                via,
+                Some(relay.id()),
+                "the unreachable RELAY must be named, or the operator is sent \
+                 to a target that never heard of the request"
+            );
+            assert!(
+                detail.contains("could not ask"),
+                "the prose must say which leg failed: {detail}"
+            );
+        }
+        other => panic!("expected the origin-side RelayRefused, got {other:?}"),
     }
 }

--- a/crates/atlasctl-agent/src/peer/control.rs
+++ b/crates/atlasctl-agent/src/peer/control.rs
@@ -237,6 +237,7 @@ impl crate::session::ControlRelay for ControlDriver {
                 .map(|rep| (rep, Some(relay)))
                 .map_err(|e| AgentError::RelayRefused {
                     node: target,
+                    via: Some(relay),
                     detail: format!("could not ask {} to forward: {e:#}", relay.short()),
                 }),
         }

--- a/crates/atlasctl-agent/src/session/forward_tests.rs
+++ b/crates/atlasctl-agent/src/session/forward_tests.rs
@@ -389,6 +389,7 @@ fn a_chain_refusal_surfaces_typed_under_the_request_id() {
                 by: relay_id(),
                 error: AgentError::RelayRefused {
                     node: target(),
+                    via: Some(relay_id()),
                     detail: "dial failed".into(),
                 },
             },
@@ -407,8 +408,8 @@ fn a_chain_refusal_surfaces_typed_under_the_request_id() {
             &out[0],
             ServerMsg::Error {
                 id: Some(4),
-                error: AgentError::RelayRefused { node, .. },
-            } if *node == target()
+                error: AgentError::RelayRefused { node, via, .. },
+            } if *node == target() && *via == Some(relay_id())
         ),
         "got {:?}",
         out[0]

--- a/crates/atlasctl-agent/src/session/remote.rs
+++ b/crates/atlasctl-agent/src/session/remote.rs
@@ -239,6 +239,14 @@ fn rep_to_msg(
             on,
             via,
         },
+        // `by` is dropped: the browser's `Error` frame has no field for it,
+        // and giving it one would change a frame every call site builds. The
+        // attribution it carried is not lost — a relay's own failure names
+        // itself inside `RelayRefused.via`, and a target's refusal already
+        // names itself in `ControlRefused.node`. What `by` alone could still
+        // tell us is a relay refusing with some THIRD error kind, which no
+        // path emits today; if one appears, that is the moment to widen the
+        // frame rather than now.
         (_, ControlRep::Refused { by: _, error }) => err(Some(id), error),
         (_, other) => err(
             Some(id),

--- a/crates/atlasctl-protocol/src/msg/error.rs
+++ b/crates/atlasctl-protocol/src/msg/error.rs
@@ -100,12 +100,21 @@ pub enum AgentError {
 
     /// A relay declined or failed to forward: requester not granted control,
     /// target not in the relay's own pin store, dial failed, or the answer
-    /// budget elapsed. `node` is the TARGET; the refusing relay is named in
-    /// `ControlRep::Refused.by` / the reply's `via`.
+    /// budget elapsed. `node` is the TARGET, `via` the relay that refused.
     #[error("the relay did not forward to `{node}`: {detail}")]
     RelayRefused {
         /// The target the relay was asked to reach.
         node: crate::fleet::NodeId,
+        /// The RELAY that refused — the machine to go look at.
+        ///
+        /// Carried structurally because `node` is the *target*: without this
+        /// a relay's own failure reads as the target's and sends the operator
+        /// to the wrong box. `None` is not "anonymous relay" — it is nobody
+        /// having said, which is what an agent built before this field
+        /// reports. Optional so the peer wire stays readable in both
+        /// directions and this needs no `PROTOCOL_VERSION` bump.
+        #[serde(default)]
+        via: Option<crate::fleet::NodeId>,
         /// The relay's stated reason.
         detail: String,
     },

--- a/crates/atlasctl-protocol/src/msg/tests.rs
+++ b/crates/atlasctl-protocol/src/msg/tests.rs
@@ -362,9 +362,17 @@ fn a_protocol_3_reply_decodes_with_no_provenance() {
 }
 
 const FP: &str = "3f2a1b0c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f8";
+const RELAY_FP: &str = "a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90";
 
 fn peer() -> crate::fleet::NodeId {
     crate::fleet::NodeId::parse(FP).expect("fixture is a valid fingerprint")
+}
+
+/// A DIFFERENT machine from [`peer`] — a relay's refusal names two nodes, and
+/// a round trip that used one id for both would pass even if the wire glued
+/// the fields together.
+fn relay_peer() -> crate::fleet::NodeId {
+    crate::fleet::NodeId::parse(RELAY_FP).expect("fixture is a valid fingerprint")
 }
 
 #[test]
@@ -454,6 +462,7 @@ fn the_routing_errors_carry_machine_readable_codes_and_round_trip() {
         },
         AgentError::RelayRefused {
             node: peer(),
+            via: Some(relay_peer()),
             detail: "requester lacks the controller grant on this machine".into(),
         },
         AgentError::ControlRefused {


### PR DESCRIPTION
`RelayRefused.node` is the *target*, so a relay's own failure reached the browser wearing the target's name. The relay's identity lived in `ControlRep::Refused.by`, which (a) is dropped when a peer reply becomes a browser `Error` frame and (b) does not exist at all when the origin cannot dial the relay.

Adds `RelayRefused.via`, filled at both production sites. `Option` + `serde(default)` keeps the peer wire readable both directions — **no `PROTOCOL_VERSION` bump, no cross-repo lockstep**.

Mutation-checked: reverting either site to `None` fails tests. The origin-side dial failure had **zero** coverage before this; it now has a test (relay routable but not dialable — the moved-networks case). 668 tests pass.