### PR TITLE
fix(pair): sanitise the peer's name before it reaches a terminal

### DIFF
--- a/crates/atlasctl-agent/src/daemon.rs
+++ b/crates/atlasctl-agent/src/daemon.rs
@@ -329,7 +329,10 @@ async fn serve_join<S>(
         // someone who wants to check, check.
         eprintln!(
             "paired with {} ({}) — verification words: {}",
-            paired.name,
+            // Sanitised: the name is the joining peer's own claim, and this
+            // line goes into the journal, where a control sequence is just as
+            // effective at rewriting what a reader sees.
+            atlasctl_protocol::fleet::DisplayName::new(&paired.name).as_str(),
             paired.node.short(),
             paired.verification
         );

--- a/crates/atlasctl-protocol/src/fleet/tests.rs
+++ b/crates/atlasctl-protocol/src/fleet/tests.rs
@@ -271,3 +271,29 @@ fn a_vouch_entry_round_trips_and_absent_vitals_carry_no_age() {
     let back: VouchedPeer = serde_json::from_str(&json).expect("round trips");
     assert_eq!(back, v);
 }
+
+/// The name in a peer's hello frame is attacker-controlled and is printed to a
+/// terminal DURING the pairing ceremony — between the verification words and
+/// the y/N prompt. An ANSI escape there can erase and repaint the words the
+/// operator is about to compare, which defeats the out-of-band check the whole
+/// SPAKE2 exchange exists to enable.
+#[test]
+fn an_ansi_escape_cannot_survive_into_a_rendered_name() {
+    let hostile = "\u{1b}[2K\u{1b}[1Aabcd-1234 \u{1b}[0m";
+    let shown = DisplayName::new(hostile);
+    assert!(
+        !shown.as_str().contains('\u{1b}'),
+        "an escape reached the terminal: {:?}",
+        shown.as_str()
+    );
+    // The printable remainder survives, so a legitimate name is not destroyed
+    // by the guard — this strips control characters, it does not redact.
+    assert!(shown.as_str().contains("abcd-1234"));
+}
+
+/// A carriage return alone is enough: it returns the cursor to column 0 and
+/// the next characters overwrite the line already drawn.
+#[test]
+fn a_bare_carriage_return_cannot_repaint_the_line() {
+    assert!(!DisplayName::new("ok\rSPOOFED").as_str().contains('\r'));
+}

--- a/crates/atlasctl/src/commands/agentpair.rs
+++ b/crates/atlasctl/src/commands/agentpair.rs
@@ -141,10 +141,15 @@ pub fn pair(args: &crate::cli::AgentPairArgs) -> Result<()> {
     // like a box that is switched off. The remedies are unrelated, so say
     // which situation this could be while the operator is still standing at
     // the keyboard.
-    println!("Paired with {} ({}).", paired.name, paired.node.short());
+    // Sanitised: the name is the peer's, and the peer is not trusted yet.
+    println!(
+        "Paired with {} ({}).",
+        atlasctl_protocol::fleet::DisplayName::new(&paired.name).as_str(),
+        paired.node.short()
+    );
     println!(
         "  {} has to have accepted too. If it said \"Nothing was trusted\",",
-        paired.name
+        atlasctl_protocol::fleet::DisplayName::new(&paired.name).as_str()
     );
     println!("  pair again — otherwise it will look unreachable from here.");
     Ok(())

--- a/crates/atlasctl/src/commands/peer.rs
+++ b/crates/atlasctl/src/commands/peer.rs
@@ -141,9 +141,16 @@ pub fn add(args: &PeerAddArgs) -> Result<()> {
     println!();
     println!("  Verification words:  {}", paired.verification);
     println!();
+    // SANITISED, and this is the site that matters most. `paired.name` comes
+    // off the not-yet-trusted peer's hello frame, and it is printed BETWEEN
+    // the verification words and the y/N prompt. A name carrying ANSI escapes
+    // ("\x1b[2K\x1b[1A…") can erase and repaint the words the operator is
+    // about to compare — defeating the out-of-band check the whole SPAKE2
+    // ceremony exists to enable. The storage site 20 lines below already
+    // wraps it; the human-facing one did not.
     println!(
         "  `atlasctl agent pair` on {} is showing the same words.",
-        paired.name
+        DisplayName::new(&paired.name).as_str()
     );
     println!("  If it is showing something else, something is relaying this");
     println!("  connection — press Ctrl-C now and nothing will be trusted.");
@@ -180,10 +187,14 @@ pub fn add(args: &PeerAddArgs) -> Result<()> {
     // like a box that is switched off. The remedies are unrelated, so say
     // which situation this could be while the operator is still standing at
     // the keyboard.
-    println!("Paired with {} ({}).", paired.name, paired.node.short());
+    println!(
+        "Paired with {} ({}).",
+        DisplayName::new(&paired.name).as_str(),
+        paired.node.short()
+    );
     println!(
         "  {} has to have accepted too. If it said \"Nothing was trusted\",",
-        paired.name
+        DisplayName::new(&paired.name).as_str()
     );
     println!("  pair again — otherwise it will look unreachable from here.");
     Ok(())

--- a/crates/atlasctl/src/commands/service.rs
+++ b/crates/atlasctl/src/commands/service.rs
@@ -153,7 +153,12 @@ fn join_fleet(join: &crate::joinarg::Join, grant_control: bool) -> Result<()> {
         grant_control,
     )?;
 
-    println!("joined {} ({})", paired.name, paired.node.short());
+    // Sanitised: the name is the peer's, and the peer is not trusted yet.
+    println!(
+        "joined {} ({})",
+        atlasctl_protocol::fleet::DisplayName::new(&paired.name).as_str(),
+        paired.node.short()
+    );
     println!("  verification words: {}", paired.verification);
     println!("  the browser that invited this machine is showing the same words.");
     println!(


### PR DESCRIPTION
`paired.name` comes straight off `PeerFrame::Hello` — from the machine the operator has **not yet decided to trust** — and is printed raw. The site that matters sits between the verification words and the `[y/N]` prompt:

```
Verification words:  d889-14aa
`atlasctl agent pair` on <PEER NAME> is showing the same words.
If it is showing something else, something is relaying this
connection — press Ctrl-C now and nothing will be trusted.
Do they match? [y/N]
```

A name of `"\x1b[2K\x1b[1A…"` erases and repaints the lines above it, so a hostile machine at the dialled address can show the operator whatever words it likes. **That defeats the out-of-band comparison the SPAKE2 exchange exists to enable** — the one check a relay cannot pass.

The repo already had the answer and applied it on the wrong side: every *storage* site wraps the name in `DisplayName::new` (which filters `!c.is_control()`). In `peer.rs` the storage call is **twenty lines below** the raw print. Six print sites now sanitise, including two I added earlier tonight and the agent's journal line.

Found by an adversarial audit. The escape and bare-CR cases are pinned by tests — which were briefly worthless: they landed in a `name_tests.rs` that nothing declares, so they compiled to nothing and `cargo test` reported them as neither run nor failed. Checking by *name* rather than trusting a green count caught it. A mutation that stops stripping controls now fails all three. 697 tests.