### PR TITLE
fix(doctor): exit non-zero when problems were found

### DIFF
--- a/crates/atlasctl/src/commands/doctor.rs
+++ b/crates/atlasctl/src/commands/doctor.rs
@@ -26,10 +26,20 @@ pub fn run() -> Result<()> {
     println!();
     if problems == 0 {
         println!("no problems found");
-    } else {
-        println!("{problems} problem(s) found");
+        return Ok(());
     }
-    Ok(())
+
+    // A diagnostic that always exits 0 cannot be gated on. SECURITY.md tells an
+    // operator to run this to find a compromised sparkrun install -- a registry
+    // redirect that lets someone else's recipes run shell commands on this host
+    // -- and a script wrapping that check had no way to see the answer, because
+    // the report went to stdout and the status was always success. Reporting a
+    // finding is not the same as failing to run, but every tool that gates on
+    // this one can only read the status, so `brew doctor`'s convention applies:
+    // print the report, then exit non-zero.
+    Err(anyhow::anyhow!(
+        "{problems} problem(s) found — see the report above"
+    ))
 }
 
 fn check_docker() -> usize {


### PR DESCRIPTION
`atlasctl doctor` printed its findings and then returned `Ok(())` whatever it found, so the process always exited **0**. Measured on this box, which currently has a real finding:

```
$ atlasctl doctor
docker:   ok (server 29.1.3)
config:   ok (/home/nologik/.config/atlasctl)
agent:    ok (listening on 127.0.0.1:34333)
network:  ok (10.10.10.9 on enp1s0f0np0, and 2 more)
sparkrun: PROBLEM — a sparkrun install was found.
          Its config ... points the `atlas` registry at Atlas-Inf/sparkrun-recipes,
          which Atlas does not control.
          A trusted registry's recipes can run shell commands on this host.

1 problem(s) found
$ echo $?
0
```

`SECURITY.md` tells an operator to run this command to find a compromised sparkrun install. A wrapper script or CI step **could not act on that** — the report goes to stdout and the status said success.

## The change

Reporting a finding is not the same as failing to run, and the summary is worded that way rather than as a crash. But everything that gates on this command can read only the exit status, so `brew doctor`'s convention applies — print the full report, then exit non-zero:

```
sparkrun: PROBLEM — a sparkrun install was found.
          ...
error: 1 problem(s) found — see the report above          (exit 1)
```

## Verification

Both paths exercised on a real machine rather than reasoned about:

| condition | result |
|---|---|
| the sparkrun finding present | `error: 1 problem(s) found — see the report above`, **exit 1** |
| `HOME` pointed at an empty dir (no sparkrun config) | `sparkrun: not installed` … `no problems found`, **exit 0** |

Workspace green (11 suites), `clippy` and `fmt` clean.

## ⚠ Behaviour change — please sign off

A script running `atlasctl doctor` under `set -e` will now **stop where it previously continued**. That is the intended effect — it is a security check — but it changes observable CLI behaviour, so I have deliberately left this unmerged for a human decision rather than landing it overnight.

Nothing in this repo depends on the old status: **no test asserts it, and no script or workflow calls the command.** The only references are `README.md` and `SECURITY.md`, both of which tell a human to run it and read the output.
