### PR TITLE
fix(launch): refuse remotely what the CLI only cautions about

### DIFF
--- a/crates/atlasctl-agent/src/control.rs
+++ b/crates/atlasctl-agent/src/control.rs
@@ -38,6 +38,10 @@ pub struct LocalControl<'a> {
     pub telemetry: Option<&'a dyn LaunchTelemetry>,
     /// Whether this machine can run a recipe at all.
     pub can_launch: &'a Result<(), String>,
+    /// What this machine's accelerator reports itself to be, for the
+    /// hardware-aware refusal in [`Self::launch`]. Empty when the probe found
+    /// nothing — which reads as "not GB10" and so gates nothing.
+    pub accelerator: &'a str,
 }
 
 impl LocalControl<'_> {
@@ -109,6 +113,33 @@ impl LocalControl<'_> {
             });
         }
         let overrides = check_settings(requested)?;
+        // A caution the CLI prints and proceeds past is worth nothing here:
+        // this path is driven by the browser and by a granted remote
+        // controller, and there is no operator at the keyboard to read it. On
+        // a GB10 the failure it warns about is a hard freeze needing a power
+        // cycle — unified memory leaves no framebuffer to fall back on — so
+        // the unattended surface refuses what the attended one merely warns
+        // about.
+        //
+        // This gates OVERRIDES only. A recipe's own value never passes through
+        // here, so the shipped 0.9 profiles keep working; what is refused is a
+        // number someone sent over the wire.
+        for (key, value) in &overrides {
+            if let atlasctl_core::ScalarValue::Float(f) = value
+                && let Some(why) = atlasctl_core::settings::caution(key, *f, self.accelerator)
+            {
+                // `Denied` is the exact vocabulary already here: "the setting
+                // exists but clients may not set it", rendered as "cannot be
+                // set remotely". That is the claim being made — not that the
+                // value is out of range, which it is not.
+                return Err(AgentError::BadSettings {
+                    errors: vec![atlasctl_protocol::settings::SettingError::Denied {
+                        key: key.clone(),
+                        reason: why,
+                    }],
+                });
+            }
+        }
         self.launcher.launch(&recipe, &overrides)
     }
 
