### PR TITLE
fix(run): the weights pre-flight must not block a launch that brings its own

### DIFF
--- a/crates/atlasctl/src/commands/run.rs
+++ b/crates/atlasctl/src/commands/run.rs
@@ -99,7 +99,15 @@ pub fn run(args: &RunArgs) -> Result<()> {
     // multi-gigabyte pull to reach the Hub library's own cache-miss message,
     // inside a container that has already exited, reachable only via
     // `atlasctl logs`.
-    if let Some(dir) = hfcache::hub_dir(Path::new(&host.hf_cache_dir), &recipe.model)
+    //
+    // Unless the launch brings its own weights: `model_from_path` points the
+    // engine at a directory, and then the Hub cache is not consulted at all, so
+    // refusing on a cache miss would block a launch that was going to work.
+    // Read off the rendered argv rather than the override map, because a recipe
+    // can set it in `defaults:` and never mention it on the command line.
+    let brings_own_weights = plan.docker.command.iter().any(|a| a == "--model-from-path");
+    if !brings_own_weights
+        && let Some(dir) = hfcache::hub_dir(Path::new(&host.hf_cache_dir), &recipe.model)
         && !dir.exists()
     {
         bail!(


### PR DESCRIPTION
#100 refuses a launch whose model is not in the host HF cache, because the container runs with `HF_HUB_OFFLINE=1` and cannot fetch it. Right for the ordinary case, wrong for the one where the operator supplies the weights directly:

```
atlasctl run <recipe> -o model_from_path=/weights/mine
error: `<recipe>` needs the model `...`, which is not in ~/.cache/huggingface
```

`model_from_path` points the engine at a directory and the Hub cache is never consulted, so the check refused a launch that was going to work.

It is reachable **precisely because** the CLI deliberately does not apply the DENY list (that is a remote-client rule): `model_from_path` is denied to a webpage and available to a local operator, which is the intended asymmetry. My #100 did not account for it.

The decision reads the **rendered argv**, not the override map — a recipe can set the key in its own `defaults:` block and never mention it on the command line, and the argv is what will actually run.

**Verified three ways against the real binary:**

| case | result |
|---|---|
| `-o model_from_path=/tmp/whatever` | renders `--model-from-path /tmp/whatever`, never reaches the cache check |
| same recipe, no override | still refused for the missing model |
| a recipe whose model *is* cached | unaffected |

Workspace green (11 suites), clippy/fmt clean, goldens unchanged.