### PR TITLE
feat(doctor): report a disk with no room for an image and a model

### DIFF
--- a/crates/atlasctl/src/commands/doctor.rs
+++ b/crates/atlasctl/src/commands/doctor.rs
@@ -17,7 +17,12 @@ pub fn run() -> Result<()> {
     problems += check_docker();
     // The three that were added after the fact, each one a failure somebody hit
     // during onboarding and diagnosed from an error naming the wrong thing.
-    for f in [check_config_dir(), check_agent(), check_reachable()] {
+    for f in [
+        check_config_dir(),
+        check_agent(),
+        check_reachable(),
+        check_disk(),
+    ] {
         println!("{}", f.line);
         problems += usize::from(f.problem);
     }
@@ -122,6 +127,33 @@ fn which(name: &str) -> Option<std::path::PathBuf> {
 }
 
 /// Where the agent keeps its identity, its pins and its browser token.
+/// Free space where docker and the model cache live.
+///
+/// Read with `df -Pk`: POSIX output is one line per filesystem with a fixed
+/// column order, which `df` without `-P` does not guarantee — a long device
+/// name wraps and the figure moves to the next line.
+///
+/// A machine we cannot measure is reported as ok rather than as a problem: an
+/// unreadable `df` says nothing about whether there is room, and doctor now
+/// exits non-zero on a problem, so guessing here would fail a healthy box.
+fn check_disk() -> Finding {
+    let out = StdProcessRunner.run(&["df".into(), "-Pk".into(), ".".into()]);
+    let free_kb = out.ok().and_then(|o| {
+        if !o.success() {
+            return None;
+        }
+        o.stdout
+            .lines()
+            .nth(1)
+            .and_then(|l| l.split_whitespace().nth(3).map(str::to_owned))
+            .and_then(|k| k.parse::<u64>().ok())
+    });
+    match free_kb {
+        Some(kb) => doctor_checks::disk_space(kb.saturating_mul(1024), "."),
+        None => doctor_checks::disk_unknown(),
+    }
+}
+
 fn check_config_dir() -> Finding {
     match crate::hostinfo::usable_config_dir() {
         Ok(dir) => doctor_checks::config_dir(ConfigDirState::Writable(dir.display().to_string())),

--- a/crates/atlasctl/src/commands/doctor_checks.rs
+++ b/crates/atlasctl/src/commands/doctor_checks.rs
@@ -44,6 +44,50 @@ impl Finding {
     }
 }
 
+/// Is there room to pull an image and a model?
+///
+/// A launch pulls the runtime image and, when the weights are not already
+/// cached, the model itself. Measured on a GB10 box: `avarok/atlas-gb10` is
+/// 2.85 GB and the smallest model in the shipped catalogue is 21.8 GB, so
+/// below their sum a launch cannot succeed. What the operator sees instead is
+/// a docker pull error, or a download that stops partway and leaves a cache
+/// entry that looks present — neither of which mentions the disk.
+///
+/// An absolute floor, deliberately not a percentage. 5% of a 3.7 TB array is
+/// 185 GB, which would call a box with 172 GB free — comfortably enough for
+/// any launch here — a problem.
+pub fn disk_space(free_bytes: u64, path: &str) -> Finding {
+    const FLOOR: u64 = 25 * 1024 * 1024 * 1024;
+    let gb = free_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
+    if free_bytes >= FLOOR {
+        return Finding::ok("disk", &format!("{gb:.0} GB free on {path}"));
+    }
+    Finding::bad(
+        "disk",
+        &format!(
+            "only {gb:.1} GB free on {path}. The runtime image is ~3 GB and the \
+             smallest model in the catalogue is ~22 GB, so a launch that has to \
+             pull either will fail — usually with a message about docker or a \
+             truncated download, not about space."
+        ),
+        &[
+            "atlasctl status            # stop anything you are not using",
+            "docker image prune -a      # reclaim images no container needs",
+            "du -sh ~/.cache/huggingface/hub/models--*   # then delete a model you can re-pull",
+        ],
+    )
+}
+
+/// When `df` could not be read at all.
+///
+/// Reported as ok, not as a problem. An unreadable `df` says nothing about
+/// whether there is room, and `doctor` exits non-zero on a problem — so
+/// guessing here would fail a perfectly healthy machine.
+#[must_use]
+pub fn disk_unknown() -> Finding {
+    Finding::ok("disk", "not measurable here")
+}
+
 /// Can this machine keep its identity and pins?
 ///
 /// The failure this catches: the config directory exists but is not writable by
@@ -220,5 +264,52 @@ mod tests {
         assert!(!f.problem);
         assert!(f.line.contains("10.10.10.9"), "{}", f.line);
         assert!(f.line.contains("1 more"), "{}", f.line);
+    }
+}
+
+#[cfg(test)]
+mod disk_tests {
+    use super::*;
+    const GB: u64 = 1024 * 1024 * 1024;
+
+    #[test]
+    fn a_box_with_room_for_an_image_and_a_model_is_fine() {
+        for free in [25 * GB, 172 * GB, 4000 * GB] {
+            let f = disk_space(free, "/");
+            assert!(!f.problem, "{} GB should be fine: {}", free / GB, f.line);
+        }
+    }
+
+    /// The floor is where it is because of measured sizes, not a round number:
+    /// a 2.85 GB image plus a 21.8 GB model is 24.65 GB.
+    #[test]
+    fn below_an_image_plus_the_smallest_model_is_a_problem() {
+        for free in [0, GB, 24 * GB] {
+            let f = disk_space(free, "/");
+            assert!(
+                f.problem,
+                "{} GB should be a problem: {}",
+                free / GB,
+                f.line
+            );
+        }
+    }
+
+    #[test]
+    fn the_message_says_what_to_do_and_names_the_path() {
+        let f = disk_space(2 * GB, "/mnt/data");
+        assert!(f.line.contains("/mnt/data"), "{}", f.line);
+        assert!(f.line.contains("2.0 GB"), "the actual figure: {}", f.line);
+        assert!(
+            f.line.contains("docker image prune"),
+            "a remedy: {}",
+            f.line
+        );
+    }
+
+    /// A percentage rule would call this box — 172 GB free, ample — a problem.
+    #[test]
+    fn a_large_but_full_looking_array_is_judged_on_free_space_not_percent() {
+        assert!(!disk_space(172 * GB, "/").problem);
     }
 }


### PR DESCRIPTION
`doctor` checked docker, the config directory, the agent, the network and sparkrun — **not** the one resource whose exhaustion is hardest to read from the symptom. A full disk surfaces as a docker pull error, or as a model download that stops partway and leaves a cache entry that *looks* present. Neither says "disk".

Not hypothetical: this box ran to **96% full** during a campaign tonight, and freeing it meant deleting a 157 GB checkpoint.

```
disk:     ok (171 GB free on .)
```
```
disk:     PROBLEM — only 2.0 GB free on /mnt/data. The runtime image is ~3 GB and the
          smallest model in the catalogue is ~22 GB, so a launch that has to pull either
          will fail — usually with a message about docker or a truncated download, not
          about space.
          atlasctl status            # stop anything you are not using
          docker image prune -a      # reclaim images no container needs
```

## The threshold is measured, not round

On a GB10 box `avarok/atlas-gb10` is **2.85 GB** and the smallest model in the shipped catalogue is **21.8 GB** — their sum, the least a cold launch can need, is 24.65 GB. The floor is **25 GiB**.

## Deliberately absolute, not a percentage

5% of a 3.7 TB array is 185 GB, which would call this machine 172 GB free — comfortably enough for any launch here — a problem. Since #97 made `doctor` exit non-zero, **a rule that fails healthy boxes teaches people to ignore the tool.** A test pins exactly that case.

For the same reason an unreadable `df` reports **ok**, not PROBLEM: it says nothing about whether there is room, and guessing would fail a healthy machine.

`df -Pk`, not `df -k`: POSIX output guarantees one line per filesystem in fixed column order. Without `-P` a long device name wraps and the figure moves to the next line.

**Verification:** the decision is a pure function over a byte count, tested at the boundary (24 GB problem, 25 GB fine) and at the percentage-rule trap. Verified live on this box. Workspace green (11 suites), clippy/fmt clean, goldens unchanged.