### PR TITLE
feat(run): answer an unknown -o key instead of only refusing it

### DIFF
--- a/crates/atlasctl-core/src/flags/mod.rs
+++ b/crates/atlasctl-core/src/flags/mod.rs
@@ -37,6 +37,25 @@ pub fn lookup(key: &str) -> Option<&'static FlagSpec> {
     ATLAS_FLAGS.iter().find(|s| s.key == key)
 }
 
+/// The recipe key for an engine flag spelled as if it were a key.
+///
+/// Someone reading the rendered command sees `--max-seq-len` and writes
+/// `-o max_seq_len=...`; the key is `max_model_len`. That is not a typo, and no
+/// edit-distance ranking finds it — the two are five edits apart — so it is
+/// answered exactly, from the table that already carries both spellings.
+#[must_use]
+pub fn key_for_flag_spelling(typed: &str) -> Option<&'static str> {
+    ATLAS_FLAGS
+        .iter()
+        .find(|s| s.flag.trim_start_matches('-').replace('-', "_") == typed && s.key != typed)
+        .map(|s| s.key)
+}
+
+/// Every key the table understands, for suggesting a near miss.
+pub fn keys() -> impl Iterator<Item = &'static str> {
+    ATLAS_FLAGS.iter().map(|s| s.key)
+}
+
 /// A resolved key that no flag in the table claims.
 ///
 /// The reference implementation dropped these in silence, which is how nine

--- a/crates/atlasctl-core/src/lib.rs
+++ b/crates/atlasctl-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod flags;
 pub mod host;
 pub mod io;
 pub mod metrics;
+pub mod nearest;
 pub mod recipe;
 pub mod registry;
 pub mod scalar;

