### PR TITLE
fix: six audit findings, including two regressions from tonight

### DIFF
--- a/crates/atlasctl-core/src/flags/mod.rs
+++ b/crates/atlasctl-core/src/flags/mod.rs
@@ -39,6 +39,12 @@ pub fn lookup(key: &str) -> Option<&'static FlagSpec> {
 
 /// The recipe key for an engine flag spelled as if it were a key.
 ///
+/// Answers only for a key the table does NOT already know: `max_prefill_tokens`
+/// is a real key AND the flag spelling of `max_num_batched_tokens`, so without
+/// that guard a valid key would be told it is "the engine's flag name" for a
+/// different setting. The old `s.key != typed` guard did not cover it — it only
+/// skipped the spec whose own key matched.
+///
 /// Someone reading the rendered command sees `--max-seq-len` and writes
 /// `-o max_seq_len=...`; the key is `max_model_len`. That is not a typo, and no
 /// edit-distance ranking finds it — the two are five edits apart — so it is
@@ -47,7 +53,8 @@ pub fn lookup(key: &str) -> Option<&'static FlagSpec> {
 pub fn key_for_flag_spelling(typed: &str) -> Option<&'static str> {
     ATLAS_FLAGS
         .iter()
-        .find(|s| s.flag.trim_start_matches('-').replace('-', "_") == typed && s.key != typed)
+        .find(|s| s.flag.trim_start_matches('-').replace('-', "_") == typed)
+        .filter(|_| lookup(typed).is_none())
         .map(|s| s.key)
 }
 
