### PR TITLE
fix(peer): sanitise the refusal, and check the version both ways

### DIFF
--- a/crates/atlasctl-agent/src/peer/link.rs
+++ b/crates/atlasctl-agent/src/peer/link.rs
@@ -314,10 +314,19 @@ where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
 {
     let hello = read_frame(stream).await?;
-    anyhow::ensure!(
-        matches!(hello, PeerFrame::Hello { .. }),
-        "a peer must introduce itself first, got {hello:?}"
-    );
+    // Both halves of the exact-match rule, on both sides. The outbound
+    // `exchange_hello` has always checked the version; this side only checked
+    // that the frame WAS a hello, so the invariant "exact match on the peer
+    // channel" held in one direction. Not exploitable — the caller is already
+    // through the pinned-SPKI TLS gate — but an invariant that is true only
+    // outbound is one nobody can rely on when the version next moves.
+    match &hello {
+        PeerFrame::Hello { version, .. } => anyhow::ensure!(
+            *version == PEER_PROTOCOL_VERSION,
+            "this node speaks peer protocol {PEER_PROTOCOL_VERSION}, the caller speaks {version}"
+        ),
+        other => anyhow::bail!("a peer must introduce itself first, got {other:?}"),
+    }
 
     write_frame(
         stream,

--- a/crates/atlasctl-agent/src/peer/pair.rs
+++ b/crates/atlasctl-agent/src/peer/pair.rs
@@ -142,7 +142,7 @@ where
         PeerFrame::PairStart { message } | PeerFrame::PairAnswer { message } => {
             hex::decode(&message).context("peer sent a malformed pairing message")?
         }
-        PeerFrame::PairRefused { reason } => bail!("the other node refused: {reason}"),
+        PeerFrame::PairRefused { reason } => bail!("{}", refusal_message(&reason)),
         other => bail!("expected a pairing message, got {other:?}"),
     };
 
@@ -168,7 +168,7 @@ where
     };
     let their_mac = match their_frame {
         PeerFrame::PairConfirm { mac } => hex::decode(&mac).unwrap_or_default(),
-        PeerFrame::PairRefused { reason } => bail!("the other node refused: {reason}"),
+        PeerFrame::PairRefused { reason } => bail!("{}", refusal_message(&reason)),
         other => bail!("expected key confirmation, got {other:?}"),
     };
 
@@ -202,7 +202,7 @@ where
     };
     let public_key = match peer_accept {
         PeerFrame::PairAccepted { public_key } => public_key,
-        PeerFrame::PairRefused { reason } => bail!("the other node refused: {reason}"),
+        PeerFrame::PairRefused { reason } => bail!("{}", refusal_message(&reason)),
         other => bail!("expected an acceptance, got {other:?}"),
     };
 
@@ -218,4 +218,18 @@ where
         name: peer_name,
         verification: confirmation.verification_words(),
     })
+}
+
+/// What the operator reads when the other node says no.
+///
+/// `reason` is the far node's prose and lands in a terminal through the anyhow
+/// chain, so it is sanitised: an ANSI escape here repaints the lines around
+/// the failure, and a failure that can redraw itself as something else is
+/// worse than one that just says no. `logs::sanitize` already strips CSI, OSC,
+/// controls and bidi for exactly this reason.
+///
+/// Separate from the three `bail!` sites so the rule has one owner and a test
+/// can prove it rather than proving `sanitize` in isolation.
+pub(super) fn refusal_message(reason: &str) -> String {
+    format!("the other node refused: {}", crate::logs::sanitize(reason))
 }

--- a/crates/atlasctl-agent/src/peer/pair_tests.rs
+++ b/crates/atlasctl-agent/src/peer/pair_tests.rs
@@ -160,3 +160,21 @@ fn a_peer_cannot_ask_to_be_pinned_under_a_key_it_does_not_hold() {
             .expect_err("a substituted key must be refused");
     assert!(err.to_string().contains("does not match"));
 }
+
+/// The refusal reason is the other node's prose and reaches an operator's
+/// terminal through the anyhow chain. An escape there repaints the lines
+/// around the failure — and a failure that can redraw itself as something
+/// else is worse than one that just says no.
+#[test]
+fn a_refusal_reason_cannot_carry_a_terminal_escape() {
+    let hostile = "\u{1b}[2K\u{1b}[1Aall good, trust me\u{1b}[0m";
+    // The message the operator actually reads, not `sanitize` in isolation:
+    // a test of the helper would stay green if the call site dropped it.
+    let shown = super::pair::refusal_message(hostile);
+    assert!(
+        !shown.contains('\u{1b}'),
+        "an escape survived into the refusal: {shown:?}"
+    );
+    // Not redaction: the operator still reads what the peer said.
+    assert!(shown.contains("all good, trust me"));
+}


### PR DESCRIPTION
Two from the same audit, both the *right mechanism on the wrong side* shape this codebase keeps producing.

**1. `PairRefused { reason }` reaches a terminal raw**, at three sites. It is the error path, so the ceremony has already failed — but an escape there repaints the lines *around* the failure, and a failure that can redraw itself as something else is worse than one that just says no. `logs::sanitize` already strips CSI, OSC, controls and bidi, and its own comment gives the reason: *"a log line must not be able to reorder the text around it."* It was applied to logs and not to this.

The rule now lives in `refusal_message` rather than three `bail!`s — the difference between a test that proves `sanitize` works and one that proves the call site **uses** it. The first stays green when the call site drops it, which is exactly the mutation run here.

**2. `serve_query` ignored the peer's protocol version**, checking only that the first frame *was* a hello, while the outbound `exchange_hello` has always required an exact match. Not exploitable — the caller is already through the pinned-SPKI TLS gate — but an invariant that holds in one direction is one nobody can rely on when the version next moves, and it has moved four times this month.

704 tests, mutation-checked.