### PR TITLE
fix(resolve): an IPv6 literal is not a host with a port

### DIFF
--- a/crates/atlasctl-agent/src/discovery.rs
+++ b/crates/atlasctl-agent/src/discovery.rs
@@ -216,11 +216,30 @@ pub fn local_os() -> String {
 
 /// Resolve a `host` or `host:port` the user typed into addresses to try.
 ///
+/// "Does it already carry a port" cannot be answered by looking for a colon:
+/// an IPv6 literal is nothing but colons. `fe80::1` was read as host `fe80`
+/// with a port of `:1`, so it never resolved — and this is reached from the
+/// manual address box and from a hand-typed `peer add`, which is precisely
+/// where someone would enter one.
+///
 /// # Errors
 /// If the name does not resolve.
 pub fn resolve_manual(target: &str, default_port: u16) -> Result<Vec<std::net::SocketAddr>> {
     use std::net::ToSocketAddrs;
-    let with_port = if target.contains(':') {
+    let target = target.trim();
+    let with_port = if let Some(close) = target.strip_prefix('[').and_then(|_| target.rfind(']')) {
+        // Bracketed: a port follows the `]` or there is none.
+        if target[close + 1..].starts_with(':') {
+            target.to_owned()
+        } else {
+            format!("{target}:{default_port}")
+        }
+    } else if target.parse::<std::net::Ipv6Addr>().is_ok() {
+        // A bare IPv6 literal carries no port and must be bracketed to take
+        // one — `fe80::1:34334` is ambiguous, and the ambiguity resolves the
+        // wrong way.
+        format!("[{target}]:{default_port}")
+    } else if target.contains(':') {
         target.to_owned()
     } else {
         format!("{target}:{default_port}")

--- a/crates/atlasctl-agent/src/discovery/tests.rs
+++ b/crates/atlasctl-agent/src/discovery/tests.rs
@@ -141,3 +141,28 @@ fn the_beacon_advertises_nothing_a_stranger_could_shop_from() {
         );
     }
 }
+
+/// An IPv6 literal is nothing but colons, so "does it already carry a port"
+/// cannot be answered by looking for one. This is reached from the manual
+/// address box and a hand-typed `peer add` — exactly where someone types an
+/// address rather than a name.
+#[test]
+fn an_ipv6_literal_gets_the_default_port_rather_than_being_torn_at_a_colon() {
+    let bare = resolve_manual("::1", 34334).expect("a bare literal must resolve");
+    assert_eq!(bare[0].port(), 34334, "the default port must be applied");
+    assert!(bare[0].is_ipv6());
+
+    let bracketed = resolve_manual("[::1]", 34334).expect("brackets without a port must resolve");
+    assert_eq!(bracketed[0].port(), 34334);
+
+    // And a bracketed literal that DOES name a port keeps it.
+    let with = resolve_manual("[::1]:9999", 34334).expect("resolves");
+    assert_eq!(with[0].port(), 9999);
+}
+
+/// Whitespace survives a copy out of a browser or a chat window.
+#[test]
+fn a_pasted_address_with_spaces_around_it_still_resolves() {
+    let a = resolve_manual("  127.0.0.1  ", 34334).expect("resolves");
+    assert_eq!(a[0].port(), 34334);
+}


### PR DESCRIPTION
`resolve_manual` tested for an existing port with `target.contains(':')`. An IPv6 literal is nothing but colons:

| input | before | after |
|---|---|---|
| `fe80::1` | passed through → `to_socket_addrs` refuses | `[fe80::1]:34334` |
| `[fe80::1]` | same failure | `[fe80::1]:34334` |
| `[fe80::1]:9999` | ok | ok |

Reached from the **manual address box** in the control page and a hand-typed `peer add` — the one path meant to cope with a topology discovery cannot see.

The site already had this right: `checkTarget` splits a port only when there is exactly one colon, and its comment names the hazard. The browser accepted the address and passed it to an agent that could not parse it.

Both fabrics are IPv4-only (`ip -o -4`, `inet`), so nothing ever *advertised* an address that hit this — it was reachable only by typing one, which is why it survived. Mutation-checked; 689 tests.