### PR TITLE
docs(security): the doctor check can now be gated on

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ atlasctl run <recipe> --print              # print the command instead of runnin
 atlasctl logs <recipe> --follow
 atlasctl stop <recipe>
 atlasctl status
-atlasctl doctor                            # check this machine for problems
+atlasctl doctor                            # check this machine for problems (exit 1 if any)
 ```
 
 `--print` is worth knowing about: it shows the exact `docker run` that `run`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,6 +25,14 @@ no trust gate at all.
 sparkrun's config file does not fix the redirect: it is compiled into the tool
 and reapplied on the next run. Removing the tool is the fix.
 
+`doctor` exits **0** when it finds nothing and **1** when it finds something, so
+this check can be gated on rather than read by eye — in a cron job, a
+provisioning script, or CI:
+
+```sh
+atlasctl doctor || echo "this machine needs attention before it runs anything"
+```
+
 ## What `atlasctl` does differently
 
 - **Recipes are compiled in.** There is no fetch step to redirect. A fresh


### PR DESCRIPTION
#97 made `atlasctl doctor` exit 1 when it finds something. SECURITY.md is the document that tells an operator to run it — to detect a sparkrun install whose registry redirect lets recipes from a host Atlas does not control run shell commands here — so it is the document that should say the check is now machine-readable rather than something to read by eye.

Adds the idiom and states the contract (0 clean, 1 found):

```sh
atlasctl doctor || echo "this machine needs attention before it runs anything"
```

and notes the exit behaviour beside the command in the README tour.

**Verified against the binary built from this branch**, not from the wording of the PR that introduced it: with the finding present on this machine, `doctor` exits 1 and the documented idiom takes its second branch.