@@ -264,6 +295,7 @@ pub struct ControlHost {
     launcher: Box<dyn Launcher>,
     telemetry: Option<Box<dyn LaunchTelemetry>>,
     can_launch: Result<(), String>,
+    accelerator: String,
 }
 
 impl ControlHost {
@@ -274,12 +306,14 @@ impl ControlHost {
         launcher: Box<dyn Launcher>,
         telemetry: Option<Box<dyn LaunchTelemetry>>,
         can_launch: Result<(), String>,
+        accelerator: String,
     ) -> Self {
         Self {
             registry,
             launcher,
             telemetry,
             can_launch,
+            accelerator,
         }
     }
 
@@ -287,6 +321,7 @@ impl ControlHost {
     #[must_use]
     pub fn control(&self) -> LocalControl<'_> {
         LocalControl {
+            accelerator: &self.accelerator,
             registry: &self.registry,
             launcher: self.launcher.as_ref(),
             telemetry: self.telemetry.as_deref(),

--- a/crates/atlasctl-agent/src/control/tests.rs
+++ b/crates/atlasctl-agent/src/control/tests.rs
@@ -33,8 +33,19 @@ impl Fixture {
         }
     }
 
+    fn control_on(&self, accelerator: &'static str) -> LocalControl<'_> {
+        LocalControl {
+            accelerator,
+            registry: &self.registry,
+            launcher: &self.launcher,
+            telemetry: None,
+            can_launch: &self.can_launch,
+        }
+    }
+
     fn control(&self) -> LocalControl<'_> {
         LocalControl {
+            accelerator: "",
             registry: &self.registry,
             launcher: &self.launcher,
             telemetry: None,
@@ -165,6 +176,7 @@ fn the_target_caps_the_log_lines_whatever_the_wire_asked() {
         asked: Mutex::new(Vec::new()),
     };
     let c = LocalControl {
+        accelerator: "",
         registry: &f.registry,
         launcher: &f.launcher,
         telemetry: Some(&telemetry),
@@ -197,4 +209,63 @@ fn stats_and_logs_without_a_telemetry_source_say_so() {
         }),
         Err(AgentError::NotReady)
     ));
+}
+
+/// A caution the CLI prints and proceeds past is worth nothing on this
+/// surface: the browser and a granted remote controller drive it, and there
+/// is no operator at the keyboard to read a warning. On a GB10 the failure it
+/// warns about is a hard freeze needing a power cycle.
+#[test]
+fn a_remote_override_above_the_gb10_caution_is_refused_not_warned() {
+    let f = Fixture::new();
+    let c = f.control_on("NVIDIA GB10");
+    let mut req = std::collections::BTreeMap::new();
+    req.insert(
+        "gpu_memory_utilization".to_owned(),
+        atlasctl_protocol::settings::SettingValue::Float(0.95),
+    );
+    let err = c.launch(&id(REAL), &req).expect_err("must refuse");
+    // Structured, not prose: `BadSettings`'s Display is a summary ("1
+    // setting(s) rejected"), and the browser renders the errors themselves.
+    let atlasctl_protocol::msg::AgentError::BadSettings { errors } = &err else {
+        panic!("expected BadSettings, got {err:?}");
+    };
+    assert!(
+        errors.iter().any(|e| matches!(
+            e,
+            atlasctl_protocol::settings::SettingError::Denied { key, .. }
+                if key == "gpu_memory_utilization"
+        )),
+        "the refusal must name the setting, as Denied: {errors:?}"
+    );
+    assert!(
+        !f.launcher.launched_anything(),
+        "nothing may reach the launcher"
+    );
+}
+
+/// The bound is hardware-aware, not a blanket cap: the same value on hardware
+/// the caution does not know is none of its business.
+#[test]
+fn the_same_value_is_untouched_on_hardware_the_caution_does_not_claim() {
+    let f = Fixture::new();
+    let c = f.control_on("NVIDIA H100");
+    let mut req = std::collections::BTreeMap::new();
+    req.insert(
+        "gpu_memory_utilization".to_owned(),
+        atlasctl_protocol::settings::SettingValue::Float(0.95),
+    );
+    // Reaches the launcher — it may still fail there for unrelated reasons,
+    // but it must not be refused by the GB10 caution.
+    let out = c.launch(&id(REAL), &req);
+    if let Err(atlasctl_protocol::msg::AgentError::BadSettings { errors }) = &out {
+        assert!(
+            !errors.iter().any(|e| matches!(
+                e,
+                atlasctl_protocol::settings::SettingError::Denied { key, .. }
+                    if key == "gpu_memory_utilization"
+            )),
+            "refused on hardware the caution does not claim: {errors:?}"
+        );
+    }
 }

--- a/crates/atlasctl-agent/src/daemon/peer_serve_tests.rs
+++ b/crates/atlasctl-agent/src/daemon/peer_serve_tests.rs
@@ -135,6 +135,7 @@ fn rig(tag: &str) -> Rig {
             Box::new(SharedLauncher(Arc::clone(&launcher))),
             None,
             Ok(()),
+            "NVIDIA GB10".to_owned(),
         )),
         peer_port: 34334,
         // Tests never reach a real dial; the budget only has to exist.

--- a/crates/atlasctl-agent/src/daemon/relay_harness.rs
+++ b/crates/atlasctl-agent/src/daemon/relay_harness.rs
@@ -140,6 +140,7 @@ pub(super) async fn spawn_serving(
             launcher,
             None,
             Ok(()),
+            "NVIDIA GB10".to_owned(),
         )),
         peer_port: a.port,
         answer_budget,

