### PR TITLE
fix(peer): check the pairing code before opening a socket

### DIFF
--- a/crates/atlasctl/src/commands/peer.rs
+++ b/crates/atlasctl/src/commands/peer.rs
@@ -85,6 +85,28 @@ pub fn age_text(then: u64, now: u64) -> String {
 /// ceremony fails — which is what both a wrong code and a relayed connection
 /// look like.
 pub fn add(args: &PeerAddArgs) -> Result<()> {
+    // Checked here, before a socket is opened. The ceremony checks it too, but
+    // only once a TLS session is up, so a typo in the operator's own hand came
+    // back as "could not pair with <machine>" naming an address and a port --
+    // which reads as "that machine refused you" and sends someone to go look at
+    // the other box. It also spent a connection to learn something knowable
+    // without one.
+    //
+    // The code itself is NOT echoed: a one-digit typo of a live code would put
+    // seven correct digits of a pairing secret into the terminal and any log
+    // scraping it.
+    if !atlasctl_agent::pairing::looks_like_code(&args.code) {
+        let n = args.code.chars().count();
+        let what = if n == 8 {
+            "every character has to be a digit".to_string()
+        } else {
+            format!("this one is {n} character(s)")
+        };
+        anyhow::bail!(
+            "a pairing code is 8 digits, and {what}. Read it off `atlasctl agent pair` on the machine you are adding."
+        );
+    }
+
     let dir = crate::hostinfo::usable_config_dir()?;
     let identity = Identity::load_or_create(&dir)?;
     let pins = PinStore::new(&dir);


### PR DESCRIPTION
`atlasctl peer add <host> --code 123` answered:

```
error: could not pair with 127.0.0.1 — 127.0.0.1:34334: a pairing code is 8 digits
```

The shape of a code is a **purely local fact**, but it was only checked inside the ceremony, *after* a TLS session was already up. So a typo in the operator own hand came back naming an address and a port — which reads as "that machine refused you" and sends someone to go look at the other box. It also spent a connection to learn something knowable without one.

### Now, before any network work

| input | message |
|---|---|
| `--code 123` | a pairing code is 8 digits, and this one is 3 character(s). |
| `--code abcdefgh` | a pairing code is 8 digits, and **every character has to be a digit**. |
| `--code 12345678a` | ... this one is 9 character(s). |

The old message answered `abcdefgh` with a bare "8 digits", which is unhelpful when the string already *is* eight characters. Each message ends with where to read the real one: `atlasctl agent pair` on the machine being added.

**The code itself is deliberately not echoed.** A one-digit typo of a live code would otherwise put seven correct digits of a pairing secret into the terminal and into anything scraping the logs; the length and the digit-ness are enough to fix the mistake.

Shape only, via the same `pairing::looks_like_code` the ceremony uses, so there is still exactly one definition of what a code looks like — and whether it is the *right* code remains a question only the exchange answers.

**Verified:** a well-formed code still goes to the network (`--code 12345678` against a dead port still reports connection refused). Workspace green (11 suites), clippy/fmt clean, goldens unchanged, 335/500 lines.