### PR TITLE
fix(install.sh): stop crying wolf about provenance, and tell Windows readers the README exists for them too

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ release, and puts it in `~/.local/bin` (`%LOCALAPPDATA%\Programs\atlasctl` on
 Windows). It needs no Python and no Rust toolchain. Running it again on a
 machine that already has atlasctl is an upgrade, or — when the version is
 already current — a way to start an agent that is installed but stopped.
-`sh scripts/install.sh --uninstall` reverses it.
+`sh scripts/install.sh --uninstall` reverses it; on Windows,
+`atlasctl agent uninstall` removes the task and the binary can be deleted from
+the install directory above.
 
 The background agent is a `systemd --user` service on Linux, a launchd
 LaunchAgent on macOS, and a Task Scheduler task at logon on Windows — a task

--- a/README.md
+++ b/README.md
@@ -10,8 +10,16 @@ runs the `docker run` it implies.
 
 ## Install
 
+Linux and macOS:
+
 ```sh
 curl -fsSL https://atlasinference.io/install.sh | sh
+```
+
+Windows, in PowerShell:
+
+```powershell
+irm https://atlasinference.io/install.ps1 | iex
 ```
 
 Or, if you already have the toolchains:
@@ -22,8 +30,16 @@ uvx pyatlasctl list            # from PyPI, no install step
 ```
 
 The installer downloads a prebuilt binary, verifies its SHA-256 against the
-release, and puts it in `~/.local/bin`. It needs no Python and no Rust
-toolchain. `sh scripts/install.sh --uninstall` reverses it.
+release, and puts it in `~/.local/bin` (`%LOCALAPPDATA%\Programs\atlasctl` on
+Windows). It needs no Python and no Rust toolchain. Running it again on a
+machine that already has atlasctl is an upgrade, or — when the version is
+already current — a way to start an agent that is installed but stopped.
+`sh scripts/install.sh --uninstall` reverses it.
+
+The background agent is a `systemd --user` service on Linux, a launchd
+LaunchAgent on macOS, and a Task Scheduler task at logon on Windows — a task
+rather than a service because a service runs in session 0, which cannot reach
+Docker Desktop's per-user named pipe.
 
 ## Use
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -90,15 +90,34 @@ verify_checksum() {
 # the one-liner depend on GitHub's CLI would defeat the point of a one-liner.
 verify_attestation() {
     archive="$1"
-    if command -v gh >/dev/null 2>&1; then
-        if gh attestation verify "$archive" --repo "$REPO" >/dev/null 2>&1; then
-            info "build provenance verified"
-        else
-            warn "build provenance could NOT be verified for $(basename "$archive")."
-            warn "If you did not expect that, stop and check the release page."
-        fi
-    else
+    if ! command -v gh >/dev/null 2>&1; then
         info "install \`gh\` to also verify build provenance: gh attestation verify <file> --repo $REPO"
+        return
+    fi
+    # "Cannot check" and "checked, and it does not verify" are different facts
+    # and only the second is alarming. They were reported identically, so every
+    # machine with a gh older than 2.49 — which has no `attestation` subcommand
+    # at all — saw "build provenance could NOT be verified. If you did not
+    # expect that, stop and check the release page." on a perfectly good
+    # install. A security warning that fires on the healthy case is worse than
+    # none: it teaches the operator to scroll past the real one.
+    if ! gh attestation --help >/dev/null 2>&1; then
+        info "this \`gh\` is too old to check build provenance (needs 2.49+)."
+        info "The checksum above was verified; provenance is the extra step."
+        return
+    fi
+    if ! gh auth status >/dev/null 2>&1; then
+        info "\`gh\` is not signed in, so build provenance was not checked."
+        info "The checksum above was verified. To also check provenance:"
+        info "    gh auth login && gh attestation verify <file> --repo $REPO"
+        return
+    fi
+    if gh attestation verify "$archive" --repo "$REPO" >/dev/null 2>&1; then
+        info "build provenance verified"
+    else
+        # Now it means something: gh can check, is signed in, and said no.
+        warn "build provenance could NOT be verified for $(basename "$archive")."
+        warn "If you did not expect that, stop and check the release page."
     fi
 }
 

--- a/scripts/tests/install-sh.test.sh
+++ b/scripts/tests/install-sh.test.sh
@@ -79,6 +79,38 @@ printf '%s  atlasctl-x86_64-unknown-linux-muslXtarXxz\n' "$good" > "$WORK/SUMS.r
 contains "a name that only matches as a regex is not accepted" \
     "$(verify "$WORK/atlasctl-x86_64-unknown-linux-musl.tar.xz" "$WORK/SUMS.regex")" "no checksum for"
 
+# --- verify_attestation -------------------------------------------------------
+# "Cannot check" and "checked, and it does not verify" are different facts, and
+# only the second is alarming. Reporting them identically meant every machine
+# with a gh older than 2.49 saw a security warning on a healthy install — which
+# is how an operator learns to scroll past the real one.
+attest() { # gh_state
+    ( . "$WORK/lib.sh"
+      # shellcheck disable=SC2317  # called indirectly, by verify_attestation
+      case "$1" in
+        absent)   command() { if [ "$2" = gh ]; then return 1; fi; /usr/bin/env command "$@"; } ;;
+        old)      gh() { case "$1" in attestation) return 1 ;; *) return 0 ;; esac; } ;;
+        # capable (attestation --help works) but not signed in
+        loggedout) gh() { case "$1" in attestation) [ "$2" = --help ] ;; auth) return 1 ;; *) return 1 ;; esac; } ;;
+        # capable, signed in, and the verification itself says no
+        broken)   gh() { case "$1" in attestation) [ "$2" = --help ] ;; auth) return 0 ;; *) return 1 ;; esac; } ;;
+        good)     gh() { return 0; } ;;
+      esac
+      verify_attestation "$WORK/atlasctl-x86_64-unknown-linux-musl.tar.xz" ) 2>&1
+}
+
+contains "no gh at all: an invitation, not a warning" "$(attest absent)" "install \`gh\`"
+out=$(attest old)
+contains "gh too old: says so, and names the version" "$out" "too old"
+case "$out" in *"could NOT be verified"*) bad "gh too old must not warn" "$out" ;; *) ok "gh too old must not warn" ;; esac
+
+out=$(attest loggedout)
+contains "gh signed out: says so" "$out" "not signed in"
+case "$out" in *"could NOT be verified"*) bad "gh signed out must not warn" "$out" ;; *) ok "gh signed out must not warn" ;; esac
+
+contains "a capable gh that refuses IS a warning" "$(attest broken)" "could NOT be verified"
+contains "a capable gh that verifies says so"     "$(attest good)"   "provenance verified"
+
 # --- install_agent ------------------------------------------------------------
 cat > "$WORK/fake-atlasctl" <<'EOF'
 #!/bin/sh

--- a/scripts/tests/install-sh.test.sh
+++ b/scripts/tests/install-sh.test.sh
@@ -85,6 +85,7 @@ contains "a name that only matches as a regex is not accepted" \
 # with a gh older than 2.49 saw a security warning on a healthy install — which
 # is how an operator learns to scroll past the real one.
 attest() { # gh_state
+    # shellcheck source=/dev/null  # generated above, from install.sh
     ( . "$WORK/lib.sh"
       # shellcheck disable=SC2317  # called indirectly, by verify_attestation
       case "$1" in


### PR DESCRIPTION
atlasctl ships a Windows binary and `install.ps1` as of #114, and the README offered neither — a Windows reader was handed `curl … | sh`, which is exactly the failure the site-side fix exists to stop.

Also documents what running the installer a **second** time does, which is the commonest reason to run it and was written down nowhere: an upgrade, or — when the version is already current — a way to start an agent that is installed but stopped.

And names the three supervisors, including why Windows gets a Task Scheduler task rather than a service (session 0 cannot reach Docker Desktop's per-user named pipe).