### PR TITLE
fix(install): the three ways a Windows install could end badly

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -56,6 +56,19 @@ jobs:
         shell: pwsh
         run: ./scripts/tests/install-ps1.test.ps1
 
+      # ...and again under WINDOWS PowerShell 5.1, which is what the one-liner on
+      # the website is actually pasted into: it is the shell `Win+X` opens and the
+      # only one present on a clean install. 5.1 and pwsh 7 disagree about native
+      # commands -- 5.1 turns the first stderr line of a redirected native command
+      # into a TERMINATING error under `$ErrorActionPreference = 'Stop'` -- so a
+      # pwsh-only suite is green while every real visitor's install aborts. That
+      # is not hypothetical: it is how `docker info` (which writes to stderr in
+      # exactly the "Docker Desktop installed but stopped" state the probe exists
+      # to report) took the installer down mid-run.
+      - name: install.ps1 behaviour (Windows PowerShell 5.1)
+        shell: powershell
+        run: ./scripts/tests/install-ps1.test.ps1
+
       # The scheduled-task plan is the half no unit test can reach: whether
       # Task Scheduler ACCEPTS this XML, whether the task then reports Running,
       # and whether uninstall removes it. Every one of those has failed for a

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -70,6 +70,32 @@ $Repo    = 'Avarok-Cybersecurity/atlas-recipes'
 $BinName = 'atlasctl'
 $Port    = 34333
 
+# Windows PowerShell 5.1 turns the FIRST stderr line of a native command into a
+# TERMINATING error when $ErrorActionPreference is 'Stop'. Both probes below run
+# commands that write to stderr in exactly the state they exist to DETECT --
+# `docker info` when Docker Desktop is installed but its engine is stopped, and
+# `agent status` when no agent is answering -- so under 5.1 the probe aborted the
+# install instead of reporting, stranding the machine with a binary and no agent.
+# pwsh 7 does not do this, which is why the test suite (which runs under pwsh)
+# never saw it. Run the probe with the preference relaxed and judge it by its
+# exit code, which is what the callers already wanted.
+function Invoke-Probe {
+    param([Parameter(Mandatory=$true)][scriptblock]$Probe)
+    $prev = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        & $Probe 2>&1 | Out-Null
+        # A probe that never reached a native command leaves $LASTEXITCODE stale;
+        # treating stale-as-zero would report a dead docker as healthy.
+        if ($null -eq $LASTEXITCODE) { return 1 }
+        return $LASTEXITCODE
+    } catch {
+        return 1
+    } finally {
+        $ErrorActionPreference = $prev
+    }
+}
+
 function Write-Info { param($m) Write-Host "[atlas] $m" -ForegroundColor Cyan }
 function Write-Warn { param($m) Write-Host "[atlas] $m" -ForegroundColor Yellow }
 function Die { param($m) Write-Host "[atlas] error: $m" -ForegroundColor Red; exit 1 }
@@ -172,8 +198,7 @@ function Install-Agent {
     }
 
     if ($SameVersion) {
-        & $Exe agent status *> $null
-        $answering = $LASTEXITCODE -eq 0
+        $answering = (Invoke-Probe { & $Exe agent status }) -eq 0
         # BOTH, not just the port. An operator who ran `atlasctl agent run` by
         # hand has an agent answering and NO task, and skipping on the port
         # alone left it that way: close the window, reboot, and "the website
@@ -220,8 +245,7 @@ function Test-Docker {
         Write-Warn "https://docs.docker.com/desktop/install/windows-install/"
         return
     }
-    docker info *> $null
-    if ($LASTEXITCODE -ne 0) {
+    if ((Invoke-Probe { docker info }) -ne 0) {
         # Installed but not running is its own state, and its own fix. Telling
         # someone to install what they already have is how a working machine
         # gets called broken.
@@ -288,12 +312,25 @@ try {
         # installer is upgrading is exactly such a process. Move it aside first:
         # Windows permits renaming a running image, and the stale copy is
         # cleaned up on the next install.
+        $old = "$exe.old"
+        $moved = $false
         if (Test-Path -LiteralPath $exe) {
-            $old = "$exe.old"
             Remove-Item -Force $old -ErrorAction SilentlyContinue
-            try { Move-Item -Force $exe $old } catch { }
+            try { Move-Item -Force $exe $old; $moved = $true } catch { }
         }
-        Copy-Item -Force $staged $exe
+        try {
+            Copy-Item -Force $staged $exe
+        } catch {
+            # Without this the machine is left with NO binary at all: the working
+            # exe is stranded at .old and the scheduled task points at a path that
+            # no longer exists. An upgrade that fails must leave the old agent
+            # running, not take the fleet's node offline.
+            if ($moved) {
+                Move-Item -Force $old $exe
+                Die "could not install the new binary ($($_.Exception.Message)); kept $oldVersion"
+            }
+            throw
+        }
         Write-Info "installed $exe"
     }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -331,12 +331,23 @@ main() {
                 [ $# -gt 0 ] || die "--join needs a value, e.g. --join 12345678@10.10.10.1"
                 join="$1"
                 ;;
-            --join=*) join="${1#--join=}" ;;
+            --join=*)
+                join="${1#--join=}"
+                # `--join=` with nothing after it read as "no join requested", so
+                # the machine installed, never joined, and the operator walked
+                # away believing it had. install.ps1 refuses this; so does this.
+                [ -n "$join" ] || die "--join= needs a value, e.g. --join=12345678@10.10.10.1"
+                ;;
             # Forwarded, not interpreted: it means "let the fleet I am joining
             # run models on this machine", and only `agent install` can act on
             # it. Noticed here so the operator is told what they just consented
             # to, on the machine they consented on.
             --grant-control) grant_control="--grant-control" ;;
+            # Silence here is how a misspelling (`--grant-contol`, `-Join`)
+            # becomes an install that quietly did not do what was asked.
+            # Warn rather than die: the one-liner is pasted by hand, and
+            # refusing outright would strand someone over a typo they can see.
+            --*) warn "ignoring unrecognised option: $1" ;;
             *) ;;
         esac
         shift

