### PR TITLE
fix(join): try every address the inviter offered, without spending its attempts

### DIFF
--- a/crates/atlasctl-agent/src/fleet/listing.rs
+++ b/crates/atlasctl-agent/src/fleet/listing.rs
@@ -402,25 +402,13 @@ fn dial_first_reachable(
     addrs: &[std::net::SocketAddr],
     code: &str,
 ) -> Result<(std::net::SocketAddr, crate::peer::pair::Paired)> {
-    let mut why: Vec<String> = Vec::new();
-    for addr in addrs {
-        match driver.pair(*addr, code) {
-            Ok(paired) => return Ok((*addr, paired)),
-            Err(e) => {
-                // Only a failure to REACH the peer earns another address.
-                // Every address here is the same machine, so a refusal has
-                // already spent one of the code's three attempts; walking the
-                // rest spends them all on one typo. See `peer::reach`.
-                let keep_going = crate::peer::reach::never_reached(&e);
-                why.push(format!("{addr}: {e:#}"));
-                if !keep_going {
-                    break;
-                }
-            }
-        }
-    }
-    anyhow::bail!(
-        "could not pair over any advertised address — {}",
-        why.join("; ")
-    )
+    // The walk and its stop rule live in `peer::reach`, shared with the
+    // joining direction: only a failure to REACH the peer earns another
+    // address, because every address here is the same machine and a refusal
+    // has already spent one of the code's three attempts.
+    // `{e:#}`, not `.context(…)`: the accumulated reasons belong in the
+    // message itself. Behind a context they only appear when something prints
+    // the whole chain, and the caller nearest the operator prints the top.
+    crate::peer::reach::walk(addrs, |addr| driver.pair(addr, code))
+        .map_err(|e| anyhow::anyhow!("could not pair over any advertised address — {e:#}"))
 }

