### PR TITLE
fix(pair): say that the other machine has to accept too

### DIFF
--- a/crates/atlasctl/src/commands/agentpair.rs
+++ b/crates/atlasctl/src/commands/agentpair.rs
@@ -133,7 +133,20 @@ pub fn pair(args: &crate::cli::AgentPairArgs) -> Result<()> {
         // separate, explicit act (`atlasctl peer grant-control`).
         false,
     )?;
+    // Two-phase pairing is two INDEPENDENT decisions, and this side cannot see
+    // the other one: a refusal there is a local `return`, and TLS carries the
+    // rejection back as a bare alert with none of its reasoning. So a machine
+    // that answered "n" — or whose prompt got EOF from a script — leaves this
+    // side listing a peer it will never be able to reach, which looks exactly
+    // like a box that is switched off. The remedies are unrelated, so say
+    // which situation this could be while the operator is still standing at
+    // the keyboard.
     println!("Paired with {} ({}).", paired.name, paired.node.short());
+    println!(
+        "  {} has to have accepted too. If it said \"Nothing was trusted\",",
+        paired.name
+    );
+    println!("  pair again — otherwise it will look unreachable from here.");
     Ok(())
 }
 

--- a/crates/atlasctl/src/commands/peer.rs
+++ b/crates/atlasctl/src/commands/peer.rs
@@ -172,7 +172,20 @@ pub fn add(args: &PeerAddArgs) -> Result<()> {
         // separate, explicit act (`atlasctl peer grant-control`).
         false,
     )?;
+    // Two-phase pairing is two INDEPENDENT decisions, and this side cannot see
+    // the other one: a refusal there is a local `return`, and TLS carries the
+    // rejection back as a bare alert with none of its reasoning. So a machine
+    // that answered "n" — or whose prompt got EOF from a script — leaves this
+    // side listing a peer it will never be able to reach, which looks exactly
+    // like a box that is switched off. The remedies are unrelated, so say
+    // which situation this could be while the operator is still standing at
+    // the keyboard.
     println!("Paired with {} ({}).", paired.name, paired.node.short());
+    println!(
+        "  {} has to have accepted too. If it said \"Nothing was trusted\",",
+        paired.name
+    );
+    println!("  pair again — otherwise it will look unreachable from here.");
     Ok(())
 }
 


### PR DESCRIPTION
Found by pairing two agents on this box for real, to verify the address-walk end to end.

B answered `y` and printed **"Paired with spark-256a"**. A's prompt got EOF and printed **"Nothing was trusted"**. B now lists a peer that A rejects on every connection (`peer::tls` refuses an unpinned peer) — and from B that is **indistinguishable from a switched-off machine**. The two remedies are unrelated.

Two-phase pairing is two independent decisions and neither side sees the other's: a refusal is a local `return`, and TLS carries the rejection back as a bare alert with none of its reasoning. B cannot learn this at pairing time; it finds out much later wearing the wrong explanation.

Both sides now say it while the operator is still at the keyboard.

Also verified in the same run: the walk skipped a refused `127.0.0.1:1` and paired on the real address, verification words matched on both sides, and the pin recorded `last_address: 10.10.10.9` — **the address that worked, not the first tried**. 689 tests.