--- a/scripts/tests/install-sh.test.sh
+++ b/scripts/tests/install-sh.test.sh
@@ -288,6 +288,19 @@ out=$(agent_fail no)
 contains "no held port: offers the foreground command" "$out" "agent run"
 contains "and names the platform's real log"          "$out" "journalctl"
 
+# --- option parsing -----------------------------------------------------------
+# The REAL script, as a subprocess. Both of these decisions happen in main()
+# before anything is fetched, so this cannot reach the network — and running the
+# real thing is the only way to cover a parser that lives inside main().
+# One invocation covers both: the unknown flag warns and parsing CONTINUES, so
+# the `--join=` after it is still reached and still refuses.
+parse_out=$(sh "$ROOT/scripts/install.sh" --bogus-flag --join= 2>&1); parse_rc=$?
+contains "an unrecognised option is named, not silently swallowed" \
+    "$parse_out" "ignoring unrecognised option: --bogus-flag"
+contains "--join= with an empty value refuses" \
+    "$parse_out" "--join= needs a value"
+check "and refusing is non-zero, so a wrapper notices" "1" "$parse_rc"
+
 printf '\n  %d passed, %d failed\n' "$pass" "$fail"
 # Explicit, not inherited. `[ "$fail" -eq 0 ]` as the last command happens to
 # be right here, but the PowerShell counterpart made exactly this mistake —


### PR DESCRIPTION
An audit of the onboarding path — reading **both sides** of each contract (page ↔ script ↔ Rust CLI)
— turned up three defects the suite could not see, plus the reason it could not see the worst one.

### 1. Windows PowerShell 5.1 aborts the install on a native command's stderr

`install.ps1:223` (`docker info *> $null`) and `:175` (`& $Exe agent status *> $null`) run under
`$ErrorActionPreference = 'Stop'`. In **5.1** — the shell `Win+X` opens, the only one on a clean
box, and therefore the one the website's one-liner is actually pasted into — redirecting a native
command's stderr while EAP is `Stop` turns its first stderr line into a **terminating error**.

Both probes hit that in precisely the state they exist to *detect*: `docker info` writes to stderr
when Docker Desktop is installed but its engine is stopped (a very common first-run state), and
`agent status` when no agent is answering. The install then died **after** placing the binary and
**before** installing the agent — the machine left in the exact half-state this script exists to fix.

Both now go through `Invoke-Probe`, which relaxes the preference and judges the probe by its exit
code, which is all either caller ever wanted. A probe that never reached a native command returns 1
rather than a stale `$LASTEXITCODE`, so a dead docker cannot read as healthy.

### 2. A failed upgrade could leave the machine with no binary at all

`install.ps1:293-296` moved the running exe to `.old` and *then* copied the new one. If that copy
threw — AV lock, disk full — the working binary was stranded at `.old` and the scheduled task pointed
at a path with nothing behind it. An upgrade that fails must leave the old agent running, not take a
fleet node offline. It now rolls back and names the version it kept. `install.sh` already did this
correctly (copy to `.new`, then atomic `mv -f`).

### 3. `--join=` installed and never joined, in silence

`install.sh:334` read `--join=` as "no join requested": the machine installed, never joined, and the
operator walked away believing it had. `install.ps1` already refused this; `install.sh` now does too,
and an unrecognised `--*` option is named rather than swallowed — warn, not die, because the
one-liner is pasted by hand and refusing outright would strand someone over a visible typo.

### Why CI could not see #1

The PowerShell suite ran under **pwsh 7 only**, which does not have that stderr behaviour. The
workflow's own comment already documents the trap for its *own* step — it just wasn't applied to the
shipped script. `windows.yml` now runs the suite under 5.1 as well.

### Tests

Three cases drive the **real** `install.sh` as a subprocess; both decisions happen inside `main()`
before anything is fetched, so they cannot reach the network. One invocation covers both, because
the unknown flag must warn and let parsing *continue* for the `--join=` after it to be reached.

Verified they fail against the unfixed parser (`40 passed, 3 failed`) and pass after (`43, 0`).

_Not fixed here, and worth knowing: `irm | iex` runs in the caller's scope, so `Set-StrictMode` and
`$ErrorActionPreference` leak into the operator's interactive session and their next pasted snippet
can fail mysteriously. The fix is a scope wrapper around a 320-line script — a restructure of the
critical install path that I did not want to make unattended and untested on a real Windows box._