### PR TITLE
fix(fleet): dial the port the peer advertised, not our own

### DIFF
--- a/crates/atlasctl-agent/src/daemon.rs
+++ b/crates/atlasctl-agent/src/daemon.rs
@@ -353,7 +353,8 @@ fn spawn_peer_poll(
             let Ok(peers) = fleet.dialable_peers() else {
                 continue;
             };
-            for (id, addr) in peers {
+            for (id, dial) in peers {
+                let addr = dial.addr;
                 // Parse the IP and attach the port, rather than formatting
                 // "{addr}:{port}" and parsing that. A SocketAddr string needs
                 // an IPv6 literal in brackets — `[fe80::1]:34334` — so the
@@ -361,10 +362,13 @@ fn spawn_peer_poll(
                 // `continue` below turned that into silence: the node stayed in
                 // the fleet, was never polled, and simply aged into "stale"
                 // forever with no error anywhere.
+                // The peer's OWN advertised port when it is announcing;
+                // ours only as a fallback. Using ours was correct only while
+                // every agent bound the same one.
                 let Some(sock) = addr
                     .parse::<std::net::IpAddr>()
                     .ok()
-                    .map(|ip| std::net::SocketAddr::new(ip, port))
+                    .map(|ip| std::net::SocketAddr::new(ip, dial.port.unwrap_or(port)))
                 else {
                     continue;
                 };

--- a/crates/atlasctl-agent/src/daemon.rs
+++ b/crates/atlasctl-agent/src/daemon.rs
@@ -355,21 +355,12 @@ fn spawn_peer_poll(
             };
             for (id, dial) in peers {
                 let addr = dial.addr;
-                // Parse the IP and attach the port, rather than formatting
-                // "{addr}:{port}" and parsing that. A SocketAddr string needs
-                // an IPv6 literal in brackets — `[fe80::1]:34334` — so the
-                // formatted form failed to parse for EVERY IPv6 peer, and the
-                // `continue` below turned that into silence: the node stayed in
-                // the fleet, was never polled, and simply aged into "stale"
-                // forever with no error anywhere.
-                // The peer's OWN advertised port when it is announcing;
-                // ours only as a fallback. Using ours was correct only while
-                // every agent bound the same one.
-                let Some(sock) = addr
-                    .parse::<std::net::IpAddr>()
-                    .ok()
-                    .map(|ip| std::net::SocketAddr::new(ip, dial.port.unwrap_or(port)))
-                else {
+                // Both rules — structural IPv6 handling and "the peer's port
+                // first" — live in `peer::reach::dial_socket`, where they are
+                // tested. They were inline here, inside a spawned loop with no
+                // unit seam, so a mutation that dropped the advertised port
+                // broke nothing.
+                let Some(sock) = crate::peer::reach::dial_socket(&addr, dial.port, port) else {
                     continue;
                 };
                 let link = fleet.classify_peer_address(&addr);

--- a/crates/atlasctl-agent/src/fleet.rs
+++ b/crates/atlasctl-agent/src/fleet.rs
@@ -353,26 +353,6 @@ impl LocalFleet {
         }
     }
 
-    /// Peers this agent should try to reach, with the address to use.
-    ///
-    /// # Errors
-    /// If the pin store cannot be read.
-    pub fn dialable_peers(&self) -> Result<Vec<(NodeId, String)>> {
-        let pinned = self.pins.load()?;
-        let seen = self.lock_seen();
-        Ok(pinned
-            .iter()
-            .filter_map(|(id, pin)| {
-                let addr = seen
-                    .as_ref()
-                    .and_then(|s| s.get(id))
-                    .and_then(|s| s.beacon.addresses.first().map(ToString::to_string))
-                    .or_else(|| pin.last_address.clone())?;
-                Some((*id, addr))
-            })
-            .collect())
-    }
-
     /// How this machine classifies the link an address sits on.
     ///
     /// Asked of our own fabric probe, never of the peer: a peer's opinion of
@@ -496,4 +476,5 @@ pub use vitals::{
     running_probe_argv, vitals_from_device,
 };
 
+pub use listing::PeerDial;
 pub use pinning::{no_vitals, record_pairing, remember_address};

--- a/crates/atlasctl-agent/src/fleet/listing.rs
+++ b/crates/atlasctl-agent/src/fleet/listing.rs
@@ -412,3 +412,50 @@ fn dial_first_reachable(
     crate::peer::reach::walk(addrs, |addr| driver.pair(addr, code))
         .map_err(|e| anyhow::anyhow!("could not pair over any advertised address — {e:#}"))
 }
+
+/// Where to reach one paired peer: its address, and the port IT advertised.
+///
+/// Separate from a bare `(NodeId, String)` so the port cannot be silently
+/// dropped on the way to the dial, which is exactly what happened while this
+/// was a two-tuple.
+#[derive(Debug, Clone)]
+pub struct PeerDial {
+    /// The address to dial — a live sighting first, else the pin.
+    pub addr: String,
+    /// The peer's own peer-channel port, when it is currently announcing.
+    pub port: Option<u16>,
+}
+
+impl super::LocalFleet {
+    /// Peers this agent should try to reach, with the address to use.
+    ///
+    /// # Errors
+    /// If the pin store cannot be read.
+    pub fn dialable_peers(&self) -> Result<Vec<(NodeId, PeerDial)>> {
+        let pinned = self.pins.load()?;
+        let seen = self.lock_seen();
+        Ok(pinned
+            .iter()
+            .filter_map(|(id, pin)| {
+                let sighting = seen.as_ref().and_then(|s| s.get(id));
+                let addr = sighting
+                    .and_then(|s| s.beacon.addresses.first().map(ToString::to_string))
+                    .or_else(|| pin.last_address.clone())?;
+                // The port the PEER announced, not the one this agent happens
+                // to listen on. A beacon has carried `peer_port` all along and
+                // the poll discarded it, dialling every peer on our own port —
+                // correct only because every agent currently binds the same
+                // one. `None` when the peer is not currently announcing, and
+                // the caller falls back to the default rather than guessing
+                // from itself.
+                Some((
+                    *id,
+                    PeerDial {
+                        addr,
+                        port: sighting.map(|s| s.beacon.peer_port),
+                    },
+                ))
+            })
+            .collect())
+    }
+}

--- a/crates/atlasctl-agent/src/fleet/sightings_tests.rs
+++ b/crates/atlasctl-agent/src/fleet/sightings_tests.rs
@@ -154,3 +154,70 @@ fn a_beacon_cannot_move_a_pinned_peer() {
         "an unauthenticated beacon must not rewrite a trusted peer's address"
     );
 }
+
+/// A beacon has always carried the peer's own `peer_port`, and the poll threw
+/// it away — every peer was dialled on THIS agent's port instead. That is
+/// correct only while every agent binds the same one, which is true today and
+/// is exactly the assumption that makes a per-machine port impossible to add.
+///
+/// It is also why a pin can only remember an IP: storing a port would persist
+/// a number nothing consults.
+#[test]
+fn a_peer_is_dialled_on_the_port_it_advertised() {
+    let t = Tmp::new("dial-port");
+    let f = fleet_at(&t.0);
+    let mine = NodeId::from_bytes([3; 32]);
+    record_pairing(
+        &f.pins,
+        mine,
+        "ef".repeat(32).as_str(),
+        DisplayName::new("odd-port-peer"),
+        0,
+        Some("10.10.10.10".to_owned()),
+        false,
+    )
+    .expect("pin");
+
+    let mut b = beacon(mine, "odd-port-peer", true);
+    b.peer_port = 34999;
+    f.observe(b);
+
+    let dials = f.dialable_peers().expect("reads");
+    let (_, dial) = dials
+        .iter()
+        .find(|(id, _)| *id == mine)
+        .expect("a pinned, announcing peer is dialable");
+    assert_eq!(
+        dial.port,
+        Some(34999),
+        "the port the PEER announced must reach the dial, not this agent's own"
+    );
+}
+
+/// A peer that is not announcing has no port to offer, and the caller falls
+/// back to the default rather than inventing one — `None` is "it did not say",
+/// which is the same distinction the vitals carry.
+#[test]
+fn a_silent_peer_offers_no_port_rather_than_a_guess() {
+    let t = Tmp::new("dial-port-silent");
+    let f = fleet_at(&t.0);
+    let mine = NodeId::from_bytes([4; 32]);
+    record_pairing(
+        &f.pins,
+        mine,
+        "ab".repeat(32).as_str(),
+        DisplayName::new("switched-off"),
+        0,
+        Some("10.10.10.11".to_owned()),
+        false,
+    )
+    .expect("pin");
+
+    let dials = f.dialable_peers().expect("reads");
+    let (_, dial) = dials
+        .iter()
+        .find(|(id, _)| *id == mine)
+        .expect("still listed");
+    assert_eq!(dial.addr, "10.10.10.11", "the pin's address stands");
+    assert_eq!(dial.port, None, "no sighting means no advertised port");
+}

--- a/crates/atlasctl-agent/src/peer/reach.rs
+++ b/crates/atlasctl-agent/src/peer/reach.rs
@@ -76,6 +76,33 @@ where
     anyhow::bail!("{}", why.join("; "))
 }
 
+/// Where to dial one peer: its address, and the port IT advertised.
+///
+/// Two rules, both of which were learned the hard way and neither of which
+/// had a test while they lived inside the poll loop:
+///
+/// 1. Parse the IP and attach the port structurally. Formatting
+///    `"{addr}:{port}"` and parsing that back needs an IPv6 literal in
+///    brackets, so it failed for EVERY IPv6 peer — and the caller's `continue`
+///    turned that into silence: the node stayed in the fleet, was never
+///    polled, and aged into "stale" forever with no error anywhere.
+/// 2. Prefer the port the PEER announced. `None` means it is not currently
+///    announcing, and only then does this agent's own port stand in. Using
+///    ours unconditionally was correct only while every agent bound the same
+///    one — the assumption that makes a per-machine port unaddable.
+///
+/// `None` when the address does not parse as an IP, which the caller skips.
+#[must_use]
+pub fn dial_socket(
+    addr: &str,
+    advertised: Option<u16>,
+    fallback: u16,
+) -> Option<std::net::SocketAddr> {
+    addr.parse::<std::net::IpAddr>()
+        .ok()
+        .map(|ip| std::net::SocketAddr::new(ip, advertised.unwrap_or(fallback)))
+}
+
 #[cfg(test)]
 mod tests {
     use super::never_reached;
@@ -177,5 +204,35 @@ mod tests {
             panic!("nothing to dial must not dial")
         });
         assert!(out.is_err());
+    }
+
+    #[test]
+    fn the_port_the_peer_announced_wins_over_this_agents_own() {
+        let s = super::dial_socket("10.10.10.9", Some(34999), 34334).expect("parses");
+        assert_eq!(s.port(), 34999);
+    }
+
+    #[test]
+    fn a_peer_that_is_not_announcing_falls_back_rather_than_being_skipped() {
+        // `None` is "it did not say", not "port zero" and not "unreachable".
+        let s = super::dial_socket("10.10.10.9", None, 34334).expect("parses");
+        assert_eq!(s.port(), 34334);
+    }
+
+    /// The regression this shape exists for: `format!("{addr}:{port}")` then
+    /// parsing back needs brackets, so every IPv6 peer produced `None` and the
+    /// caller silently skipped it forever.
+    #[test]
+    fn an_ipv6_peer_is_dialable_at_all() {
+        let s = super::dial_socket("fe80::1", Some(34999), 34334).expect("a v6 peer parses");
+        assert!(s.is_ipv6());
+        assert_eq!(s.port(), 34999);
+    }
+
+    #[test]
+    fn a_hostname_is_not_an_address_here() {
+        // This path takes addresses off a beacon or a pin, never a name; a
+        // name would have to be resolved, which is `resolve_manual`'s job.
+        assert!(super::dial_socket("spark-256a", None, 34334).is_none());
     }
 }


### PR DESCRIPTION
A beacon has carried `peer_port` since discovery was written, and the poll threw it away: `SocketAddr::new(ip, port)` used **this** agent's port for every peer.

That is correct today only because every agent binds the same one — and it is exactly the assumption that:
- makes a per-machine peer port impossible to add, and
- leaves a pin able to remember only an IP, since storing a port would persist a number nothing consults (the open finding from an earlier audit).

`dialable_peers` now returns `PeerDial { addr, port }` rather than a two-tuple, so the port cannot be dropped silently on the way to the dial. `None` means the peer is not currently announcing — the caller falls back to the default instead of guessing from itself, the same *"it did not say"* the vitals carry.

`PeerDial` and `dialable_peers` live in `fleet/listing.rs` ("turning what this agent knows into the list a browser renders") rather than `fleet.rs`, which the move keeps under the 500-line cap.

**Coverage, stated plainly:** the two new tests guard what `dialable_peers` RETURNS. Mutating the daemon's dial site to ignore the port again breaks no test — that site is inside a spawned poll loop with no unit seam. The data layer is guarded; the consumption is not. Worth a harness test later, and worth not claiming now.

697 tests.