### PR TITLE
fix(agent): stop reporting "could not look" as "nothing there"

### DIFF
--- a/crates/atlasctl-agent/src/fabric/linux.rs
+++ b/crates/atlasctl-agent/src/fabric/linux.rs
@@ -114,7 +114,12 @@ fn addresses_by_interface() -> Result<BTreeMap<String, Vec<String>>> {
 
 impl FabricProvider for LinuxFabric {
     fn raw_interfaces(&self) -> Result<Vec<RawIface>> {
-        let addrs = addresses_by_interface().unwrap_or_default();
+        // NOT `unwrap_or_default()`. `ip` missing — a slim container without
+        // iproute2 — would otherwise give every interface an empty address
+        // list, and a caller cannot tell that from a machine that genuinely
+        // has no address. It then reports "no usable network link", sending
+        // the operator to inspect a network that was never the problem.
+        let addrs = addresses_by_interface()?;
         let rdma = rdma_backed_interfaces();
 
         let entries = std::fs::read_dir(NET_DIR).with_context(|| format!("reading {NET_DIR}"))?;

--- a/crates/atlasctl-agent/src/fleet.rs
+++ b/crates/atlasctl-agent/src/fleet.rs
@@ -413,7 +413,15 @@ impl LocalFleet {
     /// pinned. A pinned peer stays in the list, marked unreachable, because it
     /// is still part of your fleet even when it is switched off.
     pub fn prune(&self) {
-        let pinned = self.pins.load().unwrap_or_default();
+        // A pin store we could not READ is not a fleet with no pins: reading
+        // it as empty evicts every idle pinned peer — the machines the doc
+        // above promises to keep — for as long as the file stays unreadable.
+        // Skipping a tick is safe because the table is capped
+        // (`MAX_SIGHTINGS`), so deferring cannot grow it without bound.
+        let Ok(pinned) = self.pins.load() else {
+            self.prune_vouches();
+            return;
+        };
         if let Ok(mut seen) = self.seen.lock() {
             seen.retain(|id, s| pinned.contains_key(id) || s.at.elapsed() < UNREACHABLE_AFTER);
         }

--- a/crates/atlasctl-agent/src/fleet/sightings_tests.rs
+++ b/crates/atlasctl-agent/src/fleet/sightings_tests.rs
@@ -63,3 +63,49 @@ fn a_paired_machine_is_still_recorded_once_the_table_is_full() {
         "a pinned peer must never be crowded out by strangers"
     );
 }
+
+/// A pin store that cannot be READ is not a fleet with no pins.
+///
+/// `prune` keeps pinned peers regardless of age — that is its stated contract,
+/// because a machine you paired is yours whether or not it is switched on. Read
+/// the pins as "none" on an I/O error and the contract inverts: the idle
+/// pinned peers are exactly the ones dropped, and they stay dropped for as long
+/// as the file is unreadable.
+#[test]
+fn an_unreadable_pin_store_does_not_evict_the_fleet_it_cannot_see() {
+    let t = Tmp::new("prune-blind");
+    let f = fleet_at(&t.0);
+    let mine = NodeId::from_bytes([7; 32]);
+    crate::fleet::record_pairing(
+        &f.pins,
+        mine,
+        "cd".repeat(32).as_str(),
+        atlasctl_protocol::fleet::DisplayName::new("switched-off-dgx"),
+        0,
+        None,
+        false,
+    )
+    .expect("pin");
+    f.observe(beacon(mine, "switched-off-dgx", true));
+
+    // It has since been switched off for longer than the window: without the
+    // pin, this sighting is stale and prune drops it.
+    {
+        let mut seen = f.lock_seen().expect("lock");
+        let s = seen.get_mut(&mine).expect("just observed");
+        s.at = std::time::Instant::now()
+            .checked_sub(crate::fleet::UNREACHABLE_AFTER + std::time::Duration::from_secs(1))
+            .expect("the test clock is past the window");
+    }
+
+    // Now the pin file becomes unreadable — a partial write, a bad disk, a
+    // half-finished save.
+    std::fs::write(t.0.join("peers.json"), b"{ this is not json").expect("corrupt");
+
+    f.prune();
+    assert!(
+        f.lock_seen().expect("lock").contains_key(&mine),
+        "a pinned peer was evicted because its pin file could not be parsed; \
+         the operator would see their fleet vanish over an I/O error"
+    );
+}

--- a/crates/atlasctl/src/commands/agent.rs
+++ b/crates/atlasctl/src/commands/agent.rs
@@ -114,21 +114,33 @@ pub fn run(args: &AgentRunArgs) -> Result<()> {
     let fabric = atlasctl_agent::fabric::macos::MacFabric::new();
     #[cfg(not(target_os = "macos"))]
     let fabric = atlasctl_agent::fabric::linux::LinuxFabric::new();
-    let addresses = fabric.addresses().unwrap_or_default();
+    // NOT `unwrap_or_default()`. `doctor` learned this already: an
+    // enumeration that FAILED is not a machine with no addresses, and the
+    // line below makes a claim about the hardware ("no usable network link")
+    // that would then be a guess. Keep the two apart — the agent still
+    // starts either way, because it can serve this machine's own browser
+    // without a cluster link, but it must not say which situation it is in
+    // unless it knows.
+    let enumerated = fabric.addresses();
+    let addresses = enumerated
+        .as_ref()
+        .map(Vec::as_slice)
+        .unwrap_or(&[])
+        .to_vec();
     let launchability = match &can_launch {
         Ok(()) => atlasctl_protocol::fleet::Launchability::yes(),
         Err(why) => atlasctl_protocol::fleet::Launchability::no(why.clone()),
     };
     eprintln!("node identity: {}", identity.id().short());
-    if addresses.is_empty() {
-        eprintln!("no usable network link — this agent cannot take part in a cluster");
-    } else {
-        eprintln!(
-            "cluster address: {} ({})",
-            addresses[0].addr,
-            addresses[0].class.label()
-        );
-    }
+    eprintln!(
+        "{}",
+        link_line(
+            enumerated
+                .as_ref()
+                .map(|a| a.first().map(|f| (f.addr.to_string(), f.class.label())))
+                .map_err(|e| format!("{e:#}"))
+        )
+    );
     // Real vitals for this machine. Capabilities are probed once here rather
     // than per sample: on a GB10 that probe is what discovers there is no
     // framebuffer to report, and the answer does not change while we run.
@@ -416,4 +428,67 @@ pub fn run(args: &AgentRunArgs) -> Result<()> {
         };
         atlasctl_agent::server::serve_on(state, listener).await
     })
+}
+
+/// What to tell the operator about this machine's links, as three distinct
+/// facts rather than two.
+///
+/// The distinction is the whole point: "we could not look" and "we looked and
+/// there is nothing" send a person to different places, and only one of them
+/// is a statement about their network. Pure so it can be tested — the
+/// enumeration it describes shells out, which is why the claim it makes is
+/// worth pinning down separately from the I/O that feeds it.
+fn link_line(first: Result<Option<(String, &'static str)>, String>) -> String {
+    match first {
+        Err(why) => format!(
+            "could not read this machine's network interfaces: {why} \
+             — clustering is off until that is fixed; run `atlasctl doctor`"
+        ),
+        Ok(None) => "no usable network link — this agent cannot take part in a cluster".to_owned(),
+        Ok(Some((addr, class))) => format!("cluster address: {addr} ({class})"),
+    }
+}
+
+#[cfg(test)]
+mod link_line_tests {
+    use super::link_line;
+
+    #[test]
+    fn a_failed_enumeration_is_never_reported_as_an_absent_network() {
+        let e = link_line(Err("running `ip -o -4 addr show`: No such file".into()));
+        assert!(
+            e.contains("could not read"),
+            "the operator must learn we could not look: {e}"
+        );
+        assert!(
+            !e.contains("no usable network link"),
+            "claiming the network is absent when `ip` is missing sends them to \
+             debug hardware that is fine: {e}"
+        );
+        assert!(
+            e.contains("doctor"),
+            "and it must say what to run next: {e}"
+        );
+    }
+
+    #[test]
+    fn an_empty_enumeration_still_says_the_network_is_the_problem() {
+        // The other side of the same coin: when we DID look and found nothing,
+        // hedging would be just as wrong.
+        let e = link_line(Ok(None));
+        assert_eq!(
+            e,
+            "no usable network link — this agent cannot take part in a cluster"
+        );
+    }
+
+    #[test]
+    fn a_found_address_is_reported_with_its_link_class() {
+        // The class is what tells RoCE from Wi-Fi, which is what the operator
+        // needs to know a cluster will actually be fast.
+        assert_eq!(
+            link_line(Ok(Some(("10.10.10.1".to_owned(), "InfiniBand")))),
+            "cluster address: 10.10.10.1 (InfiniBand)"
+        );
+    }
 }


### PR DESCRIPTION
Three siblings of the `doctor` bug fixed earlier — a failed enumeration laundered into a confident empty answer.

| where | what it claimed | what was true |
|---|---|---|
| `fabric/linux.rs` | every interface has no address | `ip` could not be run (no iproute2) |
| `commands/agent.rs` | "no usable network link" | we never managed to look |
| `fleet::prune` | nothing is pinned | `peers.json` was unreadable — and it then evicted the idle pinned peers it promises to keep, for as long as the file stayed bad |

The `agent.rs` decision is extracted into a pure, tested `link_line`, matching the `bind_failure`/`dial_hint` idiom already here. Mutation-checked: restoring either `unwrap_or_default` fails a test. 671 tests pass.