### PR TITLE
feat(run): say the weights are missing before pulling an image for nothing

### DIFF
--- a/crates/atlasctl-core/src/hfcache.rs
+++ b/crates/atlasctl-core/src/hfcache.rs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Where a Hub model lives in a local HuggingFace cache.
+//!
+//! A launch mounts the host cache at `/cache/huggingface` and sets
+//! `HF_HUB_OFFLINE=1` and `TRANSFORMERS_OFFLINE=1` (see `docker::translate`),
+//! deliberately: a recipe must not reach the network mid-launch. The
+//! consequence is that a model which is not already in that cache cannot be
+//! fetched by the container — it fails inside, after the image pull, with the
+//! Hub library's own cache-miss message. This module exists so the launcher can
+//! say so first, in terms of the recipe the operator named.
+
+use std::path::{Path, PathBuf};
+
+/// The directory a Hub id `org/name` occupies under an HF cache root.
+///
+/// `None` when `model` is not a two-part Hub id — a bare name, a local path, or
+/// anything with extra slashes. Those do not follow this layout, so the
+/// caller must not conclude anything about them from a missing directory.
+pub fn hub_dir(cache_root: &Path, model: &str) -> Option<PathBuf> {
+    // A path, not an id: `/models/foo`, `./foo`, `~/foo`.
+    if model.starts_with('/') || model.starts_with('.') || model.starts_with('~') {
+        return None;
+    }
+    let mut parts = model.split('/');
+    let (Some(org), Some(name), None) = (parts.next(), parts.next(), parts.next()) else {
+        return None;
+    };
+    if org.is_empty() || name.is_empty() {
+        return None;
+    }
+    Some(
+        cache_root
+            .join("hub")
+            .join(format!("models--{org}--{name}")),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_hub_id_maps_to_the_directory_the_hub_library_uses() {
+        let root = Path::new("/c");
+        assert_eq!(
+            hub_dir(root, "unsloth/Qwen3.8-27B-NVFP4").unwrap(),
+            Path::new("/c/hub/models--unsloth--Qwen3.8-27B-NVFP4")
+        );
+        // Dots and dashes in either half survive verbatim; only `/` is special.
+        assert_eq!(
+            hub_dir(root, "Qwen/Qwen3.6-35B-A3B-FP8").unwrap(),
+            Path::new("/c/hub/models--Qwen--Qwen3.6-35B-A3B-FP8")
+        );
+    }
+
+    /// The caller treats `None` as "cannot tell", so anything that does not
+    /// follow the layout must return it rather than a path that will be absent
+    /// and read as a missing model.
+    #[test]
+    fn anything_that_is_not_a_two_part_id_is_not_guessed_at() {
+        let root = Path::new("/c");
+        for not_an_id in [
+            "/models/local",   // absolute path
+            "./relative",      // relative path
+            "~/home-relative", // home-relative
+            "bare-name",       // no org
+            "a/b/c",           // too many parts
+            "/",               // degenerate
+            "",                // empty
+            "org/",            // empty name
+            "/name",           // empty org, and a path
+        ] {
+            assert!(
+                hub_dir(root, not_an_id).is_none(),
+                "must not guess a cache path for {not_an_id:?}"
+            );
+        }
+    }
+}

--- a/crates/atlasctl-core/src/lib.rs
+++ b/crates/atlasctl-core/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod chain;
 pub mod docker;
 pub mod flags;
+pub mod hfcache;
 pub mod host;
 pub mod io;
 pub mod metrics;

--- a/crates/atlasctl/src/commands/run.rs
+++ b/crates/atlasctl/src/commands/run.rs
@@ -10,8 +10,10 @@ use atlasctl_core::chain::UserConfig;
 use atlasctl_core::docker::collective::NcclRoce;
 use atlasctl_core::docker::profile::{NvidiaDevices, ROOTLESS_V1};
 use atlasctl_core::docker::translate::{LaunchContext, translate};
+use atlasctl_core::hfcache;
 use atlasctl_core::io::{ProcessRunner, StdProcessRunner};
 use atlasctl_core::registry::RecipeRef;
+use std::path::Path;
 
 /// Launch a recipe, or print the command it would run.
 pub fn run(args: &RunArgs) -> Result<()> {
@@ -78,6 +80,26 @@ pub fn run(args: &RunArgs) -> Result<()> {
             println!("{}", plan.docker);
         }
         return Ok(());
+    }
+
+    // The container is launched with HF_HUB_OFFLINE=1, so a model that is not
+    // already in the host cache cannot be fetched from inside it. Said here,
+    // before the image pull, because otherwise the operator waits through a
+    // multi-gigabyte pull to reach the Hub library's own cache-miss message,
+    // inside a container that has already exited, reachable only via
+    // `atlasctl logs`.
+    if let Some(dir) = hfcache::hub_dir(Path::new(&host.hf_cache_dir), &recipe.model)
+        && !dir.exists()
+    {
+        bail!(
+            "`{}` needs the model `{}`, which is not in {}.\n\
+                 The launch runs offline, so it cannot download it. Fetch it first:\n\
+                   hf download {}",
+            args.recipe,
+            recipe.model,
+            host.hf_cache_dir,
+            recipe.model
+        );
     }
 
     let runner = StdProcessRunner;


### PR DESCRIPTION
A launch mounts the host HF cache and sets `HF_HUB_OFFLINE=1` / `TRANSFORMERS_OFFLINE=1` (`docker::translate`) **deliberately** — a recipe must not reach the network mid-launch. The consequence was never surfaced to the operator.

A model that is not already cached cannot be fetched from inside the container, so the run died in there, **after a multi-gigabyte image pull**, with the Hub library's own cache-miss text — inside a container that had already exited, reachable only through `atlasctl logs`.

### Now, before the pull

```
error: `deepseek-v4-flash-nvfp4-ep2` needs the model
`nvidia/DeepSeek-V4-Flash-NVFP4`, which is not in /home/nologik/.cache/huggingface.
The launch runs offline, so it cannot download it. Fetch it first:
  hf download nvidia/DeepSeek-V4-Flash-NVFP4
```

**This is a live case, not a hypothetical.** That checkpoint was removed from this box's cache to make room for Qwen3.8-Flash-Next, and its recipe still ships. A fresh install is in the same position for *every* recipe.

## Design

`hub_dir` is a pure function with its own tests, and returns `None` for anything that is not a two-part Hub id — a local path, a bare name, `a/b/c`, `org/`, `~/x`. **The caller treats `None` as "cannot tell" and launches**, because concluding "missing" from a layout that does not apply would block a working launch.

Only an *absent directory for a real Hub id* is treated as absent. A partially downloaded one still launches and fails in the engine, which is where a partial download should be diagnosed.

The cache root is `host.hf_cache_dir` — the same value the launch mounts — rather than a second guess at where HF keeps things.

`--print` is deliberately upstream of the check: printing the command on a machine that does not hold the weights is a reasonable thing to want, and is verified still to work.

## Verification

Workspace green (11 suites), `clippy` and `fmt` clean, goldens unchanged. Both new tests verified to run by name. Both paths exercised against the real binary:

| case | result |
|---|---|
| recipe whose model was deleted | refuses with the message above, **exit 1**, no image pull |
| `--print` for an uncached recipe | still prints the command, **exit 0** |
| recipe whose model is cached | proceeds to launch normally |
