### PR TITLE
fix(settings): port is the TCP domain, not the IANA registered range

### DIFF
--- a/crates/atlasctl-agent/src/session/tests.rs
+++ b/crates/atlasctl-agent/src/session/tests.rs
@@ -268,7 +268,10 @@ fn an_out_of_range_setting_blocks_the_launch() {
     let out = s.handle(ClientMsg::Launch {
         id: 1,
         recipe: id(REAL),
-        settings: set(&[("port", SettingValue::Int(1))]),
+        // 1 was the example here until `port`'s bound was corrected to the
+        // real TCP domain; it is a valid port. This test is about an
+        // out-of-range value, so it needs one that actually is.
+        settings: set(&[("port", SettingValue::Int(99_999))]),
         on: None,
     });
     assert!(matches!(

--- a/crates/atlasctl-core/src/settings/table.rs
+++ b/crates/atlasctl-core/src/settings/table.rs
@@ -49,10 +49,21 @@ const fn e(
 #[rustfmt::skip]
 pub static EXPOSED: &[(&str, Disposition)] = &[
     // --- Server -------------------------------------------------------------
+    // `port` is the whole TCP domain, not the IANA registered range. 1024-49151
+    // was a sensible min/max for a form control, and it read as a bound; it was
+    // not one. A bound in this table states the values on which the tool is
+    // CORRECT, and 80, 443 and 65000 all are — sub-1024 binds fine when docker
+    // is root-capable, which it is here, and 49152+ is legal TCP merely
+    // conventioned for ephemeral allocation. Enforcing it on `-o` therefore
+    // removed capability rather than preventing a mistake. 0 is excluded: "let
+    // the kernel choose" is meaningless for a port the operator must dial.
+    //
+    // Contrast `gpu_memory_utilization`'s Float(0.10, 0.95) in memory.rs, which
+    // IS a domain: no deployment of this tool on GB10 is correct at 5.
     (
         "port",
         e(
-            Int(1024, 49151),
+            Int(1, 65535),
             "Port",
             "Port the model server listens on.",
             None,

--- a/crates/atlasctl-core/src/settings/tests.rs
+++ b/crates/atlasctl-core/src/settings/tests.rs
@@ -130,8 +130,11 @@ fn valid_settings_pass_through_typed() {
 fn every_problem_is_reported_at_once() {
     // Fixing a form one rejection at a time is a bad experience and encourages
     // people to stop reading the errors.
+    // `port: 1` used to be a third problem here. It is a real TCP port and the
+    // bound was widened to the actual domain, so the case now uses a value that
+    // genuinely is not one.
     let err = validate(&req(&[
-        ("port", SettingValue::Int(1)),
+        ("port", SettingValue::Int(99_999)),
         ("cache_dir", SettingValue::Str("/tmp".into())),
         ("nope", SettingValue::Int(1)),
     ]))
@@ -229,9 +232,8 @@ fn a_value_outside_the_declared_range_is_refused() {
         .expect_err("5 is not a fraction");
     assert!(e.to_string().contains("0.95"), "names the ceiling: {e}");
 
-    let e =
-        super::check_override("port", &ScalarValue::Int(99_999)).expect_err("above the port range");
-    assert!(e.to_string().contains("49151"), "{e}");
+    let e = super::check_override("port", &ScalarValue::Int(99_999)).expect_err("not a TCP port");
+    assert!(e.to_string().contains("65535"), "{e}");
 }
 
 #[test]
@@ -240,8 +242,8 @@ fn values_inside_the_range_pass_including_the_endpoints() {
         super::check_override("gpu_memory_utilization", &ScalarValue::Float(v))
             .unwrap_or_else(|e| panic!("{v} is inside the declared bound: {e}"));
     }
-    super::check_override("port", &ScalarValue::Int(1024)).expect("lower endpoint");
-    super::check_override("port", &ScalarValue::Int(49_151)).expect("upper endpoint");
+    super::check_override("port", &ScalarValue::Int(1)).expect("lower endpoint");
+    super::check_override("port", &ScalarValue::Int(65_535)).expect("upper endpoint");
 }
 
 /// A local shell is not a webpage. Refusing these here would stop someone
@@ -252,4 +254,31 @@ fn a_denied_or_unknown_key_is_not_this_functions_business() {
         .expect("denied keys are a remote-client rule, not a local one");
     super::check_override("nosuchkey", &ScalarValue::Int(1))
         .expect("unknown keys are warned about by the launcher, not refused here");
+}
+
+/// A bound states where the tool is CORRECT, not what a form should suggest.
+/// `port` was declared as the IANA registered range, so once #102 enforced
+/// bounds on `-o`, `-o port=80` — legitimate when docker is root-capable —
+/// was refused for the first time.
+#[test]
+fn the_port_bound_is_the_tcp_domain_not_the_registered_range() {
+    for p in [1_i64, 80, 443, 1024, 8000, 49151, 49152, 65000, 65535] {
+        super::check_override("port", &ScalarValue::Int(p))
+            .unwrap_or_else(|e| panic!("port {p} is a real port: {e}"));
+    }
+    for p in [0_i64, 65536, -1] {
+        super::check_override("port", &ScalarValue::Int(p)).expect_err("outside the TCP domain");
+    }
+}
+
+/// The bound that is genuinely protective must keep refusing. Widening `port`
+/// is a data fix, not a retreat from enforcing bounds.
+#[test]
+fn the_utilisation_bound_still_refuses_what_would_wedge_the_box() {
+    super::check_override("gpu_memory_utilization", &ScalarValue::Float(5.0))
+        .expect_err("5 is not a fraction");
+    super::check_override("gpu_memory_utilization", &ScalarValue::Float(1.0))
+        .expect_err("1.0 leaves nothing for anything else");
+    super::check_override("gpu_memory_utilization", &ScalarValue::Float(0.85))
+        .expect("the value the shipped recipes use");
 }


### PR DESCRIPTION
Once #102 started enforcing declared bounds on `-o`, this became the first thing to refuse a value that had always worked:

| `-o port=` | before | after #102 |
|---|---|---|
| 80 | renders | **REFUSED** |
| 443 | renders | **REFUSED** |
| 65000 | renders | **REFUSED** |

`Int(1024, 49151)` is the IANA user/registered range — a sensible `min`/`max` for a form control, and it *read* as a bound. It was not one. A bound in this table states the values on which the tool is **correct**, and 80, 443 and 65000 all are: sub-1024 binds fine when docker is root-capable (it is here), and 49152+ is legal TCP merely conventioned for ephemeral allocation. Enforcing it removed capability rather than preventing a mistake.

## The mechanism was not at fault; the data was

Two consumers share this table — a web form and a local shell — and a bound has to mean one thing to both: **the valid domain of the value**. Contrast `gpu_memory_utilization`'s `Float(0.10, 0.95)`, which *is* a domain: no deployment on GB10 is correct at 5. That one keeps refusing — verified.

The alternative considered and rejected was a `safety` vs `form` distinction in the spec so the CLI could ignore the latter. That would encode *"a bound means different things depending on who asks"* into a table whose whole discipline is one authoritative statement per setting — and a read of all ~31 exposed entries found **no other bound** that fails the test *"is any legal deployment correct outside this?"*. The new concept would have existed to serve one key.

`0` stays excluded: "let the kernel pick" is meaningless for a port the operator has to dial.

## Two tests updated, not weakened

`every_problem_is_reported_at_once` and the agent's `an_out_of_range_setting_blocks_the_launch` both used `port: 1` as their out-of-range example. That is a real port; their **intent** is unchanged, so each now uses 99999. Noted in place.

**Verified end-to-end:** 80/443/65000 render, 99999 refused, `gpu_memory_utilization=5` still refused. Workspace green (11 suites), clippy/fmt clean, goldens unchanged.