--- a/crates/atlasctl-agent/src/server.rs
+++ b/crates/atlasctl-agent/src/server.rs
@@ -37,6 +37,9 @@ pub struct AgentState {
     pub token: String,
     /// Whether this machine can run a recipe, and why not if it cannot.
     pub can_launch: Result<(), String>,
+    /// What this machine's accelerator reports itself to be, for the launch
+    /// path's hardware-aware refusal. Empty when the probe found nothing.
+    pub accelerator: String,
     /// The window in which one new machine may join, when this agent has one.
     pub joining: Option<Arc<crate::joining::JoinWindow>>,
     /// Port we are listening on, for the Host check.
@@ -162,6 +165,7 @@ async fn run_session(mut socket: ws::WebSocket, state: Arc<AgentState>) {
         launcher: state.launcher.as_ref(),
         token: &state.token,
         can_launch: state.can_launch.clone(),
+        accelerator: &state.accelerator,
         fleet: state.fleet.as_deref(),
         cluster: state.cluster.as_deref(),
         telemetry: state.telemetry.as_deref(),

--- a/crates/atlasctl-agent/src/server/tests.rs
+++ b/crates/atlasctl-agent/src/server/tests.rs
@@ -10,6 +10,7 @@ const TOKEN: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789a
 
 fn state(port: u16) -> Arc<AgentState> {
     Arc::new(AgentState {
+        accelerator: String::new(),
         registry: RegistrySet::builtin_only(),
         launcher: Box::new(RecordingLauncher::new()),
         token: TOKEN.to_string(),

--- a/crates/atlasctl-agent/src/session.rs
+++ b/crates/atlasctl-agent/src/session.rs
@@ -36,6 +36,11 @@ pub struct SessionDeps<'a> {
     pub token: &'a str,
     /// Whether this machine can run a recipe at all.
     pub can_launch: Result<(), String>,
+    /// What this machine's accelerator reports itself to be. Carried so the
+    /// launch path can refuse a setting that is merely CAUTIONED at a keyboard
+    /// — there is no operator on this surface to read a warning. Empty when
+    /// the probe found nothing, which gates nothing.
+    pub accelerator: &'a str,
     /// What this agent knows about other machines.
     ///
     /// `None` is a single-node agent: the fleet verbs answer with this machine
@@ -331,6 +336,7 @@ impl<'a> Session<'a> {
             launcher: self.deps.launcher,
             telemetry: self.deps.telemetry,
             can_launch: &self.deps.can_launch,
+            accelerator: self.deps.accelerator,
         }
     }
 

--- a/crates/atlasctl-agent/src/session/consent_tests.rs
+++ b/crates/atlasctl-agent/src/session/consent_tests.rs
@@ -115,6 +115,7 @@ fn minting_with_allow_control_stamps_the_join_window() {
     let fleet = SelfAwareFleet;
     let joining = crate::joining::JoinWindow::default();
     let (mut s, _) = Session::new(SessionDeps {
+        accelerator: "",
         registry: &f.registry,
         launcher: &f.launcher,
         token: TOKEN,

--- a/crates/atlasctl-agent/src/session/forward_tests.rs
+++ b/crates/atlasctl-agent/src/session/forward_tests.rs
@@ -147,6 +147,7 @@ fn routed_session<'a>(
     relay: Option<&'a dyn ControlRelay>,
 ) -> Session<'a> {
     let (mut s, _) = Session::new(SessionDeps {
+        accelerator: "",
         registry: &f.registry,
         launcher: &f.launcher,
         token: TOKEN,

--- a/crates/atlasctl-agent/src/session/join_tests.rs
+++ b/crates/atlasctl-agent/src/session/join_tests.rs
@@ -14,6 +14,7 @@ use atlasctl_protocol::{ClientMsg, ServerMsg};
 /// A session whose agent can take on a new machine.
 fn ready_with_window<'a>(f: &'a Fixture, w: &'a crate::joining::JoinWindow) -> Session<'a> {
     let (mut s, _) = Session::new(SessionDeps {
+        accelerator: "",
         registry: &f.registry,
         launcher: &f.launcher,
         token: TOKEN,
@@ -97,6 +98,7 @@ fn minting_before_the_handshake_is_refused() {
     let f = Fixture::new();
     let w = crate::joining::JoinWindow::default();
     let (mut s, _) = Session::new(SessionDeps {
+        accelerator: "",
         registry: &f.registry,
         launcher: &f.launcher,
         token: TOKEN,

--- a/crates/atlasctl-agent/src/session/pair_at_tests.rs
+++ b/crates/atlasctl-agent/src/session/pair_at_tests.rs
@@ -17,6 +17,7 @@ use atlasctl_protocol::{ClientMsg, ServerMsg};
 
 fn session<'a>(f: &'a Fixture, fleet: &'a RecordingFleet) -> super::Session<'a> {
     let (mut s, _) = super::Session::new(super::SessionDeps {
+        accelerator: "",
         registry: &f.registry,
         launcher: &f.launcher,
         token: TOKEN,

--- a/crates/atlasctl-agent/src/session/pairing_tests.rs
+++ b/crates/atlasctl-agent/src/session/pairing_tests.rs
@@ -113,6 +113,7 @@ use atlasctl_protocol::fleet::{NodeDescriptor, NodeId};
 /// A handshaken session wired to `fleet`.
 pub(super) fn ready_with_fleet<'a>(f: &'a Fixture, fleet: &'a dyn FleetView) -> super::Session<'a> {
     let (mut s, _) = super::Session::new(super::SessionDeps {
+        accelerator: "",
         registry: &f.registry,
         launcher: &f.launcher,
         token: TOKEN,
@@ -434,6 +435,7 @@ fn an_invitation_from_a_wireless_machine_still_carries_an_address() {
     let fleet = WirelessFleet::new();
     let window = crate::joining::JoinWindow::default();
     let (mut s, _) = super::Session::new(super::SessionDeps {
+        accelerator: "",
         registry: &f.registry,
         launcher: &f.launcher,
         token: TOKEN,

--- a/crates/atlasctl-agent/src/session/tests.rs
+++ b/crates/atlasctl-agent/src/session/tests.rs
@@ -48,6 +48,7 @@ impl Fixture {
 
     pub(super) fn session(&self) -> Session<'_> {
         let (s, _welcome) = Session::new(SessionDeps {
+            accelerator: "",
             registry: &self.registry,
             launcher: &self.launcher,
             token: TOKEN,
@@ -80,6 +81,7 @@ impl Fixture {
 fn the_agent_speaks_first_with_a_version_range() {
     let f = Fixture::new();
     let (_s, welcome) = Session::new(SessionDeps {
+        accelerator: "",
         registry: &f.registry,
         launcher: &f.launcher,
         token: TOKEN,

--- a/crates/atlasctl/src/commands/agent.rs
+++ b/crates/atlasctl/src/commands/agent.rs
@@ -267,6 +267,7 @@ pub fn run(args: &AgentRunArgs) -> Result<()> {
             )),
         ))),
         can_launch.clone(),
+        accelerator.clone(),
     ));
 
     let state = Arc::new(AgentState {
@@ -279,6 +280,7 @@ pub fn run(args: &AgentRunArgs) -> Result<()> {
         )),
         token: tok.clone().unwrap_or_default(),
         can_launch: can_launch.clone(),
+        accelerator: accelerator.clone(),
         joining: Some(Arc::clone(&joining)),
         port: args.port,
         allow_dev_origins: args.dev_origins,


### PR DESCRIPTION
`gpu_memory_utilization` is exposed as `Float(0.10, 0.95)`, and the `caution()` machinery built for exactly this had **one** caller: `atlasctl run`. The browser page and any peer holding the `controller` grant went straight past it.

A warning is the right answer where a human reads it. It is worth nothing on a surface with nobody at the keyboard — and on a GB10 the failure being warned about is a **hard freeze needing a power cycle**, since unified memory leaves no framebuffer to fall back on. The attended path keeps warn-and-allow; the unattended one refuses.

Scoped deliberately:

- **Overrides only.** A recipe's own value never passes through `check_settings`, so the shipped 0.9 profiles keep launching — which matters, because one of them backs four of the ten gates and ran all night. What is refused is a number someone sent over the wire.
- **Hardware-aware.** `caution()` only fires for the GB10 family, so the same value on hardware it does not claim is untouched. An empty accelerator gates nothing.

`SettingError::Denied` is the existing vocabulary and says precisely this — *"cannot be set remotely"* — rather than `OutOfRange`, which would be a false claim about the value.

The accelerator is plumbed through `ControlHost`, `SessionDeps` and `AgentState`; every field is required at construction, so the compiler named all fourteen sites rather than leaving one silently defaulted.

Mutation-checked: deleting the refusal fails the test, and the hardware-scoping has its own. 703 tests.