### PR TITLE
fix(recipe): suggest the recipe you meant, not the three that sort first

### DIFF
--- a/crates/atlasctl-core/src/registry/mod.rs
+++ b/crates/atlasctl-core/src/registry/mod.rs
@@ -235,19 +235,70 @@ impl RegistrySet {
         })
     }
 
-    /// Names sharing a prefix, to turn a typo into a useful message.
+    /// The names nearest `name`, to turn a typo into a useful message.
+    ///
+    /// Ranked by edit distance rather than by a shared prefix. The prefix rule
+    /// this replaces took the first six characters and then sorted the matches
+    /// ALPHABETICALLY before truncating to three, which fails in the two ways
+    /// a catalogue like this one guarantees:
+    ///
+    /// * `qwen3.8-27b-nvfp4-unsloh` shares `qwen3.` with every qwen3.x recipe,
+    ///   so the three printed were all `qwen3.5-*` while the recipe ONE
+    ///   character away never appeared. Three confident wrong answers is worse
+    ///   than none.
+    /// * `gemma4-31b-nvfp4` — one missing hyphen — shares no six-character
+    ///   prefix with `gemma-4-31b-nvfp4`, so it got no suggestion at all.
     fn close_names(&self, name: &str) -> Vec<String> {
-        let prefix: String = name.chars().take(6).collect();
-        let mut out: Vec<String> = self
+        let typed = name.chars().count();
+        let mut scored: Vec<(usize, String)> = self
             .list()
             .into_iter()
-            .map(|e| e.name)
-            .filter(|n| n.starts_with(&prefix))
+            .map(|e| (edit_distance(name, &e.name), e.name))
+            .filter(|(d, n)| *d <= max_edits(typed.max(n.chars().count())))
             .collect();
-        out.sort();
-        out.truncate(3);
-        out
+        // Distance first, then the name, so the list is stable run to run.
+        scored.sort_by(|x, y| x.0.cmp(&y.0).then_with(|| x.1.cmp(&y.1)));
+        scored.into_iter().take(3).map(|(_, n)| n).collect()
     }
+}
+
+/// How far a name may be from what was typed and still be worth printing.
+///
+/// A quarter of the longer of the two names: floored at 2 so a short name
+/// still catches a near miss, and capped at 5 so an unrelated string prints
+/// nothing rather than three wrong guesses.
+const fn max_edits(len: usize) -> usize {
+    match len / 4 {
+        0 | 1 => 2,
+        n if n > 5 => 5,
+        n => n,
+    }
+}
+
+/// Levenshtein distance over chars, two rows.
+///
+/// Recipe names are short and the catalogue is small, so the allocation per
+/// call is not worth avoiding.
+fn edit_distance(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    if a.is_empty() {
+        return b.len();
+    }
+    if b.is_empty() {
+        return a.len();
+    }
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut cur: Vec<usize> = vec![0; b.len() + 1];
+    for (i, ca) in a.iter().enumerate() {
+        cur[0] = i + 1;
+        for (j, cb) in b.iter().enumerate() {
+            let cost = usize::from(ca != cb);
+            cur[j + 1] = (prev[j + 1] + 1).min(cur[j] + 1).min(prev[j] + cost);
+        }
+        std::mem::swap(&mut prev, &mut cur);
+    }
+    prev[b.len()]
 }
 
 fn r#ref_display(r: &RecipeRef) -> String {

--- a/crates/atlasctl-core/src/registry/tests.rs
+++ b/crates/atlasctl-core/src/registry/tests.rs
@@ -246,3 +246,77 @@ fn a_real_remote_recipe_name_is_still_accepted() {
         );
     }
 }