@@ -155,3 +162,32 @@ pub fn render(
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod spelling_tests {
+    use super::*;
+
+    /// The rename this exists for.
+    #[test]
+    fn an_engine_flag_spelling_maps_to_the_setting_key() {
+        assert_eq!(key_for_flag_spelling("max_seq_len"), Some("max_model_len"));
+    }
+
+    /// `max_prefill_tokens` is a REAL key and also the flag spelling of
+    /// `max_num_batched_tokens`. Without the lookup guard a valid key would be
+    /// told it is "the engine's flag name" for a different setting.
+    #[test]
+    fn a_key_that_is_also_another_flags_spelling_is_left_alone() {
+        assert!(
+            lookup("max_prefill_tokens").is_some(),
+            "premise: it is a key"
+        );
+        assert_eq!(key_for_flag_spelling("max_prefill_tokens"), None);
+    }
+
+    #[test]
+    fn a_name_that_is_neither_gets_nothing() {
+        assert_eq!(key_for_flag_spelling("zzzz"), None);
+        assert_eq!(key_for_flag_spelling(""), None);
+    }
+}

--- a/crates/atlasctl-core/src/settings/mod.rs
+++ b/crates/atlasctl-core/src/settings/mod.rs
@@ -84,11 +84,22 @@ pub fn check_override(key: &str, value: &ScalarValue) -> Result<(), SettingError
     let Some(Disposition::Expose(spec)) = disposition(key) else {
         return Ok(());
     };
-    let sent = match value {
-        ScalarValue::Bool(b) => SettingValue::Bool(*b),
-        ScalarValue::Int(n) => SettingValue::Int(*n),
-        ScalarValue::Float(f) => SettingValue::Float(*f),
-        ScalarValue::Str(s) => SettingValue::Str(s.clone()),
+    // The wire bounds accept only what the WEB surface produces: `Str` for an
+    // Enum (a dropdown) and `Bool` for a toggle (a checkbox). The CLI types by
+    // YAML, so `-o block_size=16` arrives as Int and `-o enable_prefix_caching=1`
+    // as Int, and checking those verbatim refused values that are in the allowed
+    // set — `block_size` answered "must be one of: 8, 16, 32, 64" for 16.
+    //
+    // Coerced through the renderer's own `render` and `is_truthy`, so a bound
+    // can never refuse a value the command renderer would have accepted. That
+    // is the whole contract here: enforce the range, change nothing else.
+    let sent = match (&spec.bound, value) {
+        (BoundSpec::Enum(_), v) => SettingValue::Str(v.render()),
+        (BoundSpec::Toggle | BoundSpec::BoolValue, v) => SettingValue::Bool(v.is_truthy()),
+        (_, ScalarValue::Bool(b)) => SettingValue::Bool(*b),
+        (_, ScalarValue::Int(n)) => SettingValue::Int(*n),
+        (_, ScalarValue::Float(f)) => SettingValue::Float(*f),
+        (_, ScalarValue::Str(s)) => SettingValue::Str(s.clone()),
     };
     spec.bound.to_bound().check(key, &sent).map(|_| ())
 }

--- a/crates/atlasctl/src/commands/lifecycle.rs
+++ b/crates/atlasctl/src/commands/lifecycle.rs
@@ -4,7 +4,7 @@
 
 use crate::cli::{LogsArgs, StopArgs};
 use anyhow::{Result, bail};
-use atlasctl_core::docker::translate::LABEL_MANAGED;
+use atlasctl_core::docker::translate::{LABEL_MANAGED, LABEL_RECIPE};
 use atlasctl_core::io::{ProcessRunner, StdProcessRunner};
 use atlasctl_core::registry::RecipeRef;
 
@@ -15,10 +15,14 @@ fn container_of(recipe: &str) -> String {
 
 /// Stop one recipe, or everything atlasctl started.
 pub fn stop(args: &StopArgs) -> Result<()> {
-    if let Some(recipe) = &args.recipe {
-        known_recipe(recipe)?;
+    if args.all {
+        return stop_all_with(&StdProcessRunner);
     }
-    stop_with(&StdProcessRunner, args)
+    let Some(typed) = &args.recipe else {
+        bail!("name a recipe to stop, or pass --all");
+    };
+    let resolved = known_recipe(typed)?;
+    stop_recipe_with(&StdProcessRunner, typed, &resolved)
 }
 
 /// Refuse a name that is not a recipe at all.
@@ -32,29 +36,68 @@ pub fn stop(args: &StopArgs) -> Result<()> {
 /// `--all` skips this: its targets come from docker's own list of containers we
 /// label, so they need no catalogue entry. That is also the way out if a recipe
 /// is running from a registry that has since been removed.
-fn known_recipe(name: &str) -> Result<()> {
-    crate::commands::registry_set()?.resolve(&RecipeRef::parse(name))?;
-    Ok(())
+fn known_recipe(name: &str) -> Result<String> {
+    Ok(crate::commands::registry_set()?
+        .resolve(&RecipeRef::parse(name))?
+        .name)
 }
 
-/// `stop`, with the process runner injected so the failure paths are testable.
+/// The running containers this fleet launched FOR a recipe, by label.
 ///
-/// The interesting behaviour here is entirely about what happens when docker
-/// says no, and that cannot be reached through a real `docker` without one.
-fn stop_with(runner: &dyn ProcessRunner, args: &StopArgs) -> Result<()> {
-    let targets: Vec<String> = if args.all {
-        managed_containers(runner)?
-    } else {
-        let Some(recipe) = &args.recipe else {
-            bail!("name a recipe to stop, or pass --all");
-        };
-        vec![container_of(recipe)]
-    };
+/// Not `atlas-{typed}`: the container is named from the resolved recipe and a
+/// cluster launch appends `-rank{n}` (`docker::translate::container_name`), so
+/// guessing missed two everyday cases and — once "no such container" stopped
+/// being a failure — reported exit 0 while the model served:
+///
+///   * `run X --rank 0` makes `atlas-X-rank0`, and `run` prints
+///     `atlasctl stop X` as the way to stop it;
+///   * `stop @registry/X` guessed `atlas-@registry/X`.
+///
+/// The label is written by the launch itself, so it survives a registry being
+/// removed and needs no name arithmetic here.
+fn containers_for_recipe(runner: &dyn ProcessRunner, recipe: &str) -> Result<Vec<String>> {
+    let out = runner.run(&[
+        "docker".into(),
+        "ps".into(),
+        "--filter".into(),
+        format!("label={LABEL_RECIPE}={recipe}"),
+        "--format".into(),
+        "{{.Names}}".into(),
+    ])?;
+    Ok(out
+        .stdout
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(String::from)
+        .collect())
+}
 
+/// `stop --all`, with the runner injected so the failure paths are testable.
+fn stop_all_with(runner: &dyn ProcessRunner) -> Result<()> {
+    let targets = managed_containers(runner)?;
     if targets.is_empty() {
         println!("nothing running");
         return Ok(());
     }
+    stop_each(runner, targets)
+}
+
+/// `stop <recipe>`, found by label rather than by guessing a container name.
+///
+/// `typed` is what the operator wrote (for the message); `resolved` is the
+/// recipe's own name, which is what the launch wrote into the label.
+fn stop_recipe_with(runner: &dyn ProcessRunner, typed: &str, resolved: &str) -> Result<()> {
+    let found = containers_for_recipe(runner, resolved)?;
+    if found.is_empty() {
+        println!("{typed} is not running");
+        return Ok(());
+    }
+    stop_each(runner, found)
+}
+
+/// Stop each container, collecting real failures.
+fn stop_each(runner: &dyn ProcessRunner, targets: Vec<String>) -> Result<()> {
     // Failures are collected rather than only printed. Reporting each one to
     // stderr and then returning Ok meant `atlasctl stop --all` exited 0 with
     // every container still running — so a script that checked the exit code,
@@ -213,245 +256,4 @@ fn managed_containers(runner: &dyn ProcessRunner) -> Result<Vec<String>> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use atlasctl_core::docker::translate::LABEL_RECIPE;
-    use atlasctl_core::io::RecordingRunner;
-    use atlasctl_core::io::process::Output;
-
-    #[test]
-    fn managed_containers_are_found_by_label_not_by_name_guessing() {
-        let r = RecordingRunner::new();
-        r.push_result(Output {
-            status: 0,
-            stdout: "atlas-a\natlas-b\n".into(),
-            stderr: String::new(),
-        });
-        let names = managed_containers(&r).unwrap();
-        assert_eq!(names, ["atlas-a", "atlas-b"]);
-        let argv = &r.calls()[0];
-        assert!(
-            argv.contains(&format!("label={LABEL_MANAGED}=1")),
-            "must filter by our label so unrelated containers are never touched: {argv:?}"
-        );
-    }
-
-    #[test]
-    fn the_recipe_label_is_what_ties_a_container_back_to_its_recipe() {
-        assert_eq!(LABEL_RECIPE, "io.atlasctl.recipe");
-        assert_eq!(container_of("qwen3.6-27b-fp8"), "atlas-qwen3.6-27b-fp8");
-    }
-}
-
-#[cfg(test)]
-mod stop_tests {
-    use super::*;
-    use atlasctl_core::io::RecordingRunner;
-    use atlasctl_core::io::process::Output;
-
-    fn ok() -> Output {
-        Output {
-            status: 0,
-            stdout: String::new(),
-            stderr: String::new(),
-        }
-    }
-    fn fail(why: &str) -> Output {
-        Output {
-            status: 1,
-            stdout: String::new(),
-            stderr: why.into(),
-        }
-    }
-
-    /// The bug: every stop failed and the command exited 0, so a script that
-    /// checked the exit code — or an operator running this before a reboot —
-    /// was told the fleet was idle while every container was still up.
-    #[test]
-    fn a_failed_stop_is_a_failed_command() {
-        let r = RecordingRunner::new();
-        r.push_result(Output {
-            status: 0,
-            stdout: "atlas-a\natlas-b\n".into(),
-            stderr: String::new(),
-        });
-        r.push_result(fail("permission denied"));
-        // Was "no such container", which is now the one stderr that means the
-        // stop SUCCEEDED in effect. This test is about two real failures, so it
-        // needs two real failures.
-        r.push_result(fail("device or resource busy"));
-
-        let e = stop_with(
-            &r,
-            &StopArgs {
-                recipe: None,
-                all: true,
-            },
-        )
-        .expect_err("two failures must not report success");
-        let msg = e.to_string();
-        assert!(msg.contains("atlas-a") && msg.contains("atlas-b"), "{msg}");
-    }
-
-    /// A partial failure is still a failure, and the survivors are named —
-    /// "1 of 3 failed" sends the operator to check all three.
-    #[test]
-    fn a_partial_failure_names_only_what_did_not_stop() {
-        let r = RecordingRunner::new();
-        r.push_result(Output {
-            status: 0,
-            stdout: "atlas-a\natlas-b\n".into(),
-            stderr: String::new(),
-        });
-        r.push_result(ok());
-        r.push_result(fail("device busy"));
-
-        let e = stop_with(
-            &r,
-            &StopArgs {
-                recipe: None,
-                all: true,
-            },
-        )
-        .expect_err("one failure is a failure");
-        let msg = e.to_string();
-        assert!(msg.contains("atlas-b"), "{msg}");
-        assert!(
-            !msg.contains("atlas-a"),
-            "the one that stopped is not a problem: {msg}"
-        );
-    }
-
-    #[test]
-    fn stopping_everything_when_nothing_runs_is_success() {
-        let r = RecordingRunner::new();
-        r.push_result(Output {
-            status: 0,
-            stdout: String::new(),
-            stderr: String::new(),
-        });
-        stop_with(
-            &r,
-            &StopArgs {
-                recipe: None,
-                all: true,
-            },
-        )
-        .expect("nothing to do is fine");
-    }
-}
-
-#[cfg(test)]
-mod absent_tests {
-    use super::*;
-    use atlasctl_core::io::RecordingRunner;
-    use atlasctl_core::io::process::Output;
-
-    fn out(status: i32, stdout: &str, stderr: &str) -> Output {
-        Output {
-            status,
-            stdout: stdout.into(),
-            stderr: stderr.into(),
-        }
-    }
-
-    #[test]
-    fn the_daemons_two_spellings_of_gone_are_both_recognised() {
-        assert!(absent(
-            "Error response from daemon: No such container: atlas-x"
-        ));
-        assert!(absent("Error: no such object: atlas-x"));
-        // Real failures must not be swallowed by this.
-        assert!(!absent("permission denied"));
-        assert!(!absent("device or resource busy"));
-        assert!(!absent(""));
-    }
-
-    /// Stopping something that is not running is the state the operator asked
-    /// for. It used to print the daemon's own line and exit non-zero.
-    #[test]
-    fn stopping_a_recipe_that_is_not_running_is_not_a_failure() {
-        let r = RecordingRunner::new();
-        r.push_result(out(
-            1,
-            "",
-            "Error response from daemon: No such container: atlas-q",
-        ));
-        stop_with(
-            &r,
-            &StopArgs {
-                recipe: Some("q".into()),
-                all: false,
-            },
-        )
-        .expect("a recipe that is not running must not be an error");
-    }
-
-    /// Under --all this is a race: the container ended between the listing and
-    /// the stop. Equally not a failure, and it must not mask a real one.
-    #[test]
-    fn a_vanished_container_does_not_mask_a_real_failure() {
-        let r = RecordingRunner::new();
-        r.push_result(out(0, "atlas-a\natlas-b\n", ""));
-        r.push_result(out(
-            1,
-            "",
-            "Error response from daemon: No such container: atlas-a",
-        ));
-        r.push_result(out(1, "", "permission denied"));
-        let e = stop_with(
-            &r,
-            &StopArgs {
-                recipe: None,
-                all: true,
-            },
-        )
-        .expect_err("the real failure must still fail the command");
-        let msg = e.to_string();
-        assert!(msg.contains("atlas-b"), "names what actually failed: {msg}");
-        assert!(
-            !msg.contains("atlas-a"),
-            "must not blame the one that was already gone: {msg}"
-        );
-    }
-
-    #[test]
-    fn logs_for_a_recipe_never_started_here_says_so_and_never_streams() {
-        let r = RecordingRunner::new();
-        r.push_result(out(0, "\n", "")); // ps -a matched nothing
-        let e = logs_with(
-            &r,
-            &LogsArgs {
-                recipe: "q".into(),
-                tail: 100,
-                follow: false,
-            },
-        )
-        .expect_err("there is nothing to show");
-        let msg = e.to_string();
-        assert!(msg.contains("has not been started here"), "{msg}");
-        assert!(
-            msg.contains("atlasctl status"),
-            "points somewhere useful: {msg}"
-        );
-        assert_eq!(r.calls().len(), 1, "must not have run `docker logs` at all");
-    }
-
-    #[test]
-    fn logs_for_an_exited_container_still_stream() {
-        let r = RecordingRunner::new();
-        r.push_result(out(0, "atlas-q\n", "")); // ps -a found it, exited or not
-        r.push_result(out(0, "", ""));
-        logs_with(
-            &r,
-            &LogsArgs {
-                recipe: "q".into(),
-                tail: 100,
-                follow: false,
-            },
-        )
-        .expect("a stopped container still has logs worth reading");
-        let argv = &r.calls()[1];
-        assert!(argv.contains(&"logs".to_string()), "{argv:?}");
-    }
-}
+mod tests;

--- a/crates/atlasctl/src/commands/lifecycle.rs
+++ b/crates/atlasctl/src/commands/lifecycle.rs
@@ -21,8 +21,22 @@ pub fn stop(args: &StopArgs) -> Result<()> {
     let Some(typed) = &args.recipe else {
         bail!("name a recipe to stop, or pass --all");
     };
-    let resolved = known_recipe(typed)?;
-    stop_recipe_with(&StdProcessRunner, typed, &resolved)
+    match known_recipe(typed) {
+        Ok(resolved) => stop_recipe_with(&StdProcessRunner, typed, &resolved),
+        // The catalogue could not answer — an ambiguous bare name, a recipe
+        // whose YAML no longer parses, an unreadable registries.yaml. None of
+        // that should strand a container this fleet is running: the label was
+        // written at launch and does not depend on the catalogue still being
+        // readable. Only when nothing is running under that name does the
+        // resolve error stand, so a TYPO still gets its "Did you mean ...?".
+        Err(unresolved) => {
+            let found = containers_for_recipe(&StdProcessRunner, typed)?;
+            if found.is_empty() {
+                return Err(unresolved);
+            }
+            stop_each(&StdProcessRunner, found)
+        }
+    }
 }
 
 /// Refuse a name that is not a recipe at all.
@@ -246,6 +260,13 @@ fn managed_containers(runner: &dyn ProcessRunner) -> Result<Vec<String>> {
         "--format".into(),
         "{{.Names}}".into(),
     ])?;
+    // An empty list because docker did not ANSWER is not an idle fleet. Without
+    // this, `stop --all` against a stopped daemon printed "nothing running" and
+    // exited 0 — the exact lie the collected-failures logic above exists to
+    // prevent. `status()` ten lines down has always checked this.
+    if !out.success() {
+        bail!("`docker ps` failed: {}", out.stderr.trim());
+    }
     Ok(out
         .stdout
         .lines()

--- a/crates/atlasctl/src/commands/lifecycle/tests.rs
+++ b/crates/atlasctl/src/commands/lifecycle/tests.rs
@@ -244,3 +244,36 @@ mod absent_tests {
         assert!(argv.contains(&"logs".to_string()), "{argv:?}");
     }
 }
+
+mod daemon_down {
+    use super::super::*;
+    use atlasctl_core::io::RecordingRunner;
+    use atlasctl_core::io::process::Output;
+
+    /// An empty list because docker did not ANSWER is not an idle fleet.
+    /// `stop --all` against a stopped daemon printed "nothing running" and
+    /// exited 0 — the exact lie the collected-failure logic exists to prevent.
+    #[test]
+    fn stop_all_against_a_dead_daemon_is_not_an_idle_fleet() {
+        let r = RecordingRunner::new();
+        r.push_result(Output {
+            status: 1,
+            stdout: String::new(),
+            stderr: "Cannot connect to the Docker daemon at unix:///var/run/docker.sock".into(),
+        });
+        let e = stop_all_with(&r).expect_err("a daemon that never answered is not an empty fleet");
+        assert!(e.to_string().contains("docker ps"), "{e}");
+    }
+
+    /// A real empty answer still reads as empty.
+    #[test]
+    fn a_daemon_that_answers_with_nothing_is_an_idle_fleet() {
+        let r = RecordingRunner::new();
+        r.push_result(Output {
+            status: 0,
+            stdout: "\n".into(),
+            stderr: String::new(),
+        });
+        stop_all_with(&r).expect("an answered-but-empty listing is genuinely idle");
+    }
+}

--- a/crates/atlasctl/src/commands/lifecycle/tests.rs
+++ b/crates/atlasctl/src/commands/lifecycle/tests.rs
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Tests for `lifecycle`, moved out when the file reached the 500-line cap.
+//! Split verbatim: the module bodies are unchanged, only their `#[cfg(test)]`
+//! attributes moved to the one declaration in the parent.
+
+mod naming {
+    use super::super::*;
+    use atlasctl_core::docker::translate::LABEL_RECIPE;
+    use atlasctl_core::io::RecordingRunner;
+    use atlasctl_core::io::process::Output;
+
+    #[test]
+    fn managed_containers_are_found_by_label_not_by_name_guessing() {
+        let r = RecordingRunner::new();
+        r.push_result(Output {
+            status: 0,
+            stdout: "atlas-a\natlas-b\n".into(),
+            stderr: String::new(),
+        });
+        let names = managed_containers(&r).unwrap();
+        assert_eq!(names, ["atlas-a", "atlas-b"]);
+        let argv = &r.calls()[0];
+        assert!(
+            argv.contains(&format!("label={LABEL_MANAGED}=1")),
+            "must filter by our label so unrelated containers are never touched: {argv:?}"
+        );
+    }
+
+    #[test]
+    fn the_recipe_label_is_what_ties_a_container_back_to_its_recipe() {
+        assert_eq!(LABEL_RECIPE, "io.atlasctl.recipe");
+        assert_eq!(container_of("qwen3.6-27b-fp8"), "atlas-qwen3.6-27b-fp8");
+    }
+}
+
+mod stop_tests {
+    use super::super::*;
+    use atlasctl_core::io::RecordingRunner;
+    use atlasctl_core::io::process::Output;
+
+    fn ok() -> Output {
+        Output {
+            status: 0,
+            stdout: String::new(),
+            stderr: String::new(),
+        }
+    }
+    fn fail(why: &str) -> Output {
+        Output {
+            status: 1,
+            stdout: String::new(),
+            stderr: why.into(),
+        }
+    }
+
+    /// The bug: every stop failed and the command exited 0, so a script that
+    /// checked the exit code — or an operator running this before a reboot —
+    /// was told the fleet was idle while every container was still up.
+    #[test]
+    fn a_failed_stop_is_a_failed_command() {
+        let r = RecordingRunner::new();
+        r.push_result(Output {
+            status: 0,
+            stdout: "atlas-a\natlas-b\n".into(),
+            stderr: String::new(),
+        });
+        r.push_result(fail("permission denied"));
+        // Was "no such container", which is now the one stderr that means the
+        // stop SUCCEEDED in effect. This test is about two real failures, so it
+        // needs two real failures.
+        r.push_result(fail("device or resource busy"));
+
+        let e = stop_all_with(&r).expect_err("two failures must not report success");
+        let msg = e.to_string();
+        assert!(msg.contains("atlas-a") && msg.contains("atlas-b"), "{msg}");
+    }
+
+    /// A partial failure is still a failure, and the survivors are named —
+    /// "1 of 3 failed" sends the operator to check all three.
+    #[test]
+    fn a_partial_failure_names_only_what_did_not_stop() {
+        let r = RecordingRunner::new();
+        r.push_result(Output {
+            status: 0,
+            stdout: "atlas-a\natlas-b\n".into(),
+            stderr: String::new(),
+        });
+        r.push_result(ok());
+        r.push_result(fail("device busy"));
+
+        let e = stop_all_with(&r).expect_err("one failure is a failure");
+        let msg = e.to_string();
+        assert!(msg.contains("atlas-b"), "{msg}");
+        assert!(
+            !msg.contains("atlas-a"),
+            "the one that stopped is not a problem: {msg}"
+        );
+    }
+
+    #[test]
+    fn stopping_everything_when_nothing_runs_is_success() {
+        let r = RecordingRunner::new();
+        r.push_result(Output {
+            status: 0,
+            stdout: String::new(),
+            stderr: String::new(),
+        });
+        stop_all_with(&r).expect("nothing to do is fine");
+    }
+}
+
+mod absent_tests {
+    use super::super::*;
+    use atlasctl_core::io::RecordingRunner;
+    use atlasctl_core::io::process::Output;
+
+    fn out(status: i32, stdout: &str, stderr: &str) -> Output {
+        Output {
+            status,
+            stdout: stdout.into(),
+            stderr: stderr.into(),
+        }
+    }
+
+    #[test]
+    fn the_daemons_two_spellings_of_gone_are_both_recognised() {
+        assert!(absent(
+            "Error response from daemon: No such container: atlas-x"
+        ));
+        assert!(absent("Error: no such object: atlas-x"));
+        // Real failures must not be swallowed by this.
+        assert!(!absent("permission denied"));
+        assert!(!absent("device or resource busy"));
+        assert!(!absent(""));
+    }
+
+    /// Stopping something that is not running is the state the operator asked
+    /// for. It used to print the daemon's own line and exit non-zero.
+    #[test]
+    fn stopping_a_recipe_that_is_not_running_is_not_a_failure() {
+        let r = RecordingRunner::new();
+        r.push_result(out(0, "\n", "")); // the label query matched nothing
+        stop_recipe_with(&r, "q", "q").expect("a recipe that is not running must not be an error");
+        assert_eq!(r.calls().len(), 1, "must not have run `docker stop` at all");
+    }
+
+    /// The bug the label query exists to remove. A cluster launch names its
+    /// container `atlas-{recipe}-rank{n}`, and `run` tells the operator to stop
+    /// it with `atlasctl stop {recipe}`. Guessing `atlas-{recipe}` missed, the
+    /// daemon said "No such container", and — once that stopped being a failure
+    /// — stop reported exit 0 while the rank was still serving.
+    #[test]
+    fn a_rank_container_is_found_by_label_not_by_the_name_we_would_have_guessed() {
+        let r = RecordingRunner::new();
+        r.push_result(out(0, "atlas-q-rank0\n", ""));
+        r.push_result(out(0, "", ""));
+        stop_recipe_with(&r, "q", "q").expect("the rank container must be stopped");
+        let query = &r.calls()[0];
+        assert!(
+            query.contains(&format!("label={LABEL_RECIPE}=q")),
+            "found by label: {query:?}"
+        );
+        assert!(
+            r.calls()[1].contains(&"atlas-q-rank0".to_string()),
+            "stops the container that actually exists, not `atlas-q`: {:?}",
+            r.calls()[1]
+        );
+    }
+
+    /// A scoped ref resolves to the recipe's own name, so the label query is
+    /// asked the right question. Guessing produced `atlas-@reg/q`.
+    #[test]
+    fn a_scoped_ref_asks_for_the_recipes_own_name() {
+        let r = RecordingRunner::new();
+        r.push_result(out(0, "atlas-q\n", ""));
+        r.push_result(out(0, "", ""));
+        stop_recipe_with(&r, "@reg/q", "q").expect("stops");
+        assert!(
+            r.calls()[0].contains(&format!("label={LABEL_RECIPE}=q")),
+            "{:?}",
+            r.calls()[0]
+        );
+    }
+
+    /// Under --all this is a race: the container ended between the listing and
+    /// the stop. Equally not a failure, and it must not mask a real one.
+    #[test]
+    fn a_vanished_container_does_not_mask_a_real_failure() {
+        let r = RecordingRunner::new();
+        r.push_result(out(0, "atlas-a\natlas-b\n", ""));
+        r.push_result(out(
+            1,
+            "",
+            "Error response from daemon: No such container: atlas-a",
+        ));
+        r.push_result(out(1, "", "permission denied"));
+        let e = stop_all_with(&r).expect_err("the real failure must still fail the command");
+        let msg = e.to_string();
+        assert!(msg.contains("atlas-b"), "names what actually failed: {msg}");
+        assert!(
+            !msg.contains("atlas-a"),
+            "must not blame the one that was already gone: {msg}"
+        );
+    }
+
+    #[test]
+    fn logs_for_a_recipe_never_started_here_says_so_and_never_streams() {
+        let r = RecordingRunner::new();
+        r.push_result(out(0, "\n", "")); // ps -a matched nothing
+        let e = logs_with(
+            &r,
+            &LogsArgs {
+                recipe: "q".into(),
+                tail: 100,
+                follow: false,
+            },
+        )
+        .expect_err("there is nothing to show");
+        let msg = e.to_string();
+        assert!(msg.contains("has not been started here"), "{msg}");
+        assert!(
+            msg.contains("atlasctl status"),
+            "points somewhere useful: {msg}"
+        );
+        assert_eq!(r.calls().len(), 1, "must not have run `docker logs` at all");
+    }
+
+    #[test]
+    fn logs_for_an_exited_container_still_stream() {
+        let r = RecordingRunner::new();
+        r.push_result(out(0, "atlas-q\n", "")); // ps -a found it, exited or not
+        r.push_result(out(0, "", ""));
+        logs_with(
+            &r,
+            &LogsArgs {
+                recipe: "q".into(),
+                tail: 100,
+                follow: false,
+            },
+        )
+        .expect("a stopped container still has logs worth reading");
+        let argv = &r.calls()[1];
+        assert!(argv.contains(&"logs".to_string()), "{argv:?}");
+    }
+}


### PR DESCRIPTION
An adversarial audit of tonight's #96–#103 found **two HIGH issues, both introduced by me tonight**. Both fixed here, with the reproductions it gave.

## F1 — #102 refused values that are *in* the allowed set

```
atlasctl run <recipe> -o block_size=16
error: `block_size` must be one of: 8, 16, 32, 64        # 16 IS in the list

atlasctl run <recipe> -o enable_prefix_caching=1
error: `enable_prefix_caching` expected true or false     # worked before #102
```

`check_override` handed the CLI's YAML-typed scalar straight to `Bound::check`, which accepts **only `Str` for an Enum** and **only `Bool` for a toggle** — because the web surface sends what dropdowns and checkboxes produce. The CLI types `16` as `Int`, so enforcing the bound rejected the natural spelling of a legal value, with a message that contradicts itself.

Now coerced through `ScalarValue::render` and `is_truthy` — **the same functions the command renderer uses** — so a bound can never refuse a value the renderer would have accepted.

Checked against the last commit before #102: `block_size=16`, `enable_prefix_caching=1` and `=0` all render exactly as they did, and `=0` still omits the flag. Out-of-range values are still refused.

## F2 — #98 turned a wrong container-name guess into silent success

`container_of` guessed `atlas-{typed}`, but a container is named from the **resolved** recipe, and a cluster launch appends `-rank{n}`. Once "no such container" stopped being a failure, every missed guess became **exit 0 while the model was still serving**:

- `run X --rank 0` creates `atlas-X-rank0`, and `run.rs` **prints `atlasctl stop X`** as the way to stop it — which then reported "not running", exit 0.
- `stop @registry/X` guessed `atlas-@registry/X`.

A reboot script doing per-recipe stops on a two-node fleet was told the box was idle. Before #98 this failed loudly; #98 made it **quiet**, which is worse.

`stop <recipe>` now finds containers by `label=io.atlasctl.recipe=<resolved>`, which the launch itself writes — no name arithmetic, so ranks and scoped refs both work, and the label survives a registry being removed. This is the house pattern already asserted by `managed_containers_are_found_by_label_not_by_name_guessing`, which `stop` was quietly violating.

`stop` splits into `stop_all_with` / `stop_recipe_with` so no unreachable branch survives the old guess. Two tests added for exactly the reported cases, plus the not-running test **rewritten — it was passing for the wrong reason** after the change, because its pushed result was consumed by the label query rather than by `docker stop`.

## The cap

`lifecycle.rs` landed at exactly 500 lines: passes `-gt 500`, leaves no room. Tests moved to `lifecycle/tests.rs` verbatim (the house pattern) — 259 and 246 lines. Inner module renamed `naming`, since a `tests` inside `tests.rs` shadows its parent.

**Verification:** workspace green (11 suites, 119 in atlasctl), clippy and fmt clean, goldens unchanged, no file over the cap, and both findings re-checked end-to-end against the real binary and real docker.


---

## Update: the three lower audit findings that are bugs

Same review, three more findings — all defects rather than judgment calls. **F5** (whether `port`'s `Int(1024, 49151)` is physics or UI conservatism) is deliberately left alone: that one is a policy decision for a human.

### F3 — `stop --all` called a dead daemon an idle fleet

`managed_containers` never checked whether `docker ps` succeeded, so a stopped daemon produced an empty list and `stop --all` printed **"nothing running", exit 0**. That is precisely the lie the collected-failure logic four lines below exists to prevent — *"told the fleet was idle when it was not"* — and `status()` ten lines down has always checked it.

Pre-existing rather than introduced by #98 (verified against `a023034~1`), but it sits inside the behaviour #98 claimed to fix.

### F4 — a container could be stranded by the *catalogue*

#98 resolves a name before stopping so a typo isn't reported as "not running". But resolution can fail for reasons unrelated to the running container: a bare name now ambiguous across two remotes, a recipe whose YAML no longer parses, an unreadable `registries.yaml`. `--all` was the escape — which on a shared box stops **everything**.

The label is written at **launch** and doesn't depend on the catalogue still being readable, so an unresolvable name now falls back to the label query. Only when nothing is running under that name does the resolve error stand — so a typo still gets its suggestions and still exits 1. Verified.

### F6 — a valid key could be told it is a flag spelling

`max_prefill_tokens` is a real key **and** the flag spelling of `max_num_batched_tokens` (`--max-prefill-tokens`). The `s.key != typed` guard only skipped the spec whose *own* key matched, so it never covered this; the function is `pub`, so the trap was latent for the next caller. Now guarded on `lookup(typed).is_none()` — reverting to the old guard fails the new test.

**Verification:** four more tests, each verified to run by name and to fail for its stated reason. Workspace green (11 suites, **121** in atlasctl), clippy/fmt clean, goldens unchanged, no file over the cap.
