### PR TITLE
fix(recipe): refuse a field that would be read as an option

### DIFF
--- a/crates/atlasctl-core/src/recipe/mod.rs
+++ b/crates/atlasctl-core/src/recipe/mod.rs
@@ -107,6 +107,34 @@ pub enum RecipeError {
         /// Recipe name.
         name: String,
     },
+
+    /// A field that lands in an argv position began with `-`.
+    #[error(
+        "{name}: `{field}: {value}` starts with `-`, so it would be read as an \
+         option rather than a value. `RecipeId` forbids this for the same \
+         reason: a leading dash lets a name be parsed as a flag."
+    )]
+    FlagShaped {
+        /// Recipe name.
+        name: String,
+        /// Which field.
+        field: &'static str,
+        /// What it said.
+        value: String,
+    },
+}
+
+/// Refuse a field that would be read as an option in the argv position it
+/// lands in.
+fn flag_shaped(name: &str, field: &'static str, value: &str) -> Result<(), RecipeError> {
+    if value.trim_start().starts_with('-') {
+        return Err(RecipeError::FlagShaped {
+            name: name.to_string(),
+            field,
+            value: value.to_string(),
+        });
+    }
+    Ok(())
 }
 
 /// Why a loaded recipe cannot be launched.
@@ -159,6 +187,14 @@ impl Recipe {
             .ok_or_else(|| RecipeError::MissingModel {
                 name: name.to_string(),
             })?;
+        // `model` is rendered into `spark serve <model>` and `container` into
+        // the image operand of `docker run`, both positionally and both
+        // without a `--` separator ahead of them. A value beginning with `-`
+        // is therefore handed to an option parser: `container: --privileged`
+        // makes docker read a flag and take the NEXT token as the image. These
+        // two are recipe fields, so the audited guarantee that no override
+        // VALUE can become flag-shaped never covered them.
+        flag_shaped(name, "model", &model)?;
 
         let container = raw
             .container
@@ -167,6 +203,7 @@ impl Recipe {
             .ok_or_else(|| RecipeError::MissingContainer {
                 name: name.to_string(),
             })?;
+        flag_shaped(name, "container", &container)?;
 
         let runtime = match raw.runtime.as_deref() {
             Some("atlas") => RuntimeKind::Atlas,

--- a/crates/atlasctl-core/src/recipe/tests.rs
+++ b/crates/atlasctl-core/src/recipe/tests.rs
@@ -161,3 +161,37 @@ fn qualified_name_reflects_provenance() {
     .unwrap();
     assert_eq!(remote.qualified_name(), "@third/r");
 }
+
+/// `model` lands in `spark serve <model>` and `container` in the image operand
+/// of `docker run`, both positionally and neither behind a `--`. A value
+/// starting with `-` is handed straight to an option parser — `container:
+/// --privileged` makes docker read a flag and take the NEXT token as the
+/// image, which is an untrusted field steering the runtime rather than a
+/// launch that cleanly fails.
+///
+/// The audited guarantee that no override VALUE can become flag-shaped covers
+/// what a client sends; these two are recipe fields and were the gap.
+#[test]
+fn a_recipe_field_that_would_be_read_as_an_option_is_refused() {
+    for (field, yaml) in [
+        ("container", "model: org/m\ncontainer: \"--privileged\"\n"),
+        ("model", "model: \"--help\"\ncontainer: img\n"),
+    ] {
+        let err = parse(yaml).expect_err("must refuse a flag-shaped field");
+        let text = format!("{err}");
+        assert!(text.contains(field), "must name the field: {text}");
+        assert!(
+            text.contains("option"),
+            "must say why it is refused: {text}"
+        );
+    }
+}
+
+/// A leading dash is the hazard; a dash anywhere else is an ordinary character
+/// in an image tag or a model id, and refusing those would break real recipes.
+#[test]
+fn an_interior_dash_is_still_an_ordinary_character() {
+    let r = parse("model: unsloth/Qwen3.8-27B-NVFP4\ncontainer: avarok/atlas-gb10:latest\n")
+        .expect("a normal recipe still parses");
+    assert_eq!(r.model, "unsloth/Qwen3.8-27B-NVFP4");
+}


### PR DESCRIPTION
`model` and `container` were checked only for non-empty. Both land in an argv position with **no `--` ahead of them** — `model` in `spark serve <model>`, `container` in the image operand of `docker run`. A value beginning with `-` is handed straight to an option parser: `container: --privileged` makes docker read a flag and take the *next* token as the image, so the launch misbehaves instead of cleanly failing, and an untrusted field has steered the runtime.

Recipes come from a remote index. The audited guarantee that *"nothing a client sends can become a flag-shaped argv element"* covers **override values**; these two are **recipe fields** — the gap between the two trust boundaries.

`RecipeId` already forbids a leading dash and says why: *"a leading `-` would let an id be read as a flag."* This applies the same rule to the two fields reaching the same kind of position.

Only the **leading** dash is refused — an interior dash is ordinary in `unsloth/Qwen3.8-27B-NVFP4` and `avarok/atlas-gb10:latest`, and a test pins that so the guard cannot quietly grow into rejecting real recipes. 713 tests, mutation-checked.