--- a/crates/atlasctl-agent/src/fleet/listing.rs
+++ b/crates/atlasctl-agent/src/fleet/listing.rs
@@ -406,7 +406,17 @@ fn dial_first_reachable(
     for addr in addrs {
         match driver.pair(*addr, code) {
             Ok(paired) => return Ok((*addr, paired)),
-            Err(e) => why.push(format!("{addr}: {e:#}")),
+            Err(e) => {
+                // Only a failure to REACH the peer earns another address.
+                // Every address here is the same machine, so a refusal has
+                // already spent one of the code's three attempts; walking the
+                // rest spends them all on one typo. See `peer::reach`.
+                let keep_going = crate::peer::reach::never_reached(&e);
+                why.push(format!("{addr}: {e:#}"));
+                if !keep_going {
+                    break;
+                }
+            }
         }
     }
     anyhow::bail!(

--- a/crates/atlasctl-agent/src/fleet/pairing_tests.rs
+++ b/crates/atlasctl-agent/src/fleet/pairing_tests.rs
@@ -33,6 +33,15 @@ impl FakePairing {
             calls: std::sync::Mutex::new(Vec::new()),
         }
     }
+    /// A machine that never answered — the wrong network, a firewall, a box
+    /// asleep. Distinct from [`Self::refusing`] because only this one lets the
+    /// walk move on without spending an attempt.
+    fn unreachable() -> Self {
+        Self {
+            answer: Err(String::new()),
+            calls: std::sync::Mutex::new(Vec::new()),
+        }
+    }
     fn refusing(why: &str) -> Self {
         Self {
             answer: Err(why.to_owned()),
@@ -51,7 +60,18 @@ impl crate::fleet::PeerPairing for Arc<FakePairing> {
             .lock()
             .expect("lock")
             .push((addr, code.to_owned()));
-        self.answer.clone().map_err(|e| anyhow::anyhow!(e))
+        match self.answer.clone() {
+            Ok(p) => Ok(p),
+            // An empty reason stands for a transport failure, which is carried
+            // as a real `io::Error` so the production predicate sees what it
+            // would see in the field rather than a string we shaped for it.
+            Err(e) if e.is_empty() => Err(anyhow::Error::new(std::io::Error::new(
+                std::io::ErrorKind::ConnectionRefused,
+                "connection refused",
+            ))
+            .context("dialling the peer")),
+            Err(e) => Err(anyhow::anyhow!(e)),
+        }
     }
 }
 
@@ -169,5 +189,66 @@ fn an_exchange_that_is_never_trusted_writes_nothing() {
     assert!(
         !PinStore::new(&t.0).is_pinned(node).expect("reads"),
         "a refused exchange must never have touched the pin store"
+    );
+}
+
+/// A beacon from a machine that offers several links, like a DGX with two
+/// RoCE addresses and one on the ordinary LAN.
+fn beacon_at(id: NodeId, name: &str, addrs: &[&str]) -> crate::discovery::Beacon {
+    let mut b = beacon(id, name, true);
+    b.addresses = addrs
+        .iter()
+        .map(|a| a.parse::<std::net::IpAddr>().expect("addr"))
+        .collect();
+    b
+}
+
+/// The code allows three attempts and a DGX advertises three addresses, so a
+/// walk that treats a REFUSAL as a reason to try the next one turns a single
+/// mistyped code into a lockout — before the operator has had one real go.
+#[test]
+fn a_machine_that_answered_and_refused_costs_exactly_one_attempt() {
+    let t = Tmp::new("one-attempt");
+    let node = NodeId::from_bytes([6; 32]);
+    let driver = Arc::new(FakePairing::refusing("key confirmation failed"));
+    let f = fleet_at(&t.0).with_pairing(Box::new(Arc::clone(&driver)));
+    f.observe(beacon_at(
+        node,
+        "dgx1",
+        &["10.10.10.9", "10.10.10.13", "192.168.68.68"],
+    ));
+
+    f.pair(node, "13572468").expect_err("must refuse");
+    assert_eq!(
+        driver.calls.lock().expect("lock").len(),
+        1,
+        "every address here is the SAME machine; a refusal already spent an \
+         attempt, so the walk must stop rather than spend the rest"
+    );
+}
+
+/// The other half: when nothing answers, the next address is free, and it is
+/// the whole reason more than one is offered — a laptop can reach only the
+/// last of a DGX's three.
+#[test]
+fn an_address_that_never_answers_moves_on_to_the_next() {
+    let t = Tmp::new("walk-on");
+    let node = NodeId::from_bytes([6; 32]);
+    let driver = Arc::new(FakePairing::unreachable());
+    let f = fleet_at(&t.0).with_pairing(Box::new(Arc::clone(&driver)));
+    f.observe(beacon_at(
+        node,
+        "dgx1",
+        &["10.10.10.9", "10.10.10.13", "192.168.68.68"],
+    ));
+
+    f.pair(node, "13572468")
+        .expect_err("nothing answered anywhere");
+    let calls = driver.calls.lock().expect("lock");
+    assert_eq!(calls.len(), 3, "all three links must be tried");
+    assert_eq!(
+        calls[2].0.ip().to_string(),
+        "192.168.68.68",
+        "the LAN address is last, and is the only one a laptop could use"
     );
 }

--- a/crates/atlasctl-agent/src/peer.rs
+++ b/crates/atlasctl-agent/src/peer.rs
@@ -19,6 +19,7 @@ pub mod control;
 pub mod join;
 pub mod link;
 pub mod pair;
+pub mod reach;
 pub mod tls;
 pub mod wire;
 

--- a/crates/atlasctl-agent/src/peer/reach.rs
+++ b/crates/atlasctl-agent/src/peer/reach.rs
@@ -42,6 +42,40 @@ pub fn never_reached(err: &anyhow::Error) -> bool {
     })
 }
 
