### PR TITLE
fix(registry): a scoped ref cannot walk out of the recipe cache

### DIFF
--- a/crates/atlasctl-core/src/registry/remote.rs
+++ b/crates/atlasctl-core/src/registry/remote.rs
@@ -82,6 +82,15 @@ impl RemoteRegistry {
     /// Load one recipe by name.
     pub fn load(&self, name: &str) -> Option<Result<Recipe, RecipeError>> {
         let fs = self.fs.as_ref()?;
+        // The name is joined onto a directory, so it decides which file is
+        // read. `RecipeRef::parse` accepts anything after the `@registry/`,
+        // including `../../..`, and one caller — `RankAssignment.recipe` — is
+        // an unvalidated string from whichever node is acting as head. Without
+        // this, a scoped ref could walk out of the cache and have any `*.yaml`
+        // on the box read and parsed as a recipe.
+        if !is_safe_recipe_name(name) {
+            return None;
+        }
         let path = self.recipe_dir().join(format!("{name}.yaml"));
         let yaml = fs.read_to_string(&path).ok()?;
         Some(Recipe::parse(
@@ -191,4 +200,18 @@ impl RemoteStore {
         }
         Ok(())
     }
+}
+
+/// Whether a scoped name may be joined onto the cache directory.
+///
+/// A remote name is `family/leaf`, so slashes are legitimate and cannot simply
+/// be banned. Each SEGMENT must be a valid `RecipeId` instead — the alphabet
+/// that already exists for exactly this reason, whose own doc says "`..` and
+/// `/` would let it escape a directory". `..` fails it because an id must
+/// start with a letter or digit.
+pub(crate) fn is_safe_recipe_name(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .split('/')
+            .all(|seg| atlasctl_protocol::RecipeId::parse(seg).is_ok())
 }

--- a/crates/atlasctl-core/src/registry/tests.rs
+++ b/crates/atlasctl-core/src/registry/tests.rs
@@ -207,3 +207,42 @@ fn listing_reports_provenance_for_every_entry() {
             .any(|e| e.name == "extra" && e.registry == "third")
     );
 }
+
+/// `RecipeRef::parse` takes everything after `@registry/` verbatim, and one
+/// caller — a `RankAssignment` from whichever node is acting as head — is an
+/// unvalidated string. The name is then joined onto the cache directory, so it
+/// decides which file is read.
+#[test]
+fn a_scoped_name_cannot_walk_out_of_the_cache() {
+    use crate::registry::remote::is_safe_recipe_name;
+    for hostile in [
+        "../../../etc/hosts",
+        "..",
+        "a/../../b",
+        "/etc/passwd",
+        "",
+        "a//b",
+    ] {
+        assert!(
+            !is_safe_recipe_name(hostile),
+            "{hostile:?} must not be joined onto the recipe directory"
+        );
+    }
+}
+
+/// And the shape a real remote recipe has must still resolve — the guard is
+/// per-segment precisely so `family/leaf` keeps working.
+#[test]
+fn a_real_remote_recipe_name_is_still_accepted() {
+    use crate::registry::remote::is_safe_recipe_name;
+    for ok in [
+        "qwen3.6/qwen3.6-27b-nvfp4-unsloth",
+        "gemma4/gemma-4-26b-a4b",
+        "solo",
+    ] {
+        assert!(
+            is_safe_recipe_name(ok),
+            "{ok:?} is a legitimate remote name"
+        );
+    }
+}


### PR DESCRIPTION
`RecipeRef::parse` takes everything after `@registry/` verbatim, so `@reg/../../../etc/hosts` parses as an ordinary scoped ref. `RemoteRegistry::load` then joins it onto the cache directory — `recipe_dir().join("{name}.yaml")` — and reads whatever it lands on.

One caller makes this **remote**: `RankAssignment.recipe` is an unvalidated `String` from whichever node is acting as head, so a peer holding the `controller` grant could have any `*.yaml` on the box read and parsed as a recipe.

Slashes are legitimate here — a remote name is `family/leaf` — so the guard is **per segment** rather than a ban on `/`. Each segment must be a valid `RecipeId`: the alphabet that already exists for exactly this purpose, whose own doc says *"`..` and `/` would let it escape a directory"*. `..` fails it because an id must start with a letter or digit — so the rule that stops traversal is one already written down and tested, not a new one invented here.

An unusable name returns `None` — *"this registry does not have that"* — which is true and is a shape the lookup already has.

Mutation-checked: weakening the guard to a non-empty check fails the traversal test while the legitimate-name test still passes, pinning both directions. 710 tests.