### PR TITLE
fix(run): the CLI never checked a -o value against its declared bound

### DIFF
--- a/crates/atlasctl-core/src/settings/mod.rs
+++ b/crates/atlasctl-core/src/settings/mod.rs
@@ -63,6 +63,36 @@ fn disposition(key: &str) -> Option<&'static Disposition> {
     dispositions().find(|(k, _)| *k == key).map(|(_, d)| d)
 }
 
+/// Check one locally-supplied override against the bound the setting declares.
+///
+/// This is NOT `validate`. That function serves a webpage, so it also refuses
+/// DENIED keys and unknown ones. A local operator is not a webpage: the deny
+/// list is a statement about what a remote client may set, and applying it here
+/// would stop someone from configuring their own machine from their own shell.
+/// An unknown key is likewise left alone — the launcher already warns that it
+/// will not be applied, and that warning names the value.
+///
+/// What it does catch is the case the CLI silently passed through: a value
+/// outside the range the project declares for a setting it does expose.
+/// `-o gpu_memory_utilization=5` rendered `--gpu-memory-utilization 5` against
+/// a declared `Float(0.10, 0.95)`, on hardware where 0.90 has frozen a machine
+/// hard enough to need a power cycle.
+///
+/// # Errors
+/// The bound's own `SettingError` when the value is outside it.
+pub fn check_override(key: &str, value: &ScalarValue) -> Result<(), SettingError> {
+    let Some(Disposition::Expose(spec)) = disposition(key) else {
+        return Ok(());
+    };
+    let sent = match value {
+        ScalarValue::Bool(b) => SettingValue::Bool(*b),
+        ScalarValue::Int(n) => SettingValue::Int(*n),
+        ScalarValue::Float(f) => SettingValue::Float(*f),
+        ScalarValue::Str(s) => SettingValue::Str(s.clone()),
+    };
+    spec.bound.to_bound().check(key, &sent).map(|_| ())
+}
+
 /// Validate a client's requested overrides.
 ///
 /// Returns values ready for the config chain. Every error is collected rather

--- a/crates/atlasctl-core/src/settings/tests.rs
+++ b/crates/atlasctl-core/src/settings/tests.rs
@@ -212,3 +212,44 @@ fn the_enumerated_values_still_match_the_engine() {
          and killed every launch that chose it"
     );
 }
+
+// ---- CLI overrides against declared bounds ---------------------------------
+//
+// `validate` serves a webpage and refuses denied and unknown keys too.
+// `check_override` serves a local operator and must NOT: the deny list says
+// what a remote client may set, and an unknown key already draws a warning
+// naming the value it will not apply. What it must catch is the case the CLI
+// passed through in silence — a value outside the range the project declares.
+
+#[test]
+fn a_value_outside_the_declared_range_is_refused() {
+    // Rendered `--gpu-memory-utilization 5` before this, against a declared
+    // Float(0.10, 0.95), on hardware where 0.90 has needed a power cycle.
+    let e = super::check_override("gpu_memory_utilization", &ScalarValue::Float(5.0))
+        .expect_err("5 is not a fraction");
+    assert!(e.to_string().contains("0.95"), "names the ceiling: {e}");
+
+    let e =
+        super::check_override("port", &ScalarValue::Int(99_999)).expect_err("above the port range");
+    assert!(e.to_string().contains("49151"), "{e}");
+}
+
+#[test]
+fn values_inside_the_range_pass_including_the_endpoints() {
+    for v in [0.10_f64, 0.85, 0.95] {
+        super::check_override("gpu_memory_utilization", &ScalarValue::Float(v))
+            .unwrap_or_else(|e| panic!("{v} is inside the declared bound: {e}"));
+    }
+    super::check_override("port", &ScalarValue::Int(1024)).expect("lower endpoint");
+    super::check_override("port", &ScalarValue::Int(49_151)).expect("upper endpoint");
+}
+
+/// A local shell is not a webpage. Refusing these here would stop someone
+/// configuring their own machine, which is not what the deny list is for.
+#[test]
+fn a_denied_or_unknown_key_is_not_this_functions_business() {
+    super::check_override("host", &ScalarValue::Str("0.0.0.0".into()))
+        .expect("denied keys are a remote-client rule, not a local one");
+    super::check_override("nosuchkey", &ScalarValue::Int(1))
+        .expect("unknown keys are warned about by the launcher, not refused here");
+}

--- a/crates/atlasctl/src/validate.rs
+++ b/crates/atlasctl/src/validate.rs
@@ -35,6 +35,9 @@ pub fn build_overrides(options: &[String], port: Option<u16>) -> Result<Override
     let mut out = Overrides::new();
     for opt in options {
         let (k, v) = parse_override(opt)?;
+        // The declared bound was enforced for the web surface and not here, so
+        // the CLI passed a nonsense value straight into the rendered command.
+        atlasctl_core::settings::check_override(&k, &v)?;
         if out.insert(k.clone(), v).is_some() {
             bail!("`{k}` was given more than once");
         }


### PR DESCRIPTION
`gpu_memory_utilization` declares `Float(0.10, 0.95)` in `settings/memory.rs`. The web surface enforces it. **The CLI did not:**

```
atlasctl run <recipe> -o gpu_memory_utilization=5 --print
... --gpu-memory-utilization 5 ...
```

It rendered, with only the GB10 caution printed beside it. That is the one setting on this hardware where the number matters most — **0.90 has frozen a machine of this kind hard enough to need a power cycle**, and unified memory leaves no framebuffer to fall back on. Every `Int` bound was equally unchecked: `-o port=99999` rendered too.

`build_overrides` parsed `KEY=VALUE` and checked for duplicates. It never consulted the table, so every declared bound was decorative for anyone using a shell.

## Why not just call `settings::validate`

The check reuses `Bound::check` and the same declared `BoundSpec`, so there is one definition of a valid range rather than a CLI copy that can drift. But it is deliberately **not** `validate`, which additionally refuses denied and unknown keys:

- **DENIED** is a statement about what a *remote client* may set. A local operator is not a webpage, and refusing here would stop someone configuring their own machine from their own shell. `-o host=0.0.0.0` still works — verified.
- **UNKNOWN** keys already draw a warning naming the value and saying it will not be applied. Turning that into a hard error would break a recipe the day a flag is renamed.

## Verified against the real binary

| override | result |
|---|---|
| `gpu_memory_utilization=5` | **error: must be between 0.1 and 0.95** |
| `gpu_memory_utilization=0.95` | applied, still cautioned |
| `gpu_memory_utilization=0.85` | applied |
| `port=99999` | **error: must be between 1024 and 49151** |
| `nosuchkey=1` | warning only, launch proceeds |
| `host=0.0.0.0` (denied key) | applied |

Three tests, each verified to run by name, covering the endpoints (0.10, 0.95, 1024, 49151 all pass) so the bound is not accidentally exclusive. **Removing the call from the CLI path restores the old rendering** — that is what pins the wiring, rather than only the function.

Workspace green (11 suites), `clippy` and `fmt` clean, goldens unchanged.
