### PR TITLE
fix(pair): print a command the other machine can actually run

### DIFF
--- a/crates/atlasctl/src/commands/agentpair.rs
+++ b/crates/atlasctl/src/commands/agentpair.rs
@@ -61,7 +61,7 @@ pub fn pair(args: &crate::cli::AgentPairArgs) -> Result<()> {
     // they were told to run.
     println!(
         "      atlasctl peer add {} --code {}",
-        dial_hint(&hostname_hint(), args.port),
+        dial_hints(&dial_hosts(), args.port),
         code.as_str()
     );
     println!();
@@ -142,10 +142,56 @@ pub fn pair(args: &crate::cli::AgentPairArgs) -> Result<()> {
 /// Only ever printed as a hint in a copy-pasteable command — the address that
 /// actually matters is whichever one the operator can route to, and they are
 /// the ones who know that.
+/// Where the other machine should dial this one, best link first.
+///
+/// The addresses come from the same fabric the agent advertises, NOT from a
+/// hostname. `/proc/sys/kernel/hostname` was the old source and it fails two
+/// ways: on macOS the path does not exist at all, so a MacBook printed
+/// `atlasctl peer add <this-machine>` — a line that cannot be run — and even
+/// on Linux a hostname is only dialable if something resolves it, which
+/// nothing on a plain LAN promises.
+///
+/// Falls back to the hostname, then to the placeholder, because a command with
+/// a name in it is still a better prompt than no command.
+fn dial_hosts() -> Vec<String> {
+    use atlasctl_agent::fabric::FabricProvider as _;
+    #[cfg(target_os = "macos")]
+    let fabric = atlasctl_agent::fabric::macos::MacFabric::new();
+    #[cfg(not(target_os = "macos"))]
+    let fabric = atlasctl_agent::fabric::linux::LinuxFabric::new();
+
+    let found: Vec<String> = fabric
+        .addresses()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|a| a.class.usable_for_control())
+        .map(|a| a.addr.to_string())
+        .collect();
+    if found.is_empty() {
+        return vec![hostname_hint()];
+    }
+    found
+}
+
 fn hostname_hint() -> String {
     std::fs::read_to_string("/proc/sys/kernel/hostname")
         .map(|h| h.trim().to_owned())
         .unwrap_or_else(|_| "<this-machine>".to_owned())
+}
+
+/// Every place to dial, as one `peer add` target.
+///
+/// Comma-separated for the same reason the browser's join command is: this
+/// machine cannot know which of its networks the other one shares. A DGX
+/// offers its RoCE fabric first — right for another DGX, unreachable from a
+/// laptop — and `peer add` walks the list.
+#[must_use]
+pub fn dial_hints(hosts: &[String], port: u16) -> String {
+    hosts
+        .iter()
+        .map(|h| dial_hint(h, port))
+        .collect::<Vec<_>>()
+        .join(",")
 }
 
 /// Whether this machine's own agent is answering on the browser port.
@@ -260,8 +306,41 @@ pub fn dial_hint(host: &str, port: u16) -> String {
 
 #[cfg(test)]
 mod dial_tests {
-    use super::dial_hint;
+    use super::{dial_hint, dial_hints};
     use atlasctl_agent::peer::DEFAULT_PEER_PORT;
+
+    /// The line has to be runnable on a machine that shares ANY of this one's
+    /// networks — a DGX's RoCE fabric for another DGX, its LAN address for a
+    /// laptop. `peer add` walks the list, so all of them go in.
+    #[test]
+    fn every_link_this_machine_has_reaches_the_printed_command() {
+        let hosts = vec![
+            "10.10.10.9".to_owned(),
+            "10.10.10.13".to_owned(),
+            "192.168.68.68".to_owned(),
+        ];
+        assert_eq!(
+            dial_hints(&hosts, DEFAULT_PEER_PORT),
+            "10.10.10.9,10.10.10.13,192.168.68.68"
+        );
+    }
+
+    /// The port applies to every entry, not just the first: a partial list is
+    /// a line that works until the operator's machine is on the wrong network.
+    #[test]
+    fn a_non_default_port_is_carried_onto_every_address() {
+        let hosts = vec!["10.0.0.1".to_owned(), "fe80::1".to_owned()];
+        assert_eq!(dial_hints(&hosts, 34444), "10.0.0.1:34444,[fe80::1]:34444");
+    }
+
+    #[test]
+    fn one_address_prints_exactly_as_it_did_before() {
+        // No comma, no change for the ordinary single-homed machine.
+        assert_eq!(
+            dial_hints(&["spark-256a".to_owned()], DEFAULT_PEER_PORT),
+            "spark-256a"
+        );
+    }
 
     #[test]
     fn the_default_port_is_left_off_because_peer_add_assumes_it() {

--- a/crates/atlasctl/src/commands/peer.rs
+++ b/crates/atlasctl/src/commands/peer.rs
@@ -89,10 +89,32 @@ pub fn add(args: &PeerAddArgs) -> Result<()> {
     let identity = Identity::load_or_create(&dir)?;
     let pins = PinStore::new(&dir);
 
-    let addrs = resolve_manual(&args.target, DEFAULT_PEER_PORT)?;
-    let addr = *addrs
-        .first()
-        .ok_or_else(|| anyhow::anyhow!("{} resolved to no addresses", args.target))?;
+    // Every alternative the other machine printed, in the order it offered
+    // them. `agent pair` emits a comma-separated target for the same reason
+    // the browser's join command carries one: the inviting machine cannot know
+    // which of its networks this one shares. A host that will not resolve is
+    // recorded rather than fatal — often the LAST entry is the only one this
+    // machine's network can even name.
+    let mut addrs: Vec<std::net::SocketAddr> = Vec::new();
+    let mut unresolved: Vec<String> = Vec::new();
+    for host in args
+        .target
+        .split(',')
+        .map(str::trim)
+        .filter(|h| !h.is_empty())
+    {
+        match resolve_manual(host, DEFAULT_PEER_PORT) {
+            Ok(found) => addrs.extend(found),
+            Err(e) => unresolved.push(format!("{host}: {e:#}")),
+        }
+    }
+    if addrs.is_empty() {
+        anyhow::bail!(
+            "{} resolved to no addresses — {}",
+            args.target,
+            unresolved.join("; ")
+        );
+    }
 
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -101,12 +123,20 @@ pub fn add(args: &PeerAddArgs) -> Result<()> {
 
     // The same function the browser-driven path calls. Two implementations of
     // a pairing ceremony is one implementation nobody audits.
-    let paired = runtime.block_on(atlasctl_agent::peer::join::dial_and_pair(
-        &identity,
-        pins.clone(),
-        addr,
-        &args.code,
-    ))?;
+    //
+    // Walked by `peer::reach`, which stops the moment a machine ANSWERS: the
+    // addresses are all the same machine, so a refusal has already spent one
+    // of the code's attempts and marching through the rest spends them all on
+    // one typo.
+    let (addr, paired) = atlasctl_agent::peer::reach::walk(&addrs, |addr| {
+        runtime.block_on(atlasctl_agent::peer::join::dial_and_pair(
+            &identity,
+            pins.clone(),
+            addr,
+            &args.code,
+        ))
+    })
+    .map_err(|e| anyhow::anyhow!("could not pair with {} — {e:#}", args.target))?;
 
     println!();
     println!("  Verification words:  {}", paired.verification);


### PR DESCRIPTION
`atlasctl agent pair` built its hint from `/proc/sys/kernel/hostname`:

- **macOS**: that path does not exist, so a MacBook printed `atlasctl peer add <this-machine> --code …` — unrunnable. The empty-command-bar bug, in the terminal.
- **Linux**: it printed a hostname the other machine can only dial if something resolves it. Nothing on a plain LAN promises that.

It now uses the same fabric the agent advertises, printing every usable address as the browser's join command does. Verified live on this box:

```
atlasctl peer add 10.10.10.9,10.10.10.13,192.168.68.68 --code …
```

`peer add` takes a comma-separated target and walks it via `peer::reach::walk` — which also fixes the `.first()` it had (a hostname with several A records, or IPv6+IPv4, only ever tried one). The walk stops as soon as a machine answers, so alternatives never spend the code's three attempts, and the address that *worked* is what gets pinned. A non-default port is carried onto every entry.

684 tests.