### PR TITLE
fix(registry): a scope should not cost the operator the suggestion

### DIFF
--- a/crates/atlasctl-core/src/registry/mod.rs
+++ b/crates/atlasctl-core/src/registry/mod.rs
@@ -62,13 +62,28 @@ impl RecipeRef {
 /// Why a reference could not be resolved.
 #[derive(Debug, thiserror::Error)]
 pub enum ResolveError {
+    /// No registry by that name at all.
+    ///
+    /// Distinct from `NotFound`, which says the registry exists and does not
+    /// carry the recipe. Reporting an unknown registry as the latter sent an
+    /// operator looking for a recipe when the typo was in the scope.
+    #[error("no registry named `{registry}`{}", suggestion(.close))]
+    NoSuchRegistry {
+        /// The registry that was named.
+        registry: String,
+        /// Registries that are close to it, if any.
+        close: Vec<String>,
+    },
+
     /// No recipe of that name in that registry.
-    #[error("no recipe named `{name}` in registry `{registry}`")]
+    #[error("no recipe named `{name}` in registry `{registry}`{}", suggestion(.close))]
     NotFound {
         /// The recipe name.
         name: String,
         /// The registry searched.
         registry: String,
+        /// Similar names in that registry, if any.
+        close: Vec<String>,
     },
 
     /// No recipe of that name anywhere.
@@ -162,24 +177,36 @@ impl RegistrySet {
     /// Resolve a reference to a loaded recipe.
     pub fn resolve(&self, r#ref: &RecipeRef) -> Result<Recipe, ResolveError> {
         match r#ref {
+            // A scoped ref gets the same near-miss list a bare one does. It
+            // did not, so `@atlas/qwen3.8-27b-nvfp4-unsloh` was refused flatly
+            // while the identical bare typo was answered with the recipe it
+            // meant — the scope should not cost the operator the suggestion.
             RecipeRef::Scoped { registry, name } if registry == BUILTIN => self
                 .load_builtin(name)
                 .ok_or_else(|| ResolveError::NotFound {
                     name: name.clone(),
                     registry: registry.clone(),
+                    close: self.close_names(name),
                 })?,
             RecipeRef::Scoped { registry, name } => {
                 let reg = self
                     .remotes
                     .iter()
                     .find(|r| &r.name == registry)
-                    .ok_or_else(|| ResolveError::NotFound {
-                        name: name.clone(),
+                    // The registry itself is missing — say so. Reporting this
+                    // as "no recipe named X in registry Y" claims Y exists.
+                    .ok_or_else(|| ResolveError::NoSuchRegistry {
                         registry: registry.clone(),
+                        close: crate::nearest::nearest(
+                            registry,
+                            std::iter::once(BUILTIN.to_string())
+                                .chain(self.remotes.iter().map(|r| r.name.clone())),
+                        ),
                     })?;
                 reg.load(name).ok_or_else(|| ResolveError::NotFound {
                     name: name.clone(),
                     registry: registry.clone(),
+                    close: crate::nearest::nearest(name, reg.recipe_names()),
                 })?
             }
             RecipeRef::Bare(name) => return self.resolve_bare(name),
@@ -214,6 +241,7 @@ impl RegistrySet {
                 .ok_or_else(|| ResolveError::NotFound {
                     name: name.to_string(),
                     registry: one.name.clone(),
+                    close: crate::nearest::nearest(name, one.recipe_names()),
                 })?
                 .map_err(ResolveError::from),
             many => Err(ResolveError::Ambiguous {

--- a/crates/atlasctl-core/src/registry/tests.rs
+++ b/crates/atlasctl-core/src/registry/tests.rs
@@ -299,3 +299,61 @@ fn at_most_three_names_are_offered() {
         assert!(reg.close_names(probe).len() <= 3, "{probe}");
     }
 }
+
+// ---- scoped refs ------------------------------------------------------------
+//
+// A scope should cost the operator nothing. Before this, `@atlas/<typo>` was
+// refused flatly while the identical BARE typo was answered with the recipe it
+// meant, and a misspelt REGISTRY was reported as "no recipe named X in registry
+// Y" — which claims Y exists and sends someone looking for the wrong thing.
+
+#[test]
+fn a_scoped_typo_gets_the_same_suggestion_as_a_bare_one() {
+    let set = RegistrySet::builtin_only();
+    let bare = set
+        .resolve(&RecipeRef::parse("qwen3.8-27b-nvfp4-unsloh"))
+        .expect_err("refused")
+        .to_string();
+    let scoped = set
+        .resolve(&RecipeRef::parse("@atlas/qwen3.8-27b-nvfp4-unsloh"))
+        .expect_err("refused")
+        .to_string();
+    assert!(bare.contains("Did you mean"), "{bare}");
+    assert!(
+        scoped.contains("Did you mean"),
+        "the scope cost the hint: {scoped}"
+    );
+    assert!(
+        scoped.contains("qwen3.8-27b-nvfp4-unsloth"),
+        "and it must name the recipe meant: {scoped}"
+    );
+}
+
+#[test]
+fn an_unknown_registry_is_not_reported_as_a_missing_recipe() {
+    let e = RegistrySet::builtin_only()
+        .resolve(&RecipeRef::parse("@nosuch/foo"))
+        .expect_err("refused")
+        .to_string();
+    assert!(e.contains("no registry named `nosuch`"), "{e}");
+    assert!(
+        !e.contains("no recipe named"),
+        "claiming the registry exists is the bug: {e}"
+    );
+}
+
+#[test]
+fn a_near_miss_registry_is_suggested() {
+    let e = RegistrySet::builtin_only()
+        .resolve(&RecipeRef::parse("@atlaz/foo"))
+        .expect_err("refused")
+        .to_string();
+    assert!(e.contains("Did you mean atlas?"), "{e}");
+}
+
+#[test]
+fn a_correct_scoped_ref_still_resolves() {
+    RegistrySet::builtin_only()
+        .resolve(&RecipeRef::parse("@atlas/qwen3.8-27b-nvfp4-unsloth"))
+        .expect("the qualified form is the documented one");
+}


### PR DESCRIPTION
Two things a scoped ref got wrong, both found by running the command.

## The suggestion vanished behind a scope

```
atlasctl recipe show qwen3.8-27b-nvfp4-unsloh
  -> no recipe named `...`. Did you mean qwen3.8-27b-nvfp4-unsloth, ...?

atlasctl recipe show @atlas/qwen3.8-27b-nvfp4-unsloh
  -> no recipe named `...` in registry `atlas`          (nothing else)
```

The identical typo was answered with the recipe it meant in one form and refused flatly in the other. Scoped refs now carry the same near-miss list, from the same `nearest` the bare path uses — for the builtin registry, and for a remote using that remote own names as candidates.

## An unknown registry was reported as a missing recipe

```
atlasctl recipe show @nosuch/foo
  -> no recipe named `foo` in registry `nosuch`
```

That claims `nosuch` **exists** and does not have `foo`. It does not exist at all, and the message sends an operator looking for a recipe when the typo was in the scope.

```
@nosuch/foo  -> no registry named `nosuch`
@atlaz/foo   -> no registry named `atlaz`. Did you mean atlas?
```

`NotFound` keeps its meaning — the registry exists and does not carry the recipe — which is now true whenever it is raised.

**Verification:** four tests, each verified to run by name, including that a **correct scoped ref still resolves**. The qualified form is the one the docs recommend, so breaking it while improving its errors would be the worse trade. Workspace green (11 suites), clippy/fmt clean, goldens unchanged.