### PR TITLE
fix(recipe): a recipe may not read the agent's secrets or its egress policy

### DIFF
--- a/crates/atlasctl-core/src/docker/translate.rs
+++ b/crates/atlasctl-core/src/docker/translate.rs
@@ -64,6 +64,19 @@ pub enum TranslateError {
         source: NotLaunchable,
     },
 
+    /// A recipe tried to set the operator's network-egress policy.
+    #[error(
+        "{name}: a recipe may not set {key}. Offline-by-default is the \
+         operator's policy, not the recipe's — a recipe that could flip it \
+         could also decide, silently, that this launch may reach the network"
+    )]
+    EgressOverride {
+        /// Recipe name.
+        name: String,
+        /// The key it tried to set.
+        key: String,
+    },
+
     /// Two settings would render the same flag.
     #[error("{name}: {source}")]
     AliasConflict {
@@ -228,7 +241,7 @@ pub fn translate(
         auto_remove: true,
         restart: None,
         name: container_name(&recipe.name, placement),
-        env: build_env(recipe, host, placement, collective),
+        env: build_env(recipe, host, placement, collective)?,
         volumes: BTreeMap::from([(host.hf_cache_dir.clone(), CONTAINER_HF_HOME.to_string())]),
         image: recipe.container.clone(),
         command,
@@ -269,14 +282,26 @@ fn container_name(recipe: &str, placement: &Placement) -> String {
 /// Container environment: our standard block, the fabric block for a cluster
 /// launch, then the recipe's own.
 ///
-/// The recipe wins on collision — it is the more specific statement of intent —
-/// and `$VAR` in its values expands against the host snapshot.
+/// `$VAR` in a recipe's values expands against an ALLOWLIST of the host's
+/// environment, never the whole of it, and a recipe cannot overwrite the
+/// offline block above.
+///
+/// Both restrictions exist because a recipe is not ours. Recipes are fetched
+/// from a remote index and the recipe also names the image it runs, so
+/// expanding `${HF_TOKEN}` or `${AWS_SECRET_ACCESS_KEY}` against the agent's
+/// real environment hands the operator's secrets to code the recipe author
+/// chose — and setting `HF_HUB_OFFLINE=0` re-opens the network to carry them
+/// out. Neither needs a bug elsewhere to work; the two together are just what
+/// "the recipe wins on collision" meant.
+///
+/// No recipe in this repository references `$VAR` at all, and none sets the
+/// offline keys, so this narrows a capability nothing shipped is using.
 fn build_env(
     recipe: &Recipe,
     host: &HostSnapshot,
     placement: &Placement,
     collective: &dyn CollectiveEnv,
-) -> BTreeMap<String, String> {
+) -> Result<BTreeMap<String, String>, TranslateError> {
     let mut env = BTreeMap::from([
         // Offline by default: weights are pre-fetched, and a launch that
         // silently reaches out to the network is a launch you cannot reproduce.
@@ -289,10 +314,69 @@ fn build_env(
         env.extend(collective.cluster_env());
     }
     for (k, v) in &recipe.env {
-        env.insert(k.clone(), host.expand(v));
+        // The offline block is this launcher's statement, not the recipe's.
+        // Silently letting the more specific value win is right for tuning and
+        // wrong for the switch that decides whether the container can reach
+        // the network at all.
+        // Refused, not dropped. Silently ignoring it would launch the
+        // container under a policy the recipe author did not choose, which is
+        // worse than either honouring or refusing — the author is owed an
+        // answer either way.
+        if EGRESS_ENV.contains(&k.as_str()) {
+            return Err(TranslateError::EgressOverride {
+                name: recipe.name.clone(),
+                key: k.clone(),
+            });
+        }
+        env.insert(k.clone(), expand_allowed(host, v));
     }
-    env
+    Ok(env)
 }
 
+/// Keys that decide whether this launch may reach the network.
+///
+/// `HF_HOME` is deliberately NOT here: it is a path inside the container, not
+/// a boundary, and a custom cache layout is a real thing a recipe may want.
+/// Forbid what is dangerous, only what is dangerous.
+const EGRESS_ENV: [&str; 2] = ["HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE"];
+
+/// Host variables a recipe's `$VAR` may read.
+///
+/// An allowlist, not a deny list: the interesting names are the ones nobody
+/// thought to forbid. Adding an entry is a security decision — it publishes
+/// that variable's value to any image any recipe names — and belongs with the
+/// same scrutiny as the settings deny list.
+const PASSTHROUGH_ENV: [&str; 6] = [
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "NO_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "no_proxy",
+];
+
+/// Expand `$VAR` against the passthrough allowlist only.
+///
+/// A name outside the list reads as unset, which `HostSnapshot::expand`
+/// already renders as the empty string. That is the existing contract for an
+/// unset variable — "deliberately not an error: failing a launch over an unset
+/// optional would be worse" — so a recipe asking for something it may not have
+/// behaves exactly as if the host did not have it.
+fn expand_allowed(host: &HostSnapshot, raw: &str) -> String {
+    let allowed = HostSnapshot {
+        env: host
+            .env
+            .iter()
+            .filter(|(k, _)| PASSTHROUGH_ENV.contains(&k.as_str()))
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect(),
+        ..host.clone()
+    };
+    allowed.expand(raw)
+}
+
+#[cfg(test)]
+#[path = "translate/env_tests.rs"]
+mod env_tests;
 #[cfg(test)]
 mod tests;

--- a/crates/atlasctl-core/src/docker/translate/env_tests.rs
+++ b/crates/atlasctl-core/src/docker/translate/env_tests.rs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! What a recipe may read from the host, and what it may not set.
+//!
+//! Split from `tests.rs` on the 500-line cap, and the seam is real: that file
+//! is about turning a recipe into a command, and these are about the trust
+//! boundary around the recipe itself. Recipes arrive from a remote index and
+//! name the image they run, so "what can this content reach" is its own
+//! question with its own answers.
+
+use super::tests::{ctx, host, plan, recipe};
+use crate::chain::{Overrides, UserConfig};
+use crate::docker::Placement;
+use crate::docker::profile::NvidiaDevices;
+use crate::docker::translate::{TranslateError, translate};
+use crate::recipe::Recipe;
+
+/// The refusing half of `plan`, here because this is the only file that needs
+/// a translate that fails.
+fn plan_err(r: &Recipe, p: &Placement) -> TranslateError {
+    translate(
+        r,
+        &Overrides::new(),
+        &UserConfig::new(),
+        &host(),
+        p,
+        &ctx(&NvidiaDevices),
+    )
+    .expect_err("must refuse")
+}
+
+/// The half of "the recipe is the more specific intent" that survives: a
+/// container-internal path is the recipe's business.
+#[test]
+fn a_recipe_still_overrides_a_container_internal_path() {
+    let p = plan(&recipe("env:\n  HF_HOME: /custom\n"), &Placement::Solo);
+    assert_eq!(p.docker.env["HF_HOME"], "/custom");
+}
+
+/// The half that does not. A recipe is remote, third-party-extensible content
+/// and it also names the image it runs, so expanding `$VAR` against the
+/// agent's whole environment let it read a credential and hand it to code of
+/// its own choosing. This test used to assert the opposite, with `$TOKEN` as
+/// its example — which reads less like a considered trade-off than like the
+/// hazard never coming up.
+#[test]
+fn a_recipe_cannot_read_a_host_variable_outside_the_allowlist() {
+    let p = plan(&recipe("env:\n  KEY: \"pre-$TOKEN\"\n"), &Placement::Solo);
+    assert_eq!(
+        p.docker.env["KEY"], "pre-",
+        "a name outside the allowlist must read as unset, not as the host's value"
+    );
+}
+
+/// The allowlist is not empty: proxy settings are the one class of host
+/// variable a container legitimately needs.
+#[test]
+fn a_proxy_variable_still_expands() {
+    let p = plan(
+        &recipe("env:\n  KEY: \"via-$HTTPS_PROXY\"\n"),
+        &Placement::Solo,
+    );
+    assert_eq!(p.docker.env["KEY"], "via-http://proxy:8080");
+}
+
+/// Refused, not ignored. A recipe setting this is affirmatively trying to
+/// change the operator's egress policy; dropping it silently would launch
+/// under a policy its author did not choose.
+#[test]
+fn a_recipe_that_sets_the_offline_switch_is_refused_by_name() {
+    let err = plan_err(&recipe("env:\n  HF_HUB_OFFLINE: \"0\"\n"), &Placement::Solo);
+    let text = format!("{err}");
+    assert!(text.contains("HF_HUB_OFFLINE"), "must name the key: {text}");
+}

--- a/crates/atlasctl-core/src/docker/translate/tests.rs
+++ b/crates/atlasctl-core/src/docker/translate/tests.rs
@@ -6,17 +6,23 @@ use crate::docker::profile::{AmdDevices, NvidiaDevices, ROOTLESS_V1};
 use crate::recipe::Provenance;
 use crate::scalar::ScalarValue;
 
-fn host() -> HostSnapshot {
+pub(super) fn host() -> HostSnapshot {
     HostSnapshot {
         uid: 1000,
         gid: 1000,
         home: "/home/spark".into(),
         hf_cache_dir: "/home/spark/.cache/huggingface".into(),
-        env: [("TOKEN".to_string(), "abc".to_string())].into(),
+        // TOKEN stands for a credential the agent holds; the proxy is the
+        // one class a recipe may legitimately read.
+        env: [
+            ("TOKEN".to_string(), "abc".to_string()),
+            ("HTTPS_PROXY".to_string(), "http://proxy:8080".to_string()),
+        ]
+        .into(),
     }
 }
 
-fn recipe(extra: &str) -> Recipe {
+pub(super) fn recipe(extra: &str) -> Recipe {
     let yaml = format!(
         "model: org/m\ncontainer: img:tag\nruntime: atlas\n\
          defaults:\n  port: 8888\n  gpu_memory_utilization: 0.88\n{extra}"
@@ -31,7 +37,7 @@ fn recipe(extra: &str) -> Recipe {
     .expect("parses")
 }
 
-fn ctx(devices: &dyn super::DeviceProfile) -> LaunchContext<'_> {
+pub(super) fn ctx(devices: &dyn super::DeviceProfile) -> LaunchContext<'_> {
     LaunchContext {
         profile: &ROOTLESS_V1,
         devices,
@@ -39,7 +45,7 @@ fn ctx(devices: &dyn super::DeviceProfile) -> LaunchContext<'_> {
     }
 }
 
-fn plan(r: &Recipe, p: &Placement) -> LaunchPlan {
+pub(super) fn plan(r: &Recipe, p: &Placement) -> LaunchPlan {
     translate(
         r,
         &Overrides::new(),
@@ -86,19 +92,6 @@ fn the_standard_environment_is_offline_by_default() {
     assert_eq!(p.docker.env["HF_HUB_OFFLINE"], "1");
     assert_eq!(p.docker.env["TRANSFORMERS_OFFLINE"], "1");
     assert_eq!(p.docker.env["HF_HOME"], "/cache/huggingface");
-}
-
-#[test]
-fn recipe_env_overrides_the_standard_block_and_expands_variables() {
-    let p = plan(
-        &recipe("env:\n  HF_HOME: /custom\n  KEY: \"pre-$TOKEN\"\n"),
-        &Placement::Solo,
-    );
-    assert_eq!(
-        p.docker.env["HF_HOME"], "/custom",
-        "the recipe is the more specific intent"
-    );
-    assert_eq!(p.docker.env["KEY"], "pre-abc");
 }
 
 #[test]


### PR DESCRIPTION
Recipes come from a remote index, third-party registries can be added, and a recipe names the image it runs. It could also expand `$VAR` in its `env:` values against the agent's **entire process environment**, and its env merged *after* the standard block so it won on collision:

```yaml
container: attacker/img
env: { X: "${HF_TOKEN}", HF_HUB_OFFLINE: "0" }
```

The operator's credentials handed to code the recipe chose, with the network reopened to carry them out — while the registry module's own header promises a recipe *"cannot influence anything outside its own launch."*

**Two changes, scoped to what is actually dangerous:**

- `$VAR` expands against an **allowlist** (proxy variables). A name outside it reads as unset — the existing contract — so a recipe asking for something it may not have behaves as if the host lacked it.
- `HF_HUB_OFFLINE`/`TRANSFORMERS_OFFLINE` are **refused with a named error**. Offline-by-default is the *operator's* policy and means nothing if remote content can flip it. Refused rather than dropped: ignoring it silently would launch under a policy the author did not choose.

`HF_HOME` stays overridable — a path inside the container, not a boundary. My first attempt protected all three and broke a legitimate capability for no security gain.

**Measured before deciding:** no recipe here references `$VAR` at all, and none sets the offline keys.

The old test asserted both behaviours as intent, with `$TOKEN` as its worked example — which reads less like a considered trade-off than like the hazard never coming up. Four tests pin the new contract, and each mechanism fails its own test under a compiling mutation. 709 tests.