+/// Try each address in turn, stopping the moment a machine answers — whether
+/// it says yes or no.
+///
+/// Both callers walk the same list under the same rule — `fleet::listing`
+/// pairing a discovered machine, and `agent install --join` joining someone
+/// else's fleet — so the rule lives once. Errors accumulate: reporting only
+/// the last names whichever address sorted last, usually the least
+/// interesting failure, and hides that several links were tried.
+///
+/// # Errors
+/// When no address produced a success, with every reason, in order.
+pub fn walk<T, F>(
+    addrs: &[std::net::SocketAddr],
+    mut dial: F,
+) -> anyhow::Result<(std::net::SocketAddr, T)>
+where
+    F: FnMut(std::net::SocketAddr) -> anyhow::Result<T>,
+{
+    let mut why: Vec<String> = Vec::new();
+    for addr in addrs {
+        match dial(*addr) {
+            Ok(v) => return Ok((*addr, v)),
+            Err(e) => {
+                let keep_going = never_reached(&e);
+                why.push(format!("{addr}: {e:#}"));
+                if !keep_going {
+                    break;
+                }
+            }
+        }
+    }
+    anyhow::bail!("{}", why.join("; "))
+}
+
 #[cfg(test)]
 mod tests {
     use super::never_reached;
@@ -87,5 +121,61 @@ mod tests {
     #[test]
     fn an_unrecognised_failure_stops_rather_than_spending_an_attempt() {
         assert!(!never_reached(&io(ErrorKind::InvalidData)));
+    }
+
+    fn a(n: u8) -> std::net::SocketAddr {
+        std::net::SocketAddr::from(([10, 10, 10, n], 34334))
+    }
+
+    #[test]
+    fn the_walk_stops_at_the_first_machine_that_answers_and_refuses() {
+        let mut seen = Vec::new();
+        let out = super::walk(&[a(9), a(13), a(68)], |addr| -> anyhow::Result<()> {
+            seen.push(addr);
+            Err(anyhow!("key confirmation failed"))
+        });
+        assert!(out.is_err());
+        assert_eq!(seen, vec![a(9)], "the rest are the same machine");
+    }
+
+    #[test]
+    fn the_walk_continues_past_every_address_that_never_answers() {
+        let mut seen = Vec::new();
+        let out = super::walk(&[a(9), a(13), a(68)], |addr| -> anyhow::Result<()> {
+            seen.push(addr);
+            Err(io(ErrorKind::HostUnreachable))
+        });
+        let e = out.expect_err("nothing answered").to_string();
+        assert_eq!(seen, vec![a(9), a(13), a(68)]);
+        for n in [9u8, 13, 68] {
+            assert!(
+                e.contains(&format!("10.10.10.{n}")),
+                "every link tried must be named, not just the last: {e}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_address_that_worked_is_the_one_returned() {
+        // The caller pins it, so returning the first tried would record a link
+        // the machine has just proved it cannot use.
+        let (addr, v) = super::walk(&[a(9), a(68)], |addr| {
+            if addr == a(68) {
+                Ok("paired")
+            } else {
+                Err(io(ErrorKind::TimedOut))
+            }
+        })
+        .expect("the LAN address answers");
+        assert_eq!(addr, a(68));
+        assert_eq!(v, "paired");
+    }
+
+    #[test]
+    fn an_empty_list_is_an_error_rather_than_a_silent_success() {
+        let out = super::walk(&[], |_| -> anyhow::Result<()> {
+            panic!("nothing to dial must not dial")
+        });
+        assert!(out.is_err());
     }
 }

--- a/crates/atlasctl-agent/src/peer/reach.rs
+++ b/crates/atlasctl-agent/src/peer/reach.rs
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Did we ever get to talk to that machine?
+//!
+//! An inviting machine offers several addresses because it cannot know which
+//! of its networks the new machine shares, and the joiner tries them in turn.
+//! Whether trying the next one is FREE depends entirely on how the last one
+//! failed, and the two cases look identical from a distance:
+//!
+//! - nothing answered — wrong network, firewall, box asleep. The code was
+//!   never presented, so the next address costs nothing.
+//! - the machine answered and said no. Every address in the list is the same
+//!   machine, so this already spent one of the code's [`crate::pairing::
+//!   MAX_ATTEMPTS`] tries. Marching through the rest spends the remainder and
+//!   locks the operator out — on their FIRST mistyped code, before they have
+//!   had one real go.
+//!
+//! With three attempts and a DGX that advertises three addresses, not making
+//! this distinction turns a single typo into a lockout.
+
+use std::io::ErrorKind;
+
+/// Whether `err` means no peer ever answered, so another address may be tried
+/// without spending an attempt.
+///
+/// Errs toward `false`: an unrecognised failure stops the walk. Giving up one
+/// address early is a worse message; giving up an attempt is a lockout.
+#[must_use]
+pub fn never_reached(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        cause.downcast_ref::<std::io::Error>().is_some_and(|io| {
+            matches!(
+                io.kind(),
+                ErrorKind::ConnectionRefused
+                    | ErrorKind::TimedOut
+                    | ErrorKind::HostUnreachable
+                    | ErrorKind::NetworkUnreachable
+                    | ErrorKind::AddrNotAvailable
+                    | ErrorKind::NotFound
+            )
+        })
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::never_reached;
+    use anyhow::anyhow;
+    use std::io::{Error, ErrorKind};
+
+    fn io(kind: ErrorKind) -> anyhow::Error {
+        anyhow::Error::new(Error::new(kind, "boom"))
+    }
+
+    #[test]
+    fn the_ways_a_wrong_network_fails_all_allow_the_next_address() {
+        for kind in [
+            ErrorKind::ConnectionRefused,
+            ErrorKind::TimedOut,
+            ErrorKind::HostUnreachable,
+            ErrorKind::NetworkUnreachable,
+        ] {
+            assert!(never_reached(&io(kind)), "{kind:?} means nobody answered");
+        }
+    }
+
+    #[test]
+    fn a_transport_failure_is_still_recognised_under_context() {
+        // The real call sites wrap with `.context(…)`, so the io::Error is
+        // never the outermost cause; looking only at the top would report
+        // every failure as a refusal and stop after one address.
+        let e = io(ErrorKind::ConnectionRefused).context("dialling 10.10.10.9:34334");
+        assert!(never_reached(&e));
+    }
+
+    #[test]
+    fn a_refusal_by_the_far_machine_ends_the_walk() {
+        // This is the one that matters: the peer DID answer. Trying the next
+        // address spends another of three attempts on the same machine.
+        let e = anyhow!("key confirmation failed: the code does not match");
+        assert!(
+            !never_reached(&e),
+            "a machine that answered and refused must not cost a second attempt"
+        );
+    }
+
+    #[test]
+    fn an_unrecognised_failure_stops_rather_than_spending_an_attempt() {
+        assert!(!never_reached(&io(ErrorKind::InvalidData)));
+    }
+}

--- a/crates/atlasctl/src/commands/service.rs
+++ b/crates/atlasctl/src/commands/service.rs
@@ -93,31 +93,70 @@ fn join_fleet(join: &crate::joinarg::Join, grant_control: bool) -> Result<()> {
     let identity = Identity::load_or_create(&dir)?;
     let pins = PinStore::new(&dir);
 
-    let addrs = atlasctl_agent::discovery::resolve_manual(
-        &join.host,
-        atlasctl_agent::peer::DEFAULT_PEER_PORT,
-    )?;
-    let addr = *addrs
-        .first()
-        .ok_or_else(|| anyhow::anyhow!("{} resolved to no addresses", join.host))?;
+    // Every alternative the inviter offered, flattened in the order given. A
+    // host that will not resolve is recorded rather than fatal: the LAST entry
+    // is often the only one this machine's network can even name.
+    let mut addrs: Vec<std::net::SocketAddr> = Vec::new();
+    let mut unresolved: Vec<String> = Vec::new();
+    for host in &join.hosts {
+        match atlasctl_agent::discovery::resolve_manual(
+            host,
+            atlasctl_agent::peer::DEFAULT_PEER_PORT,
+        ) {
+            Ok(found) => addrs.extend(found),
+            Err(e) => unresolved.push(format!("{host}: {e:#}")),
+        }
+    }
+    if addrs.is_empty() {
+        anyhow::bail!(
+            "none of the addresses in --join could be resolved — {}",
+            unresolved.join("; ")
+        );
+    }
 
-    println!("\njoining the fleet at {addr}…");
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .context("starting a runtime")?;
-    let paired = rt
-        .block_on(atlasctl_agent::peer::join::dial_and_pair(
+
+    let mut tried: Vec<String> = Vec::new();
+    let mut paired = None;
+    for addr in &addrs {
+        println!("\njoining the fleet at {addr}…");
+        match rt.block_on(atlasctl_agent::peer::join::dial_and_pair(
             &identity,
             pins.clone(),
-            addr,
+            *addr,
             &join.code,
-        ))
-        .with_context(|| {
-            format!(
-                "could not join {addr}. The code expires, and is good for one machine only — mint a fresh one if this is not the first try."
-            )
-        })?;
+        )) {
+            Ok(p) => {
+                // Keep the address that WORKED: it is what gets pinned, and
+                // pinning the one we tried first would record a link this
+                // machine has just proved it cannot use.
+                paired = Some((p, *addr));
+                break;
+            }
+            Err(e) => {
+                // Same rule as `fleet::listing`: a machine that answered and
+                // refused has already spent an attempt, and the remaining
+                // addresses are the same machine. Stop, so one mistyped code
+                // costs one try rather than all three.
+                let keep_going = atlasctl_agent::peer::reach::never_reached(&e);
+                tried.push(format!("{addr}: {e:#}"));
+                if !keep_going {
+                    break;
+                }
+                println!("  no answer there; trying the next address…");
+            }
+        }
+    }
+    let (paired, addr) = paired.ok_or_else(|| {
+        anyhow::anyhow!(
+            "could not join over {}. The code expires, and is good for one machine only — mint a fresh one if this is not the first try.\n  {}",
+            if tried.len() == 1 { "that address".to_owned() } else { format!("any of {} addresses", tried.len()) },
+            tried.join("\n  ")
+        )
+    })?;
 
     atlasctl_agent::fleet::record_pairing(
         &pins,

--- a/crates/atlasctl/src/commands/service.rs
+++ b/crates/atlasctl/src/commands/service.rs
@@ -119,42 +119,20 @@ fn join_fleet(join: &crate::joinarg::Join, grant_control: bool) -> Result<()> {
         .build()
         .context("starting a runtime")?;
 
-    let mut tried: Vec<String> = Vec::new();
-    let mut paired = None;
-    for addr in &addrs {
+    // Same walk, same stop rule as pairing a discovered machine: `peer::reach`
+    // owns both, so the joining direction cannot drift from the other one.
+    let (addr, paired) = atlasctl_agent::peer::reach::walk(&addrs, |addr| {
         println!("\njoining the fleet at {addr}…");
-        match rt.block_on(atlasctl_agent::peer::join::dial_and_pair(
+        rt.block_on(atlasctl_agent::peer::join::dial_and_pair(
             &identity,
             pins.clone(),
-            *addr,
+            addr,
             &join.code,
-        )) {
-            Ok(p) => {
-                // Keep the address that WORKED: it is what gets pinned, and
-                // pinning the one we tried first would record a link this
-                // machine has just proved it cannot use.
-                paired = Some((p, *addr));
-                break;
-            }
-            Err(e) => {
-                // Same rule as `fleet::listing`: a machine that answered and
-                // refused has already spent an attempt, and the remaining
-                // addresses are the same machine. Stop, so one mistyped code
-                // costs one try rather than all three.
-                let keep_going = atlasctl_agent::peer::reach::never_reached(&e);
-                tried.push(format!("{addr}: {e:#}"));
-                if !keep_going {
-                    break;
-                }
-                println!("  no answer there; trying the next address…");
-            }
-        }
-    }
-    let (paired, addr) = paired.ok_or_else(|| {
+        ))
+    })
+    .map_err(|e| {
         anyhow::anyhow!(
-            "could not join over {}. The code expires, and is good for one machine only — mint a fresh one if this is not the first try.\n  {}",
-            if tried.len() == 1 { "that address".to_owned() } else { format!("any of {} addresses", tried.len()) },
-            tried.join("\n  ")
+            "could not join the fleet. The code expires, and is good for one machine only — mint a fresh one if this is not the first try.\n  {e:#}"
         )
     })?;
 

--- a/crates/atlasctl/src/joinarg.rs
+++ b/crates/atlasctl/src/joinarg.rs
@@ -19,8 +19,15 @@ use anyhow::{Result, bail};
 pub struct Join {
     /// The digits minted by the machine doing the inviting.
     pub code: String,
-    /// Where to dial it, as typed — a host or an address, optionally with a port.
-    pub host: String,
+    /// Every place the inviting machine said it can be reached, in the order
+    /// it offered them, as typed — a host or address, optionally with a port.
+    ///
+    /// A list because the inviting machine cannot know which of its networks
+    /// the new one shares. A DGX offers its RoCE fabric first (correct, and
+    /// fastest, for another DGX) and its ordinary LAN address last; a laptop
+    /// can only reach the last. Naming one would work for whichever machine
+    /// we guessed and fail on the other, remotely, after a clean install.
+    pub hosts: Vec<String>,
 }
 
 /// Split `<code>@<host>` into its parts.
@@ -48,12 +55,21 @@ pub fn parse(raw: &str) -> Result<Join> {
             atlasctl_agent::pairing::CODE_DIGITS
         );
     }
-    if host.is_empty() {
+    // Commas separate the alternatives. Neither a hostname, an IPv4 address,
+    // a `host:port` nor a bracketed IPv6 literal can contain one, so this
+    // cannot split a value that was meant to stay whole.
+    let hosts: Vec<String> = host
+        .split(',')
+        .map(str::trim)
+        .filter(|h| !h.is_empty())
+        .map(str::to_owned)
+        .collect();
+    if hosts.is_empty() {
         bail!("--join names no machine to dial; expected <code>@<host>");
     }
     Ok(Join {
         code: code.to_owned(),
-        host: host.to_owned(),
+        hosts,
     })
 }
 
@@ -65,14 +81,14 @@ mod tests {
     fn an_ordinary_invitation_splits() {
         let j = parse("12345678@10.10.10.1").expect("parses");
         assert_eq!(j.code, "12345678");
-        assert_eq!(j.host, "10.10.10.1");
+        assert_eq!(j.hosts, ["10.10.10.1"]);
     }
 
     #[test]
     fn a_host_and_port_survives() {
         assert_eq!(
-            parse("12345678@spark:34334").expect("parses").host,
-            "spark:34334"
+            parse("12345678@spark:34334").expect("parses").hosts,
+            ["spark:34334"]
         );
     }
 
@@ -81,12 +97,12 @@ mod tests {
     #[test]
     fn an_ipv6_literal_is_not_torn_apart() {
         let j = parse("12345678@[fe80::1]:34334").expect("parses");
-        assert_eq!(j.host, "[fe80::1]:34334");
+        assert_eq!(j.hosts, ["[fe80::1]:34334"]);
     }
 
     #[test]
     fn surrounding_whitespace_from_a_copy_paste_is_forgiven() {
-        assert_eq!(parse("  12345678@host \n").expect("parses").host, "host");
+        assert_eq!(parse("  12345678@host \n").expect("parses").hosts, ["host"]);
     }
 
     /// The message has to teach the shape, because it is read on the machine
@@ -117,5 +133,24 @@ mod tests {
     fn an_empty_host_is_refused_rather_than_dialled() {
         assert!(parse("12345678@").is_err());
         assert!(parse("12345678@   ").is_err());
+        assert!(
+            parse("12345678@,,").is_err(),
+            "a list of nothing is still nothing to dial"
+        );
+    }
+
+    /// The case this list exists for: a DGX offers its RoCE fabric first and
+    /// its LAN address last, and only the last is reachable from a laptop.
+    #[test]
+    fn every_alternative_the_inviter_offered_is_kept_in_order() {
+        let j = parse("12345678@10.10.10.9,10.10.10.13,192.168.68.68").expect("parses");
+        assert_eq!(j.hosts, ["10.10.10.9", "10.10.10.13", "192.168.68.68"]);
+    }
+
+    #[test]
+    fn a_ragged_list_from_a_copy_paste_still_parses() {
+        // Spaces after commas survive a trip through a chat window.
+        let j = parse("12345678@ a , b ,, c ").expect("parses");
+        assert_eq!(j.hosts, ["a", "b", "c"]);
     }
 }


### PR DESCRIPTION
Found by driving `mint_join_code` against a **live agent**: it returns `[10.10.10.9, 10.10.10.13, 192.168.68.68]` — RoCE first, which is the right ranking for cluster traffic. The site renders the *first* into the pasted command, so a laptop on `192.168.68.x` gets a command naming a fabric address it cannot dial: installs cleanly, then fails to pair.

No address in that list is wrong — `10.10.10.9` is the *best* entry for another DGX. The inviter cannot know which network the joiner shares, so `--join` now carries all of them and the joiner walks the list.

**Walking it naively would be worse.** `MAX_ATTEMPTS = 3` and a DGX offers 3 addresses, so treating a refusal as a reason to try the next turns one mistyped code into a lockout. `peer::reach::never_reached` separates *nothing answered* (free) from *answered and said no* (stop). Both walks use it — including `fleet::listing`, which had the same flaw already.

Note this concerns the **direct pairing dial** only. SPAKE2 is bound to the TLS exporter, so pairing deliberately cannot be relayed; reaching fabric nodes from a laptop goes through `PairPeerAt` / vouched control forwarding instead.

680 tests. Mutation-checked at the helper *and* both call sites.