### PR TITLE
fix(fleet): a beacon must not rewrite a trusted peer's address

### DIFF
--- a/crates/atlasctl-agent/src/daemon.rs
+++ b/crates/atlasctl-agent/src/daemon.rs
@@ -392,6 +392,14 @@ fn spawn_peer_poll(
                         if let Some(digest) = report.vouched.clone() {
                             fleet.record_vouches(id, digest);
                         }
+                        // Where the peer actually IS, persisted from the one
+                        // place that has proven it: this exchange completed
+                        // mutual TLS against the pinned key, so `sock` is an
+                        // address that machine really answers on. `observe`
+                        // used to do this from an unauthenticated beacon, which
+                        // let anything on the LAN rewrite a trusted peer's
+                        // address by announcing its (public) fingerprint.
+                        let _ = crate::fleet::remember_address(&pins, id, &sock.ip().to_string());
                         fleet.record_report(report);
                         if let Some(node) = fleet.nodes().into_iter().find(|n| n.id == id) {
                             let _ = events.send(ServerMsg::FleetEvent {

--- a/crates/atlasctl-agent/src/fleet.rs
+++ b/crates/atlasctl-agent/src/fleet.rs
@@ -291,13 +291,13 @@ impl LocalFleet {
         // A node cannot advertise itself into your pin store, and it cannot
         // advertise away a pin you already hold: this only ever writes into the
         // sightings table.
+        //
+        // That was false until `remember_address` moved out of here: it writes
+        // the PIN store, so any LAN host could rewrite a trusted peer's address
+        // by announcing its (public) fingerprint. It now runs after an
+        // authenticated poll, which has proven the address.
         if beacon.id == self.identity.id() {
             return;
-        }
-        // A sighting of a peer we trust also refreshes where we think it is,
-        // so the address outlives this process.
-        if let Some(addr) = beacon.addresses.first().map(ToString::to_string) {
-            let _ = remember_address(&self.pins, beacon.id, &addr);
         }
         if let Ok(mut seen) = self.seen.lock() {
             // Refreshing something already here, or something we have pinned,

--- a/crates/atlasctl-agent/src/fleet/sightings_tests.rs
+++ b/crates/atlasctl-agent/src/fleet/sightings_tests.rs
@@ -7,6 +7,9 @@
 //! unauthenticated network can make it STORE.
 
 use super::tests::{Tmp, beacon, fleet_at};
+use crate::fleet::record_pairing;
+use crate::identity::{Identity, PinStore};
+use atlasctl_protocol::fleet::DisplayName;
 use atlasctl_protocol::fleet::NodeId;
 
 /// mDNS is unauthenticated: anything on the LAN can announce any id. Without a
@@ -107,5 +110,47 @@ fn an_unreadable_pin_store_does_not_evict_the_fleet_it_cannot_see() {
         f.lock_seen().expect("lock").contains_key(&mine),
         "a pinned peer was evicted because its pin file could not be parsed; \
          the operator would see their fleet vanish over an I/O error"
+    );
+}
+
+/// An mDNS beacon is unauthenticated and a `NodeId` is a public key
+/// fingerprint that rides in every one of them, so "claims to be a peer you
+/// trust" is not a thing an attacker has to guess.
+///
+/// `observe` used to call `remember_address`, which writes `last_address` into
+/// the PIN store — three lines under a comment promising it "only ever writes
+/// into the sightings table". Anything on the LAN could therefore rewrite where
+/// a trusted machine was believed to live, persistently: the agent dials the
+/// attacker, the real machine reads as unreachable, and a restart does not
+/// clear it. SPKI pinning refuses the impersonation, so this was redirection
+/// rather than key compromise — which is exactly the kind of bug that survives,
+/// because nothing visibly breaks.
+#[test]
+fn a_beacon_cannot_move_a_pinned_peer() {
+    let t = Tmp::new("beacon-move");
+    let peer = Identity::generate();
+    let pins = PinStore::new(&t.0);
+    record_pairing(
+        &pins,
+        peer.id(),
+        &hex::encode(peer.public().as_bytes()),
+        DisplayName::new("spark-43fa"),
+        0,
+        Some("10.10.10.10".to_owned()),
+        false,
+    )
+    .expect("pin");
+
+    // A hostile beacon claiming that peer's id, from somewhere else entirely.
+    let mut hostile = beacon(peer.id(), "spark-43fa", true);
+    hostile.addresses = vec!["10.10.10.99".parse().expect("addr")];
+    fleet_at(&t.0).observe(hostile);
+
+    assert_eq!(
+        pins.load().expect("read")[&peer.id()]
+            .last_address
+            .as_deref(),
+        Some("10.10.10.10"),
+        "an unauthenticated beacon must not rewrite a trusted peer's address"
     );
 }

--- a/crates/atlasctl-agent/src/fleet/tests.rs
+++ b/crates/atlasctl-agent/src/fleet/tests.rs
@@ -417,28 +417,22 @@ fn a_paired_peers_address_survives_this_agent_restarting() {
     let t = Tmp::new("addrmem");
     let peer = Identity::generate();
     let pins = PinStore::new(&t.0);
+    // The address is recorded by the PAIRING — `peer add` pins the address the
+    // ceremony actually completed over — and refreshed by an authenticated
+    // poll. It used to be written here by `observe`, from an unauthenticated
+    // beacon; see `a_beacon_cannot_move_a_pinned_peer` for why it is not.
     record_pairing(
         &pins,
         peer.id(),
         &hex::encode(peer.public().as_bytes()),
         DisplayName::new("spark-43fa"),
         0,
-        None,
+        Some("10.10.10.10".to_owned()),
         false,
     )
     .expect("pin");
 
-    // First run: a beacon arrives, and the address is remembered.
-    let first = fleet_at(&t.0);
-    first.observe(beacon(peer.id(), "spark-43fa", true));
-    assert_eq!(
-        pins.load().expect("read")[&peer.id()]
-            .last_address
-            .as_deref(),
-        Some("10.10.10.10")
-    );
-
-    // Second run: fresh process, no sightings at all.
+    // A fresh process, no sightings at all.
     let restarted = fleet_at(&t.0);
     let listed = restarted
         .nodes()


### PR DESCRIPTION
Found by an adversarial audit of tonight's work; confirmed in the code.

`observe()` carried this comment — and called `remember_address` three lines later, which does `pins.add(updated)`, a write to the on-disk **pin store**:

> A node cannot advertise itself into your pin store, and it cannot advertise away a pin you already hold: this only ever writes into the sightings table.

mDNS is unauthenticated and a `NodeId` is a public key fingerprint carried in every beacon, so *"claim to be a machine you trust"* is not something an attacker has to guess. Anything on the LAN could rewrite `last_address` for a trusted peer, **persistently**: the agent dials the attacker, the real machine reads as unreachable, and a restart does not clear it. SPKI pinning refuses the impersonation, so this is redirection, not key compromise — which is why it survived: nothing visibly breaks.

The refresh moves to where the address is **proven** — after a successful authenticated poll (mutual TLS against the pinned key). The honest case loses nothing: a live beacon still lands in `seen`, and `dialable_peers` prefers a sighting over the pin regardless.

An existing test asserted the old behaviour, encoding the hole as intent; it now takes its address from the pairing (what `peer add` records) and keeps the restart property it was actually about. Mutation-checked: restoring the write fails the new test. 693 tests.