+
+// ---- typo suggestions ------------------------------------------------------
+//
+// The prefix rule these replace printed three wrong recipes for a typo one
+// character from a real one, and nothing at all for a missing hyphen. Both are
+// pinned below against the real builtin catalogue, so a future change to the
+// ranking has to keep answering them.
+
+#[test]
+fn edit_distance_is_symmetric_and_counts_single_edits() {
+    assert_eq!(super::edit_distance("", ""), 0);
+    assert_eq!(super::edit_distance("abc", ""), 3);
+    assert_eq!(super::edit_distance("", "abc"), 3);
+    assert_eq!(super::edit_distance("abc", "abc"), 0);
+    // one deletion, one insertion, one substitution
+    assert_eq!(super::edit_distance("unsloh", "unsloth"), 1);
+    assert_eq!(super::edit_distance("gemma4", "gemma-4"), 1);
+    assert_eq!(super::edit_distance("abc", "abd"), 1);
+    assert_eq!(super::edit_distance("unsloth", "unsloh"), 1);
+    // multi-byte input must not panic or count bytes
+    assert_eq!(super::edit_distance("héllo", "hello"), 1);
+}
+
+#[test]
+fn the_edit_ceiling_stays_inside_its_stated_bounds() {
+    assert_eq!(super::max_edits(0), 2, "floor");
+    assert_eq!(super::max_edits(7), 2, "floor still applies to short names");
+    assert_eq!(super::max_edits(12), 3);
+    assert_eq!(super::max_edits(20), 5);
+    assert_eq!(super::max_edits(200), 5, "cap");
+}
+
+#[test]
+fn a_one_character_typo_suggests_the_recipe_it_meant() {
+    let reg = RegistrySet::builtin_only();
+    let close = reg.close_names("qwen3.8-27b-nvfp4-unsloh");
+    assert!(
+        close.contains(&"qwen3.8-27b-nvfp4-unsloth".to_string()),
+        "the recipe one character away must be offered, got {close:?}"
+    );
+    assert_eq!(
+        close.first().map(String::as_str),
+        Some("qwen3.8-27b-nvfp4-unsloth"),
+        "and it must be FIRST, not merely present: {close:?}"
+    );
+}
+
+#[test]
+fn a_missing_hyphen_still_finds_the_name() {
+    let reg = RegistrySet::builtin_only();
+    let close = reg.close_names("gemma4-31b-nvfp4");
+    assert!(
+        close.contains(&"gemma-4-31b-nvfp4".to_string()),
+        "a single missing hyphen produced no suggestion under the prefix rule, got {close:?}"
+    );
+}
+
+#[test]
+fn an_unrelated_name_suggests_nothing_rather_than_guessing() {
+    let reg = RegistrySet::builtin_only();
+    assert!(
+        reg.close_names("nope/nothere").is_empty(),
+        "an unrelated string must not draw three confident wrong answers"
+    );
+    assert!(reg.close_names("zzzzzzzzzzzzzzzzzzzz").is_empty());
+}
+
+#[test]
+fn at_most_three_names_are_offered() {
+    let reg = RegistrySet::builtin_only();
+    for probe in ["qwen3.6-27b-nvfp4", "gemma-4-31b-nvfp4", "qwen"] {
+        assert!(reg.close_names(probe).len() <= 3, "{probe}");
+    }
+}


### PR DESCRIPTION
`close_names` took the first **six** characters of what was typed, kept every name starting with them, sorted those **alphabetically**, and printed the first three. On a catalogue whose names share long prefixes, that fails in both directions. Both reproduced against the real builtin registry:

### A typo one character from a real recipe got three wrong answers

```
atlasctl recipe show qwen3.8-27b-nvfp4-unsloh

before:  Did you mean qwen3.5-0.8b-bf16-atlas, qwen3.5-122b-a10b-nvfp4-ep2,
                      qwen3.5-122b-a10b-nvfp4-single?
after:   Did you mean qwen3.8-27b-nvfp4-unsloth, ...
```

`qwen3.` is shared by every `qwen3.x` recipe, so alphabetical order filled all three slots with `qwen3.5` while the recipe **one character away** never appeared. Three confident wrong answers is worse than none.

### A missing hyphen switched the mechanism off entirely

```
atlasctl recipe show gemma4-31b-nvfp4

before:  (no suggestion at all)
after:   Did you mean gemma-4-31b-nvfp4?
```

A typo *inside* the first six characters shares no prefix, so suggestions disappeared exactly when they were needed.

## The change

Names are ranked by Levenshtein distance, tie-broken by name so the list is stable run to run. The ceiling is a quarter of the longer name, floored at 2 so short names still catch a near miss and capped at 5 so an unrelated string prints nothing rather than guessing — `nope/nothere` still suggests nothing, which is the one thing the old rule got right.

## Verification

There were **no tests for this path**. Six added, and two mutations confirm they fail for the stated reasons rather than documenting current behaviour:

| mutation | result |
|---|---|
| rank alphabetically instead of by distance | 20 pass / **1 fail** |
| remove the distance ceiling | 19 pass / **2 fail** |
| restored | **21 pass / 0 fail**, file byte-identical |

Workspace green (11 suites), `clippy` and `fmt` clean, and the golden test — the one that broke `main` via #16 — passes unchanged, since this touches only error text.