--- a/crates/atlasctl-core/src/nearest.rs
+++ b/crates/atlasctl-core/src/nearest.rs
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! "Did you mean …?" over a fixed vocabulary.
+//!
+//! Extracted from the recipe registry when a second caller appeared: recipe
+//! names and setting keys are different vocabularies with the same problem, and
+//! two rankings would drift. The rule this replaced ranked by a shared six
+//! character prefix and then ALPHABETICALLY, which on a catalogue with long
+//! common prefixes filled every slot with the wrong answer while the name one
+//! character away never appeared.
+
+/// How far a name may be from what was typed and still be worth printing.
+///
+/// A quarter of the longer of the two names: floored at 2 so a short name still
+/// catches a near miss, and capped at 5 so an unrelated string prints nothing
+/// rather than three wrong guesses.
+const fn max_edits(len: usize) -> usize {
+    match len / 4 {
+        0 | 1 => 2,
+        n if n > 5 => 5,
+        n => n,
+    }
+}
+
+/// Levenshtein distance over chars, two rows.
+///
+/// The vocabularies here are small and the names short, so the allocation per
+/// call is not worth avoiding.
+fn edit_distance(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    if a.is_empty() {
+        return b.len();
+    }
+    if b.is_empty() {
+        return a.len();
+    }
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut cur: Vec<usize> = vec![0; b.len() + 1];
+    for (i, ca) in a.iter().enumerate() {
+        cur[0] = i + 1;
+        for (j, cb) in b.iter().enumerate() {
+            let cost = usize::from(ca != cb);
+            cur[j + 1] = (prev[j + 1] + 1).min(cur[j] + 1).min(prev[j] + cost);
+        }
+        std::mem::swap(&mut prev, &mut cur);
+    }
+    prev[b.len()]
+}
+
+/// The (at most three) candidates nearest `typed`, closest first.
+///
+/// Empty when nothing is near enough, which is the answer for a string that was
+/// not a typo of anything: three confident wrong guesses are worse than none.
+/// Ties break by name so the list is stable run to run.
+pub fn nearest<I, S>(typed: &str, candidates: I) -> Vec<String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let typed_len = typed.chars().count();
+    let mut scored: Vec<(usize, String)> = candidates
+        .into_iter()
+        .filter_map(|c| {
+            let name = c.as_ref();
+            let d = edit_distance(typed, name);
+            (d <= max_edits(typed_len.max(name.chars().count()))).then(|| (d, name.to_string()))
+        })
+        .collect();
+    scored.sort_by(|x, y| x.0.cmp(&y.0).then_with(|| x.1.cmp(&y.1)));
+    scored.into_iter().take(3).map(|(_, n)| n).collect()
+}
+
+/// Render a suggestion list as the tail of an error message.
+///
+/// Empty string when there is nothing near, so the caller can append it
+/// unconditionally without composing two message shapes.
+#[must_use]
+pub fn did_you_mean(candidates: &[String]) -> String {
+    if candidates.is_empty() {
+        String::new()
+    } else {
+        format!(". Did you mean {}?", candidates.join(", "))
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/atlasctl-core/src/nearest/tests.rs
+++ b/crates/atlasctl-core/src/nearest/tests.rs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use super::*;
+
+#[test]
+fn edit_distance_is_symmetric_and_counts_single_edits() {
+    assert_eq!(edit_distance("", ""), 0);
+    assert_eq!(edit_distance("abc", ""), 3);
+    assert_eq!(edit_distance("", "abc"), 3);
+    assert_eq!(edit_distance("abc", "abc"), 0);
+    assert_eq!(edit_distance("unsloh", "unsloth"), 1);
+    assert_eq!(edit_distance("unsloth", "unsloh"), 1);
+    assert_eq!(edit_distance("gemma4", "gemma-4"), 1);
+    assert_eq!(edit_distance("abc", "abd"), 1);
+    // Multi-byte input must not panic, and must count chars not bytes.
+    assert_eq!(edit_distance("héllo", "hello"), 1);
+}
+
+#[test]
+fn the_edit_ceiling_stays_inside_its_stated_bounds() {
+    assert_eq!(max_edits(0), 2, "floor");
+    assert_eq!(max_edits(7), 2, "floor still applies to short names");
+    assert_eq!(max_edits(12), 3);
+    assert_eq!(max_edits(20), 5);
+    assert_eq!(max_edits(200), 5, "cap");
+}
+
+/// The case the prefix-and-alphabetical rule got wrong: the right answer is
+/// one character away but sorts after two others sharing the prefix.
+#[test]
+fn the_nearest_name_comes_first_not_the_alphabetically_first() {
+    let vocab = [
+        "qwen3.5-0.8b-bf16-atlas",
+        "qwen3.5-122b-a10b-nvfp4-ep2",
+        "qwen3.8-27b-nvfp4-unsloth",
+    ];
+    let got = nearest("qwen3.8-27b-nvfp4-unsloh", vocab);
+    assert_eq!(
+        got.first().map(String::as_str),
+        Some("qwen3.8-27b-nvfp4-unsloth"),
+        "{got:?}"
+    );
+}
+
+#[test]
+fn a_typo_inside_the_first_characters_is_still_found() {
+    // Shares no six-character prefix with the answer, which is what the old
+    // rule keyed on.
+    assert_eq!(
+        nearest("gemma4-31b-nvfp4", ["gemma-4-31b-nvfp4"]),
+        ["gemma-4-31b-nvfp4"]
+    );
+    // NOT this one, and the fact is worth pinning: `max_seq_len` is what a
+    // reader of the rendered command types, and `max_model_len` is the key --
+    // but they are five edits apart, past the ceiling. Distance is the wrong
+    // instrument for a rename; `flags::key_for_flag_spelling` answers it from
+    // the table that holds both spellings.
+    assert!(
+        nearest("max_seq_len", ["max_model_len"]).is_empty(),
+        "a rename is not a typo and must not be papered over by a loose ceiling"
+    );
+}
+
+#[test]
+fn an_unrelated_string_suggests_nothing_rather_than_guessing() {
+    assert!(
+        nearest(
+            "nope/nothere",
+            ["qwen3.8-27b-nvfp4-unsloth", "gemma-4-31b-nvfp4"]
+        )
+        .is_empty()
+    );
+    assert!(nearest("zzzzzzzzzzzzzzzzzzzz", ["port", "max_model_len"]).is_empty());
+}
+
+#[test]
+fn at_most_three_are_offered_and_ties_are_stable() {
+    let vocab = ["aaa1", "aaa2", "aaa3", "aaa4", "aaa5"];
+    let got = nearest("aaa", vocab);
+    assert_eq!(got.len(), 3, "{got:?}");
+    assert_eq!(got, ["aaa1", "aaa2", "aaa3"], "ties break by name: {got:?}");
+    assert_eq!(nearest("aaa", vocab), got, "same answer twice");
+}
+
+#[test]
+fn the_message_tail_is_empty_when_there_is_nothing_to_suggest() {
+    assert_eq!(did_you_mean(&[]), "");
+    assert_eq!(did_you_mean(&["a".to_string()]), ". Did you mean a?");
+    assert_eq!(
+        did_you_mean(&["a".to_string(), "b".to_string()]),
+        ". Did you mean a, b?"
+    );
+}

--- a/crates/atlasctl-core/src/registry/mod.rs
+++ b/crates/atlasctl-core/src/registry/mod.rs
@@ -249,56 +249,8 @@ impl RegistrySet {
     /// * `gemma4-31b-nvfp4` — one missing hyphen — shares no six-character
     ///   prefix with `gemma-4-31b-nvfp4`, so it got no suggestion at all.
     fn close_names(&self, name: &str) -> Vec<String> {
-        let typed = name.chars().count();
-        let mut scored: Vec<(usize, String)> = self
-            .list()
-            .into_iter()
-            .map(|e| (edit_distance(name, &e.name), e.name))
-            .filter(|(d, n)| *d <= max_edits(typed.max(n.chars().count())))
-            .collect();
-        // Distance first, then the name, so the list is stable run to run.
-        scored.sort_by(|x, y| x.0.cmp(&y.0).then_with(|| x.1.cmp(&y.1)));
-        scored.into_iter().take(3).map(|(_, n)| n).collect()
+        crate::nearest::nearest(name, self.list().into_iter().map(|e| e.name))
     }
-}
-
-/// How far a name may be from what was typed and still be worth printing.
-///
-/// A quarter of the longer of the two names: floored at 2 so a short name
-/// still catches a near miss, and capped at 5 so an unrelated string prints
-/// nothing rather than three wrong guesses.
-const fn max_edits(len: usize) -> usize {
-    match len / 4 {
-        0 | 1 => 2,
-        n if n > 5 => 5,
-        n => n,
-    }
-}
-
-/// Levenshtein distance over chars, two rows.
-///
-/// Recipe names are short and the catalogue is small, so the allocation per
-/// call is not worth avoiding.
-fn edit_distance(a: &str, b: &str) -> usize {
-    let a: Vec<char> = a.chars().collect();
-    let b: Vec<char> = b.chars().collect();
-    if a.is_empty() {
-        return b.len();
-    }
-    if b.is_empty() {
-        return a.len();
-    }
-    let mut prev: Vec<usize> = (0..=b.len()).collect();
-    let mut cur: Vec<usize> = vec![0; b.len() + 1];
-    for (i, ca) in a.iter().enumerate() {
-        cur[0] = i + 1;
-        for (j, cb) in b.iter().enumerate() {
-            let cost = usize::from(ca != cb);
-            cur[j + 1] = (prev[j + 1] + 1).min(cur[j] + 1).min(prev[j] + cost);
-        }
-        std::mem::swap(&mut prev, &mut cur);
-    }
-    prev[b.len()]
 }
 
 fn r#ref_display(r: &RecipeRef) -> String {

--- a/crates/atlasctl-core/src/registry/tests.rs
+++ b/crates/atlasctl-core/src/registry/tests.rs
@@ -253,30 +253,9 @@ fn a_real_remote_recipe_name_is_still_accepted() {
 // character from a real one, and nothing at all for a missing hyphen. Both are
 // pinned below against the real builtin catalogue, so a future change to the
 // ranking has to keep answering them.
-
-#[test]
-fn edit_distance_is_symmetric_and_counts_single_edits() {
-    assert_eq!(super::edit_distance("", ""), 0);
-    assert_eq!(super::edit_distance("abc", ""), 3);
-    assert_eq!(super::edit_distance("", "abc"), 3);
-    assert_eq!(super::edit_distance("abc", "abc"), 0);
-    // one deletion, one insertion, one substitution
-    assert_eq!(super::edit_distance("unsloh", "unsloth"), 1);
-    assert_eq!(super::edit_distance("gemma4", "gemma-4"), 1);
-    assert_eq!(super::edit_distance("abc", "abd"), 1);
-    assert_eq!(super::edit_distance("unsloth", "unsloh"), 1);
-    // multi-byte input must not panic or count bytes
-    assert_eq!(super::edit_distance("héllo", "hello"), 1);
-}
-
-#[test]
-fn the_edit_ceiling_stays_inside_its_stated_bounds() {
-    assert_eq!(super::max_edits(0), 2, "floor");
-    assert_eq!(super::max_edits(7), 2, "floor still applies to short names");
-    assert_eq!(super::max_edits(12), 3);
-    assert_eq!(super::max_edits(20), 5);
-    assert_eq!(super::max_edits(200), 5, "cap");
-}
+//
+// The ranking itself now lives in `crate::nearest`, with its own tests; what
+// stays here is that the REGISTRY asks it the right question.
 
 #[test]
 fn a_one_character_typo_suggests_the_recipe_it_meant() {

--- a/crates/atlasctl/src/commands/run.rs
+++ b/crates/atlasctl/src/commands/run.rs
@@ -11,6 +11,7 @@ use atlasctl_core::docker::collective::NcclRoce;
 use atlasctl_core::docker::profile::{NvidiaDevices, ROOTLESS_V1};
 use atlasctl_core::docker::translate::{LaunchContext, translate};
 use atlasctl_core::io::{ProcessRunner, StdProcessRunner};
+use atlasctl_core::nearest;
 use atlasctl_core::registry::RecipeRef;
 
 /// Launch a recipe, or print the command it would run.
@@ -51,9 +52,19 @@ pub fn run(args: &RunArgs) -> Result<()> {
     // Say what will not be applied before doing anything, not after. The tool
     // this replaces dropped these settings in silence.
     for u in &plan.unmapped {
+        // Two different mistakes, answered differently. Reading the rendered
+        // command and typing what you saw is not a typo -- `--max-seq-len` is
+        // the key `max_model_len` -- and no distance ranking finds it, so the
+        // table that holds both spellings answers it exactly. Anything else
+        // gets the near-miss list.
+        let hint = if let Some(key) = atlasctl_core::flags::key_for_flag_spelling(&u.key) {
+            format!(". That is the engine's flag name; the setting key is `{key}`")
+        } else {
+            nearest::did_you_mean(&nearest::nearest(&u.key, atlasctl_core::flags::keys()))
+        };
         eprintln!(
             "warning: `{}` is not a setting this version understands; \
-             it will NOT be applied (value: {})",
+             it will NOT be applied (value: {}){hint}",
             u.key, u.rendered
         );
     }


### PR DESCRIPTION
```
$ atlasctl run <recipe> -o max_seq_len=8192
warning: `max_seq_len` is not a setting this version understands; it will
         NOT be applied (value: 8192)
```

**That key is not a typo.** `--max-seq-len` is what the rendered command shows, so it is exactly what a reader types — and the setting is called `max_model_len`. The warning was correct and left the operator with nowhere to go.

## Two different mistakes, answered differently

| input | now |
|---|---|
| `-o max_seq_len=8192` | … That is the engine's flag name; the setting key is `max_model_len` |
| `-o max_model_lenn=8192` | … Did you mean max_model_len? |
| `-o zzzzzzzz=1` | … *(no suggestion)* |

The rename is answered **exactly**, from the flag table that already carries both spellings (`key: "max_model_len", flag: "--max-seq-len"`).

It *cannot* be found by ranking: the two names are **five edits apart**, well past the ceiling. I wrote the fuzzy version first and its test failed on this very case — which is the useful result, because it shows distance is the wrong instrument for a rename. A test now pins it: `nearest("max_seq_len", ["max_model_len"])` must stay **empty**, so nobody later "fixes" this by loosening the threshold until unrelated strings start matching.

## SSOT

The ranking moves out of the registry into `crate::nearest`, because a second caller now exists and two copies would drift. `close_names` becomes one line over it.

Recipe-name suggestions verified **unchanged** after the move:

```
recipe show qwen3.8-27b-nvfp4-unsloh  → Did you mean qwen3.8-27b-nvfp4-unsloth, …
recipe show gemma4-31b-nvfp4          → Did you mean gemma-4-31b-nvfp4?
recipe show nope/nothere              → (no suggestion)
```

Its two unit tests move with it; what stays in the registry tests is that the registry asks the right question of it. `did_you_mean` returns an empty string when nothing is near, so a caller appends it unconditionally rather than composing two message shapes.

Workspace green (11 suites), `clippy` and `fmt` clean, goldens unchanged.
