### PR TITLE
fix(rank): a rank may only stop a container this fleet launched

### DIFF
--- a/crates/atlasctl/src/rankservice/mod.rs
+++ b/crates/atlasctl/src/rankservice/mod.rs
@@ -371,6 +371,10 @@ impl RankService for LocalRankService {
     }
 
     fn alive(&self, container: &str) -> Result<bool> {
+        // Not ours to ask about. See `is_ours`.
+        if !is_ours(container) {
+            return Ok(false);
+        }
         let out = self
             .runner
             .run(&[
@@ -391,6 +395,18 @@ impl RankService for LocalRankService {
     }
 
     fn stop(&self, container: &str) -> Result<()> {
+        // The name arrives from whichever node is acting as head, and this
+        // runs `docker rm -f` on it. Unbounded, that is a peer with the
+        // `controller` grant force-removing ANY container on this machine —
+        // well past "drive its own launch, one hop". The browser's own stop
+        // has always been scoped to `atlas-{recipe}`; this path had no
+        // equivalent.
+        if !is_ours(container) {
+            anyhow::bail!(
+                "refusing to stop `{container}`: a rank may only stop a \
+                 container this fleet launched, and that name is not one"
+            );
+        }
         let out = self
             .runner
             .run(&[
@@ -417,6 +433,25 @@ impl RankService for LocalRankService {
             *slot = None;
         }
     }
+}
+
+/// Whether a container name is one this fleet could have created.
+///
+/// `translate::container_name` only ever produces `atlas-{recipe}` or
+/// `atlas-{recipe}-rank{n}`, and `recipe` is a `RecipeId` — lowercase
+/// alphanumerics, `.` and `-`. Anything outside that shape was not launched by
+/// us, so a request to stop it is not a request we can honour.
+///
+/// A prefix test alone would already stop the escalation; matching the shape
+/// costs nothing more and keeps the rule readable next to the thing it mirrors.
+pub(crate) fn is_ours(container: &str) -> bool {
+    let Some(rest) = container.strip_prefix("atlas-") else {
+        return false;
+    };
+    !rest.is_empty()
+        && rest
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '.' || c == '-')
 }
 
 #[cfg(test)]

--- a/crates/atlasctl/src/rankservice/tests.rs
+++ b/crates/atlasctl/src/rankservice/tests.rs
@@ -460,3 +460,37 @@ mod collective_binding {
         assert!(!cmd.contains("NCCL_IB_HCA"), "{cmd}");
     }
 }
+
+/// `stop` runs `docker rm -f` on a name that arrives from whichever node is
+/// acting as head. Unbounded, that is a peer holding the `controller` grant
+/// force-removing ANY container on this machine — well past "drive its own
+/// launch, one hop". The browser's own stop has always been scoped to
+/// `atlas-{recipe}`; this path had no equivalent.
+#[test]
+fn a_rank_may_only_stop_a_container_this_fleet_launched() {
+    use crate::rankservice::is_ours;
+    for foreign in [
+        "postgres",
+        "someone-elses-db",
+        "ATLAS-shouty",
+        "atlas-",
+        "atlas-../evil",
+        "",
+    ] {
+        assert!(!is_ours(foreign), "{foreign:?} was not launched by us");
+    }
+}
+
+/// And the names this fleet really produces must still be stoppable, or a
+/// cluster launch could never be torn down.
+#[test]
+fn the_names_translate_actually_produces_are_still_ours() {
+    use crate::rankservice::is_ours;
+    for mine in [
+        "atlas-qwen3.6-27b-nvfp4-unsloth",
+        "atlas-qwen3.6-35b-a3b-fp8-bf16head-rank0",
+        "atlas-qwen3.6-35b-a3b-fp8-bf16head-rank11",
+    ] {
+        assert!(is_ours(mine), "{mine:?} is a name translate produces");
+    }
+}


### PR DESCRIPTION
`stop` ran `docker rm -f` on a container name supplied by whichever node is acting as head, with no check that this machine had launched it. A peer holding the `controller` grant could force-remove **any** container on the box — a database, another tenant's work, anything — well past the *"drive its own launch, one hop"* that grant means. `alive` had the same reach in read form.

The browser's own stop has always been scoped to `atlas-{recipe}`; this path never grew the equivalent.

`translate::container_name` only ever produces `atlas-{recipe}` or `atlas-{recipe}-rank{n}`, and `recipe` is a `RecipeId`. `is_ours` matches that shape, so a name we could not have created is refused — **loudly** for `stop` (a head asking to stop something is owed an answer) and as *"not running"* for `alive`, which is the truthful reply about a container this node does not own.

Mutation-checked, plus a second test pinning the real names: `atlas-qwen3.6-35b-a3b-fp8-bf16head-rank0` and friends must stay stoppable, or a cluster launch could never be torn down. 715 tests.