### PR TITLE
fix(lifecycle): say "not running" instead of quoting the docker daemon

### DIFF
--- a/crates/atlasctl/src/commands/lifecycle.rs
+++ b/crates/atlasctl/src/commands/lifecycle.rs
@@ -45,6 +45,14 @@ fn stop_with(runner: &dyn ProcessRunner, args: &StopArgs) -> Result<()> {
         let out = runner.run(&["docker".into(), "stop".into(), name.clone()])?;
         if out.success() {
             println!("stopped {name}");
+        } else if absent(&out.stderr) {
+            // Not a failure: the state the operator asked for is already true.
+            // This printed "could not stop atlas-x: Error response from daemon:
+            // No such container: atlas-x" and then exited non-zero, sending
+            // someone to inspect docker over a recipe that was simply never
+            // started. Under --all it is a race -- the container ended between
+            // the listing and the stop -- which is equally not a failure.
+            println!("{name} is not running");
         } else {
             let why = out.stderr.trim();
             eprintln!("could not stop {name}: {why}");
@@ -69,6 +77,38 @@ fn stop_with(runner: &dyn ProcessRunner, args: &StopArgs) -> Result<()> {
 /// replaces ran `sleep infinity` as PID 1, so its `docker logs` showed nothing
 /// and it had to tail a file inside the container instead.
 pub fn logs(args: &LogsArgs) -> Result<()> {
+    logs_with(&StdProcessRunner, args)
+}
+
+/// `logs`, with the runner injected so the not-started path is testable.
+fn logs_with(runner: &dyn ProcessRunner, args: &LogsArgs) -> Result<()> {
+    let name = container_of(&args.recipe);
+
+    // Ask whether the container exists before streaming. `docker logs` on a
+    // container that is not there prints the daemon's own line and exits 1,
+    // which surfaced as "`docker logs` exited with status 1" -- accurate, and
+    // no help to anyone. Asked as a filter rather than by matching the error
+    // text, because the daemon words it differently per command: `stop` and
+    // `logs` say "No such container", `inspect` says "no such object".
+    //
+    // `ps -a`, not `ps`: a container that exited still has logs worth reading,
+    // and that is often exactly why someone is here.
+    let probe = runner.run(&[
+        "docker".into(),
+        "ps".into(),
+        "-a".into(),
+        "--filter".into(),
+        format!("name=^{name}$"),
+        "--format".into(),
+        "{{.Names}}".into(),
+    ])?;
+    if probe.success() && probe.stdout.trim().is_empty() {
+        bail!(
+            "no container for `{}` on this machine — it has not been started here. `atlasctl status` lists what is running",
+            args.recipe
+        );
+    }
+
     let mut argv = vec![
         "docker".to_string(),
         "logs".to_string(),
@@ -78,12 +118,22 @@ pub fn logs(args: &LogsArgs) -> Result<()> {
     if args.follow {
         argv.push("--follow".to_string());
     }
-    argv.push(container_of(&args.recipe));
-    let code = StdProcessRunner.run_streaming(&argv)?;
+    argv.push(name);
+    let code = runner.run_streaming(&argv)?;
     if code != 0 {
         bail!("`docker logs` exited with status {code}");
     }
     Ok(())
+}
+
+/// Whether the daemon is saying the container is not there.
+///
+/// Matched on text because `docker stop` exits 1 for every failure and carries
+/// the distinction only in stderr. Lowercased and checked for both spellings,
+/// since the wording is not stable across commands or versions.
+fn absent(stderr: &str) -> bool {
+    let s = stderr.to_ascii_lowercase();
+    s.contains("no such container") || s.contains("no such object")
 }
 
 /// Show what atlasctl has running.
@@ -205,7 +255,10 @@ mod stop_tests {
             stderr: String::new(),
         });
         r.push_result(fail("permission denied"));
-        r.push_result(fail("no such container"));
+        // Was "no such container", which is now the one stderr that means the
+        // stop SUCCEEDED in effect. This test is about two real failures, so it
+        // needs two real failures.
+        r.push_result(fail("device or resource busy"));
 
         let e = stop_with(
             &r,
@@ -264,5 +317,120 @@ mod stop_tests {
             },
         )
         .expect("nothing to do is fine");
+    }
+}
+
+#[cfg(test)]
+mod absent_tests {
+    use super::*;
+    use atlasctl_core::io::RecordingRunner;
+    use atlasctl_core::io::process::Output;
+
+    fn out(status: i32, stdout: &str, stderr: &str) -> Output {
+        Output {
+            status,
+            stdout: stdout.into(),
+            stderr: stderr.into(),
+        }
+    }
+
+    #[test]
+    fn the_daemons_two_spellings_of_gone_are_both_recognised() {
+        assert!(absent(
+            "Error response from daemon: No such container: atlas-x"
+        ));
+        assert!(absent("Error: no such object: atlas-x"));
+        // Real failures must not be swallowed by this.
+        assert!(!absent("permission denied"));
+        assert!(!absent("device or resource busy"));
+        assert!(!absent(""));
+    }
+
+    /// Stopping something that is not running is the state the operator asked
+    /// for. It used to print the daemon's own line and exit non-zero.
+    #[test]
+    fn stopping_a_recipe_that_is_not_running_is_not_a_failure() {
+        let r = RecordingRunner::new();
+        r.push_result(out(
+            1,
+            "",
+            "Error response from daemon: No such container: atlas-q",
+        ));
+        stop_with(
+            &r,
+            &StopArgs {
+                recipe: Some("q".into()),
+                all: false,
+            },
+        )
+        .expect("a recipe that is not running must not be an error");
+    }
+
+    /// Under --all this is a race: the container ended between the listing and
+    /// the stop. Equally not a failure, and it must not mask a real one.
+    #[test]
+    fn a_vanished_container_does_not_mask_a_real_failure() {
+        let r = RecordingRunner::new();
+        r.push_result(out(0, "atlas-a\natlas-b\n", ""));
+        r.push_result(out(
+            1,
+            "",
+            "Error response from daemon: No such container: atlas-a",
+        ));
+        r.push_result(out(1, "", "permission denied"));
+        let e = stop_with(
+            &r,
+            &StopArgs {
+                recipe: None,
+                all: true,
+            },
+        )
+        .expect_err("the real failure must still fail the command");
+        let msg = e.to_string();
+        assert!(msg.contains("atlas-b"), "names what actually failed: {msg}");
+        assert!(
+            !msg.contains("atlas-a"),
+            "must not blame the one that was already gone: {msg}"
+        );
+    }
+
+    #[test]
+    fn logs_for_a_recipe_never_started_here_says_so_and_never_streams() {
+        let r = RecordingRunner::new();
+        r.push_result(out(0, "\n", "")); // ps -a matched nothing
+        let e = logs_with(
+            &r,
+            &LogsArgs {
+                recipe: "q".into(),
+                tail: 100,
+                follow: false,
+            },
+        )
+        .expect_err("there is nothing to show");
+        let msg = e.to_string();
+        assert!(msg.contains("has not been started here"), "{msg}");
+        assert!(
+            msg.contains("atlasctl status"),
+            "points somewhere useful: {msg}"
+        );
+        assert_eq!(r.calls().len(), 1, "must not have run `docker logs` at all");
+    }
+
+    #[test]
+    fn logs_for_an_exited_container_still_stream() {
+        let r = RecordingRunner::new();
+        r.push_result(out(0, "atlas-q\n", "")); // ps -a found it, exited or not
+        r.push_result(out(0, "", ""));
+        logs_with(
+            &r,
+            &LogsArgs {
+                recipe: "q".into(),
+                tail: 100,
+                follow: false,
+            },
+        )
+        .expect("a stopped container still has logs worth reading");
+        let argv = &r.calls()[1];
+        assert!(argv.contains(&"logs".to_string()), "{argv:?}");
     }
 }

--- a/crates/atlasctl/src/commands/lifecycle.rs
+++ b/crates/atlasctl/src/commands/lifecycle.rs
@@ -6,6 +6,7 @@ use crate::cli::{LogsArgs, StopArgs};
 use anyhow::{Result, bail};
 use atlasctl_core::docker::translate::LABEL_MANAGED;
 use atlasctl_core::io::{ProcessRunner, StdProcessRunner};
+use atlasctl_core::registry::RecipeRef;
 
 /// Container name for a recipe's solo launch.
 fn container_of(recipe: &str) -> String {
@@ -14,7 +15,26 @@ fn container_of(recipe: &str) -> String {
 
 /// Stop one recipe, or everything atlasctl started.
 pub fn stop(args: &StopArgs) -> Result<()> {
+    if let Some(recipe) = &args.recipe {
+        known_recipe(recipe)?;
+    }
     stop_with(&StdProcessRunner, args)
+}
+
+/// Refuse a name that is not a recipe at all.
+///
+/// Without this, "not running" answers a TYPO as readily as a real recipe, and
+/// since that is no longer a failure, `atlasctl stop $RECIPE` with a misspelt
+/// variable would report success having stopped nothing. Resolving through the
+/// registry also means a near miss gets the same "Did you mean ...?" list the
+/// rest of the CLI gives.
+///
+/// `--all` skips this: its targets come from docker's own list of containers we
+/// label, so they need no catalogue entry. That is also the way out if a recipe
+/// is running from a registry that has since been removed.
+fn known_recipe(name: &str) -> Result<()> {
+    crate::commands::registry_set()?.resolve(&RecipeRef::parse(name))?;
+    Ok(())
 }
 
 /// `stop`, with the process runner injected so the failure paths are testable.
@@ -77,6 +97,7 @@ fn stop_with(runner: &dyn ProcessRunner, args: &StopArgs) -> Result<()> {
 /// replaces ran `sleep infinity` as PID 1, so its `docker logs` showed nothing
 /// and it had to tail a file inside the container instead.
 pub fn logs(args: &LogsArgs) -> Result<()> {
+    known_recipe(&args.recipe)?;
     logs_with(&StdProcessRunner, args)
 }
 


### PR DESCRIPTION
Both everyday mistakes — stopping or reading logs for a recipe that is not running — answered with docker's internals. Measured against real docker on this box:

```
$ atlasctl stop qwen3.8-27b-nvfp4-unsloth
could not stop atlas-qwen3.8-27b-nvfp4-unsloth: Error response from daemon:
  No such container: atlas-qwen3.8-27b-nvfp4-unsloth
error: could not stop 1 container(s): atlas-qwen3.8-27b-nvfp4-unsloth      (exit 1)

$ atlasctl logs qwen3.8-27b-nvfp4-unsloth
Error response from daemon: No such container: atlas-qwen3.8-...
error: `docker logs` exited with status 1                                 (exit 1)
```

`status` already answers this shape of question with a plain `nothing running`. These two sent the operator to go look at docker over a recipe that was simply never started.

### After

```
$ atlasctl stop qwen3.8-27b-nvfp4-unsloth
atlas-qwen3.8-27b-nvfp4-unsloth is not running                            (exit 0)

$ atlasctl logs qwen3.8-27b-nvfp4-unsloth
error: no container for `qwen3.8-27b-nvfp4-unsloth` on this machine — it has
not been started here. `atlasctl status` lists what is running             (exit 1)
```

## ⚠ Behaviour change on `stop`

A recipe that is not running is **no longer a failed stop**. The state the operator asked for is already true, and under `--all` it is a race — the container ended between the listing and the stop.

A real failure still fails. `a_vanished_container_does_not_mask_a_real_failure` pins exactly that: the command still errors, **names `atlas-b`** which really failed, and **does not name `atlas-a`** which was already gone.

This required changing one fixture in `a_failed_stop_is_a_failed_command`, which used `fail("no such container")` as an arbitrary second error. That string now means the opposite, so the test needed two *real* failures to keep testing what its name says — noted in place.

## Why a filter, not error-text matching, for `logs`

The daemon words it differently per command. Verified here:

| command | text on a missing container |
|---|---|
| `docker stop` | `Error response from daemon: No such container: …` |
| `docker logs` | `Error response from daemon: No such container: …` |
| `docker inspect` | `Error: no such object: …` |

So `logs` asks `docker ps -a --filter name=^…$` instead. `ps -a`, not `ps`: a container that exited still has logs worth reading, and that is often exactly why someone is looking.

`absent()` accepts both spellings lowercased, and rejects `permission denied` / `device or resource busy` so a real failure is never swallowed.

`logs` also gained an injected runner (SBIO), matching the existing `stop_with`, so the never-started path is testable without a live docker — one test asserts `docker logs` is **not run at all** in that case.

## Verification

5 tests added, each verified to run by name (not merely to compile). Workspace green (11 suites), `clippy` and `fmt` clean, goldens unchanged, file 436/500 lines. Both paths also exercised end-to-end against real docker, shown above.


---

## Update: closing the typo hole this would otherwise open

Once "not running" stopped being a failure, it answered a **typo** exactly as readily as a real recipe:

```
atlasctl stop qwen3.8-27b-nvfp4-unslothh     # note the doubled h
atlas-qwen3.8-27b-nvfp4-unslothh is not running        (exit 0)
```

Interactively the echoed name gives it away, but `atlasctl stop "$RECIPE"` with a misspelt variable would have reported success having stopped nothing — the same class of lie as the `$?`-after-a-pipeline bugs fixed elsewhere this session.

`stop <recipe>` and `logs <recipe>` now resolve the name through the registry first — the same path `run` and `show` already take — so a near miss inherits the "Did you mean …?" list from #96:

```
error: no recipe named `qwen3.8-27b-nvfp4-unslothh`.
  Did you mean qwen3.8-27b-nvfp4-unsloth, qwen3.6-27b-nvfp4-unsloth,
  qwen3.8-27b-nvfp4-unsloth-bfcl?                      (exit 1)
```

`--all` deliberately skips the check: its targets come from docker's own list of containers carrying our label, so they need no catalogue entry. That is also the escape hatch if a recipe is running from a registry since removed — otherwise this change would make such a container unstoppable through atlasctl.

Resolution sits in the public wrappers, so `stop_with`/`logs_with` keep their injected runner and stay testable with neither registry nor docker I/O.

All four paths verified end-to-end against the real binary and real docker:

| case | result |
|---|---|
| real recipe, not running | `is not running`, **exit 0** |
| typo, `stop` | suggestion list, **exit 1** |
| typo, `logs` | suggestion list, **exit 1** |
| real recipe, never started | `not been started here`, **exit 1** |

Workspace green (11 suites), clippy/fmt clean, goldens unchanged, 457/500 lines.
