### PR TITLE
fix(agent): make the installer an upgrader, and a starter

### DIFF
--- a/crates/atlasctl-agent/src/server.rs
+++ b/crates/atlasctl-agent/src/server.rs
@@ -98,9 +98,20 @@ pub async fn serve(state: Arc<AgentState>, port: u16) -> Result<()> {
 /// If the port is taken.
 pub async fn bind(port: u16) -> Result<tokio::net::TcpListener> {
     let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
-    let listener = tokio::net::TcpListener::bind(addr)
-        .await
-        .with_context(|| format!("could not bind {addr} — is another agent already running?"))?;
+    let listener = tokio::net::TcpListener::bind(addr).await.with_context(|| {
+        // Naming the remedy, not just the symptom. This is what an
+        // operator sees after `curl … | sh` on a machine that already had
+        // an agent: the installer could not bootstrap the service (the
+        // label was loaded), suggested `agent install` to find out why,
+        // and that reproduced the same line — so `agent run` by hand was
+        // the third dead end in a row.
+        format!(
+            "could not bind {addr} — an agent is already listening there.\n\
+                 \x20 If you meant to upgrade it, `atlasctl agent install` now replaces\n\
+                 \x20 a running service in place. If you started one by hand, stop that\n\
+                 \x20 process first, or pass `--port` to run a second one alongside it."
+        )
+    })?;
 
     let bound = listener.local_addr()?;
     debug_assert!(

--- a/crates/atlasctl/src/commands/service.rs
+++ b/crates/atlasctl/src/commands/service.rs
@@ -51,8 +51,20 @@ pub fn install(args: &crate::cli::AgentInstallArgs) -> Result<()> {
         // operator ends up pairing a browser against a five-second crash loop.
         println!("agent installed, but it is NOT running");
         println!("  the unit is enabled and the supervisor accepted it, so this is");
-        println!("  the agent exiting at startup. See why with:");
-        println!("    journalctl --user -u atlasctl-agent -n 50");
+        println!("  the agent exiting at startup. The usual cause is the port:");
+        println!("    an agent started by hand still holds {}.", args.port);
+        println!("  See why with:");
+        match done.kind {
+            // `journalctl` does not exist on macOS, and it was the only thing
+            // offered here — so the one diagnostic an operator was handed
+            // failed too, on the platform where this path is most likely.
+            crate::service::plan::ServiceKind::Launchd => {
+                println!("    tail -n 50 ~/Library/Logs/atlasctl-agent.log");
+            }
+            crate::service::plan::ServiceKind::Systemd => {
+                println!("    journalctl --user -u atlasctl-agent -n 50");
+            }
+        }
     }
     println!("  unit: {}", done.unit_path.display());
     println!("  port: {}", args.port);

--- a/crates/atlasctl/src/service.rs
+++ b/crates/atlasctl/src/service.rs
@@ -73,6 +73,18 @@ pub fn install(
     fs.create_dir_all(parent)?;
     fs.write_atomic(&p.unit_path, &p.unit_body)?;
 
+    // Best-effort, and BEFORE activation: on macOS this unloads an agent that
+    // is already bootstrapped, so installing over one upgrades it instead of
+    // dying on `Bootstrap failed: 5: Input/output error`. It exits non-zero on
+    // a first install, when there is nothing to unload, which is why it cannot
+    // be an `activate` step.
+    let mut skipped = Vec::new();
+    for argv in &p.pre_activate {
+        if !matches!(runner.run(argv), Ok(out) if out.success()) {
+            // Nothing to say: on a first install this is the normal path.
+        }
+    }
+
     let mut running = true;
     for argv in &p.activate {
         let out = runner.run(argv)?;
@@ -88,7 +100,6 @@ pub fn install(
         }
     }
 
-    let mut skipped = Vec::new();
     for argv in &p.best_effort {
         match runner.run(argv) {
             Ok(out) if out.success() => {}

--- a/crates/atlasctl/src/service/plan.rs
+++ b/crates/atlasctl/src/service/plan.rs
@@ -125,6 +125,19 @@ pub struct ServicePlan {
     pub unit_path: PathBuf,
     /// Its contents.
     pub unit_body: String,
+    /// Commands to run BEFORE activation, whose failure is expected and
+    /// ignored, in order.
+    ///
+    /// This exists for one shape: making activation idempotent. `launchctl
+    /// bootstrap` refuses a label that is already loaded, with
+    /// `Bootstrap failed: 5: Input/output error` — a message that names neither
+    /// the cause nor the remedy — so re-running the installer to UPGRADE an
+    /// agent failed at the last step, and `atlasctl agent install`, which the
+    /// installer suggests as the way to see why, reproduced the same line.
+    ///
+    /// Separate from `best_effort` because ORDER is the whole point: a teardown
+    /// that runs after the thing it was meant to make room for is useless.
+    pub pre_activate: Vec<Vec<String>>,
     /// Commands to run after writing it, in order.
     pub activate: Vec<Vec<String>>,
     /// The command that answers "is it actually running now?".
@@ -222,6 +235,9 @@ fn systemd(agent: &AgentInvocation, home: &Path) -> ServicePlan {
         // A headless box logs nobody in, so without lingering the service stops
         // the moment the installing session ends. It is also exactly the call
         // that is unavailable in a container, so it cannot be required.
+        // systemd needs none: `enable --now` is already idempotent, and
+        // re-running it over a live unit restarts it with the new binary.
+        pre_activate: Vec::new(),
         best_effort: vec![vec!["loginctl".to_owned(), "enable-linger".to_owned()]],
         deactivate: vec![sc(&["disable", "--now", &unit])],
     }
@@ -271,6 +287,15 @@ fn launchd(agent: &AgentInvocation, home: &Path, uid: u32) -> ServicePlan {
         kind: ServiceKind::Launchd,
         unit_path: unit_path.clone(),
         unit_body,
+        // Unload first, so installing over an existing agent UPGRADES it
+        // rather than failing. `bootout` exits non-zero when the label is not
+        // loaded, which is the ordinary first-install case, so it cannot be an
+        // `activate` step.
+        pre_activate: vec![vec![
+            "launchctl".to_owned(),
+            "bootout".to_owned(),
+            format!("{target}/{LAUNCHD_LABEL}"),
+        ]],
         activate: vec![vec![
             "launchctl".to_owned(),
             "bootstrap".to_owned(),

--- a/crates/atlasctl/src/service/tests.rs
+++ b/crates/atlasctl/src/service/tests.rs
@@ -417,3 +417,57 @@ fn a_crash_looping_agent_is_reported_rather_than_raised() {
         "the unit path is still reported so they can inspect it"
     );
 }
+
+// ---- installing over a running agent ----------------------------------------
+//
+// Reported from a real macOS run: `curl … | sh` on a machine that already had
+// an agent printed
+//
+//   error: `launchctl bootstrap gui/501 …plist` failed:
+//          Bootstrap failed: 5: Input/output error
+//
+// `bootstrap` refuses a label that is already loaded, and error 5 names neither
+// the cause nor the remedy. The installer then suggested `atlasctl agent
+// install` to see why, which reproduced the same line, and `agent run` by hand
+// hit the port the live agent still held. Three dead ends for "I ran the
+// installer twice".
+
+#[test]
+fn launchd_unloads_before_it_bootstraps() {
+    let p = plan(ServiceKind::Launchd, &agent(), Path::new("/Users/x"), 501);
+    let pre: Vec<String> = p.pre_activate.iter().map(|a| a.join(" ")).collect();
+    let act: Vec<String> = p.activate.iter().map(|a| a.join(" ")).collect();
+    assert!(
+        pre.iter().any(|c| c.contains("bootout")),
+        "an install over a live agent must unload it first: {pre:?}"
+    );
+    assert!(act.iter().any(|c| c.contains("bootstrap")), "{act:?}");
+    assert!(
+        pre.iter().all(|c| !c.contains("bootstrap")),
+        "the unload must not be the activation step: {pre:?}"
+    );
+}
+
+/// It has to be `pre_activate`, not `activate`: on a FIRST install there is
+/// nothing to unload and `bootout` exits non-zero, which would turn a clean
+/// install into a failure.
+#[test]
+fn the_unload_is_allowed_to_fail() {
+    let p = plan(ServiceKind::Launchd, &agent(), Path::new("/Users/x"), 501);
+    assert!(!p.pre_activate.is_empty());
+    for argv in &p.activate {
+        assert!(
+            !argv.join(" ").contains("bootout"),
+            "bootout in `activate` fails every first install: {argv:?}"
+        );
+    }
+}
+
+/// systemd needs none of this — `enable --now` is idempotent and restarts a
+/// live unit with the new binary. Adding a teardown there would stop an agent
+/// that did not need stopping.
+#[test]
+fn systemd_needs_no_pre_step() {
+    let p = plan(ServiceKind::Systemd, &agent(), Path::new("/home/x"), 1000);
+    assert!(p.pre_activate.is_empty(), "{:?}", p.pre_activate);
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -102,7 +102,21 @@ install_agent() {
         info "start it yourself later with: $BIN_NAME agent install"
         return
     fi
-    info "installing the background agent"
+    # Re-running the installer on a machine that already has this exact version
+    # is the commonest reason to run it at all: the binary is there, the service
+    # is not up, and the website says "no agent". Nothing needs installing --
+    # the machine needs STARTING. A join is the exception: it is the step the
+    # operator came for, so it runs regardless.
+    if [ -n "${4:-}" ] && [ -z "${2:-}" ]; then
+        if "$exe" agent status >/dev/null 2>&1; then
+            info "the agent is already running — this machine is ready."
+            info "if a browser does not see it, pair it: $BIN_NAME agent token"
+            return
+        fi
+        info "starting the agent that is already installed here"
+    else
+        info "installing the background agent"
+    fi
     # The join is NOT silenced: it is the step the operator is watching, and
     # its output carries the verification words they are meant to compare.
     if [ -n "${2:-}" ]; then
@@ -129,10 +143,26 @@ install_agent() {
         return
     fi
     warn "could not install the agent as a service on this machine."
-    warn "atlasctl itself is installed and works. To run the agent by hand:"
+    warn "atlasctl itself is installed and works."
+    # "Run agent install to see why" was the old advice, and it reproduced the
+    # SAME line the operator had just read — a third dead end after the failed
+    # bootstrap. Check the likeliest cause here instead: an agent already
+    # holding the port is what makes a re-install look like a broken install.
+    if command -v lsof >/dev/null 2>&1 && lsof -nP -iTCP:34333 -sTCP:LISTEN >/dev/null 2>&1; then
+        warn "an agent is ALREADY listening on 127.0.0.1:34333, so this machine"
+        warn "is usable right now — the website will find it. Nothing else to do."
+        warn "To point that agent at this newly installed binary, stop it and run:"
+        warn "    $BIN_NAME agent install"
+        return
+    fi
+    warn "To run the agent by hand:"
     warn "    $BIN_NAME agent run"
-    warn "or, to see why the service install failed:"
-    warn "    $BIN_NAME agent install"
+    warn "Its startup log, if the service did start and then exit:"
+    if [ "$(uname -s)" = "Darwin" ]; then
+        warn "    tail -n 50 ~/Library/Logs/atlasctl-agent.log"
+    else
+        warn "    journalctl --user -u atlasctl-agent -n 50"
+    fi
 }
 
 check_docker() {
@@ -273,11 +303,28 @@ main() {
     dir="${ATLASCTL_INSTALL_DIR:-$HOME/.local/bin}"
     mkdir -p "$dir"
     [ -f "$tmp/$BIN_NAME" ] || die "the archive did not contain $BIN_NAME"
-    # Install to a temp name and rename, so an interrupted install cannot leave
-    # a half-written binary on PATH.
-    install -m 0755 "$tmp/$BIN_NAME" "$dir/.$BIN_NAME.new"
-    mv -f "$dir/.$BIN_NAME.new" "$dir/$BIN_NAME"
-    info "installed $dir/$BIN_NAME"
+
+    # Ask the two binaries their versions rather than parsing a release tag: the
+    # downloaded one is already here and already checksum-verified, so this
+    # needs no second endpoint and cannot be fooled by a tag naming scheme that
+    # changes. An unreadable or non-answering existing binary compares unequal,
+    # which lands on the upgrade path -- the safe direction.
+    new_version=$("$tmp/$BIN_NAME" --version 2>/dev/null || true)
+    old_version=""
+    [ -x "$dir/$BIN_NAME" ] && old_version=$("$dir/$BIN_NAME" --version 2>/dev/null || true)
+
+    same_version=""
+    if [ -n "$new_version" ] && [ "$old_version" = "$new_version" ]; then
+        same_version="yes"
+        info "$new_version is already installed here — keeping it."
+    else
+        [ -z "$old_version" ] || info "upgrading $old_version -> $new_version"
+        # Install to a temp name and rename, so an interrupted install cannot leave
+        # a half-written binary on PATH.
+        install -m 0755 "$tmp/$BIN_NAME" "$dir/.$BIN_NAME.new"
+        mv -f "$dir/.$BIN_NAME.new" "$dir/$BIN_NAME"
+        info "installed $dir/$BIN_NAME"
+    fi
 
     case ":$PATH:" in
         *":$dir:"*) ;;
@@ -289,7 +336,7 @@ main() {
 
     check_docker
     check_sparkrun
-    install_agent "$dir/$BIN_NAME" "$join" "$grant_control"
+    install_agent "$dir/$BIN_NAME" "$join" "$grant_control" "$same_version"
 
     info "done. Try:"
     info "    $BIN_NAME list"


### PR DESCRIPTION
Reported from a real macOS run of `curl -fsSL https://atlasinference.io/install.sh | sh` on a machine that already had an agent:

```
error: `launchctl bootstrap gui/501 /Users/nologik/Library/LaunchAgents/io.atlasinference.atlasctl-agent.plist` failed:
       Bootstrap failed: 5: Input/output error
…
error: could not bind 127.0.0.1:34333 — is another agent already running?
caused by: Address already in use (os error 48)
```

Three separate dead ends for the commonest reason to run the installer at all: running it a second time.

### 1. There was no upgrade path on macOS
`launchctl bootstrap` refuses a label that is already loaded, and the launchd plan had no `bootout` — so the only supported install was onto a machine that had never installed.

`ServicePlan` gains `pre_activate`: best-effort commands that run **before** activation. Separate from `best_effort` (which runs after) because ordering is the entire point, and allowed to fail because a first install has nothing to unload. systemd gets an empty one — `enable --now` is already idempotent, and adding a teardown there would stop an agent that did not need stopping.

### 2. The suggested diagnostic reproduced the error
`install.sh` said "to see why the service install failed: `atlasctl agent install`" — the same command, the same line. It now checks the likeliest cause (an agent already holding the port, which is what makes a re-install look like a broken install) and names the platform's real log. `journalctl` does not exist on macOS and was the only diagnostic offered, on the platform where this path is most likely.

### 3. "Installed but not running" is now its own outcome
The installer asks both binaries their version rather than parsing a release tag — the downloaded one is already checksum-verified and present, so this needs no second endpoint and cannot be fooled by a tag scheme change. When they match it keeps the existing binary, then either reports the machine is already ready or **starts** it, so a browser can find a machine that was installed but down. A `--join` runs regardless: it is the step the operator came for.

The bind error in `atlasctl-agent` now names the remedy instead of asking a question the operator cannot answer.

### Verification
- `pre_activate` ordering pinned by three unit tests: launchd unloads before it bootstraps, the unload is in `pre_activate` (not `activate`, where it would fail every first install), and systemd has none.
- `install.sh`'s four branches driven against a stub binary: same-version+running, same-version+down, upgrade, and same-version+`--join`.
- Workspace suite, clippy, fmt, goldens clean.

**Not verified live:** the launchd path itself. This box is Linux; only the plan logic is exercised here.
