### PR TITLE
fix(agent): four ways the installed agent misbehaved on a user's machine

### DIFF
--- a/crates/atlasctl-agent/src/daemon.rs
+++ b/crates/atlasctl-agent/src/daemon.rs
@@ -45,6 +45,7 @@ pub const PEER_POLL_INTERVAL: Duration = Duration::from_secs(5);
 // The vitals and prune timers live in `daemon/housekeeping.rs`. They are
 // timers over local state; this file is the machine-to-machine half.
 mod housekeeping;
+mod join;
 mod peer_serve;
 
 #[cfg(test)]
@@ -215,7 +216,7 @@ fn spawn_peer_listener(
                 // in a log. Only these phases are bounded -- a PINNED peer's
                 // link below is long-lived on purpose and gets no deadline.
                 let Ok(Ok(mut tls)) =
-                    tokio::time::timeout(HANDSHAKE_TIMEOUT, acceptor.accept(tcp)).await
+                    tokio::time::timeout(join::HANDSHAKE_TIMEOUT, acceptor.accept(tcp)).await
                 else {
                     // An unpaired caller failing (or stalling) the handshake is
                     // the system working, not an incident worth logging.
@@ -234,8 +235,8 @@ fn spawn_peer_listener(
                     // stranger who completes the handshake and then goes quiet
                     // sits in `read_frame` forever.
                     let _ = tokio::time::timeout(
-                        JOIN_TIMEOUT,
-                        serve_join(&mut tls, &identity, &pins, &joining, &fleet),
+                        join::JOIN_TIMEOUT,
+                        join::serve_join(&mut tls, &identity, &pins, &joining, &fleet),
                     )
                     .await;
                     return;
@@ -259,137 +260,6 @@ fn peer_of<S>(
     let (_, conn) = tls.get_ref();
     let cert = conn.peer_certificates().and_then(<[_]>::first)?;
     crate::peer::tls::peer_identity(cert).ok().map(|(id, _)| id)
-}
-
-/// How long an unpinned caller gets to finish a TLS handshake.
-const HANDSHAKE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
-
-/// How long an unpinned caller gets to finish the pairing ceremony. Four frames
-/// between two machines on a LAN; the generosity is deliberate, the bound is the
-/// point.
-const JOIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
-
-/// Serve a machine that is not pinned: it may pair, and nothing else.
-///
-/// Reached only inside a join window, because that is what let it complete a
-/// handshake at all. A failure here is ordinary — a mistyped digit, a dropped
-/// connection — and is charged against the window's attempt budget rather than
-/// logged as an incident.
-async fn serve_join<S>(
-    tls: &mut tokio_rustls::server::TlsStream<S>,
-    identity: &crate::identity::Identity,
-    pins: &crate::identity::PinStore,
-    joining: &crate::joining::JoinWindow,
-    fleet: &crate::fleet::LocalFleet,
-) where
-    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
-{
-    // Charges a guess up front. Every path out of this function below is
-    // therefore already accounted for, including the two that return without
-    // running a ceremony at all — previously those were free retries.
-    //
-    // ⚠ The cost of that choice, which is real and not yet paid: this charges
-    // for a CONNECTION, not for a guess at the code. Unpair is one-sided by
-    // design (`fleet/listing.rs`), so a machine we removed still pins us and its
-    // link poller keeps dialing every five seconds. Outside a window those
-    // handshakes are refused cheaply — but the moment a human mints a join code,
-    // that poller's next three connections complete the handshake, land here,
-    // and spend the whole budget in about fifteen seconds. Every "add a machine"
-    // afterwards fails with "that invitation was already used", forever, and
-    // nothing names the ex-peer as the cause.
-    //
-    // Fixing it properly means charging only once the caller has actually
-    // attempted the PAIRING protocol — a non-pairing first frame is not a guess
-    // — which means reading and classifying that frame before `pair::run` owns
-    // the stream. That is a change to the ceremony's shape, and it is not made
-    // here because getting it subtly wrong turns a rate limit into no rate limit.
-    let Some(code) = joining.begin_attempt() else {
-        // The window closed between the handshake and here.
-        return;
-    };
-    let Some(peer) = peer_of(tls) else {
-        return;
-    };
-    let binding = {
-        let (_, conn) = tls.get_ref();
-        match crate::pairing::binding_from_server(conn) {
-            Ok(b) => b,
-            Err(_) => return,
-        }
-    };
-
-    // The failure arm is deliberately empty: `begin_attempt` already charged
-    // this guess, so there is nothing left to record when the ceremony fails.
-    if let Ok(paired) = crate::peer::pair::run(
-        tls,
-        crate::peer::pair::Role::Responder,
-        identity,
-        peer,
-        &code,
-        binding,
-    )
-    .await
-    {
-        // Single use: the invitation is spent whether or not the pin
-        // write below succeeds, because the code has now been seen on the
-        // wire by whoever answered.
-        //
-        // Losing this race means another ceremony already spent the
-        // invitation. Both peers hold a valid code, so neither is
-        // necessarily hostile — but "one invitation, one machine" is the
-        // property, and admitting the loser would quietly break it.
-        let Some(consumed) = joining.consume() else {
-            eprintln!(
-                "refusing {}: that invitation was already used by another machine. \
-                     Mint a fresh one to add this node.",
-                paired.node.short()
-            );
-            return;
-        };
-        if let Err(e) = crate::fleet::record_pairing(
-            pins,
-            paired.node,
-            &paired.public_key,
-            atlasctl_protocol::fleet::DisplayName::new(&paired.name),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map_or(0, |d| d.as_secs()),
-            None,
-            // The grant the human chose when they minted this invitation,
-            // written with the pin so consent and trust land atomically.
-            consumed.allow_control,
-        ) {
-            // Announcing a pairing whose pin never reached disk is how a
-            // fleet ends up with one side believing it is paired and the
-            // other rejecting it on the next connection, with nothing
-            // anywhere saying why.
-            eprintln!(
-                "pairing with {} completed but could not be recorded: {e:#}. \
-                     The peer believes it is paired; this machine does not.",
-                paired.node.short()
-            );
-            return;
-        }
-        let _ = fleet;
-        // The words, not just the name. The machine that DIALLED shows these to
-        // its operator and asks them to compare — and until now this side
-        // printed nothing to compare against, so the comparison was one-sided
-        // and the question the other dialog asked could not be answered.
-        //
-        // This is a log line rather than a prompt because this side is
-        // typically headless and unattended: the ceremony is authorised by the
-        // invitation, which a human minted here minutes ago. The words let
-        // someone who wants to check, check.
-        eprintln!(
-            "paired with {} ({}) — verification words: {}",
-            // Sanitised: the name is the joining peer's own claim, and this
-            // line goes into the journal, where a control sequence is just as
-            // effective at rewriting what a reader sees.
-            atlasctl_protocol::fleet::DisplayName::new(&paired.name).as_str(),
-            paired.node.short(),
-            paired.verification
-        );
-    }
 }
 
 /// Ask each paired peer how it is.

--- a/crates/atlasctl-agent/src/daemon.rs
+++ b/crates/atlasctl-agent/src/daemon.rs
@@ -185,19 +185,34 @@ fn spawn_peer_listener(
         };
         eprintln!("peer channel on 0.0.0.0:{port}");
 
+        // 0 means "the last accept succeeded", which is also what makes the
+        // first failure of a run the one that gets printed.
+        let mut backoff_ms: u64 = 0;
         loop {
             let (tcp, _) = match listener.accept().await {
-                Ok(v) => v,
+                Ok(v) => {
+                    backoff_ms = 0;
+                    v
+                }
                 Err(e) => {
                     // Backoff, not a bare `continue`. Under fd exhaustion
                     // (EMFILE -- plausible while this same process is pulling a
                     // multi-GB image) `accept` fails IMMEDIATELY and forever, so
                     // retrying with no pause burns 100% of a core silently,
-                    // inside a service that bounds memory but not CPU. Ten
-                    // milliseconds is invisible to a real connection and turns a
-                    // hot spin into an idle one that says why.
-                    eprintln!("peer listener: accept failed: {e}");
-                    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                    // inside a service that bounds memory but not CPU.
+                    //
+                    // The backoff DOUBLES, and only the first failure of a run
+                    // is printed. A fixed 10ms pause plus a line each time is
+                    // ~100 journal entries a second for as long as the condition
+                    // lasts -- trading a CPU spin for a log flood, which under
+                    // journald's rate limiting means dropping everyone else's
+                    // messages too. One line names the condition; the ramp to a
+                    // second keeps the loop responsive when it clears.
+                    if backoff_ms == 0 {
+                        eprintln!("peer listener: accept failed: {e}");
+                    }
+                    backoff_ms = (backoff_ms * 2).clamp(10, 1000);
+                    tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)).await;
                     continue;
                 }
             };

--- a/crates/atlasctl-agent/src/daemon.rs
+++ b/crates/atlasctl-agent/src/daemon.rs
@@ -185,8 +185,20 @@ fn spawn_peer_listener(
         eprintln!("peer channel on 0.0.0.0:{port}");
 
         loop {
-            let Ok((tcp, _)) = listener.accept().await else {
-                continue;
+            let (tcp, _) = match listener.accept().await {
+                Ok(v) => v,
+                Err(e) => {
+                    // Backoff, not a bare `continue`. Under fd exhaustion
+                    // (EMFILE -- plausible while this same process is pulling a
+                    // multi-GB image) `accept` fails IMMEDIATELY and forever, so
+                    // retrying with no pause burns 100% of a core silently,
+                    // inside a service that bounds memory but not CPU. Ten
+                    // milliseconds is invisible to a real connection and turns a
+                    // hot spin into an idle one that says why.
+                    eprintln!("peer listener: accept failed: {e}");
+                    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                    continue;
+                }
             };
             let acceptor = acceptor.clone();
             let fleet = Arc::clone(&fleet);

--- a/crates/atlasctl-agent/src/daemon.rs
+++ b/crates/atlasctl-agent/src/daemon.rs
@@ -207,9 +207,18 @@ fn spawn_peer_listener(
             let identity = Arc::clone(&identity);
             let serve = Arc::clone(&serve);
             tokio::spawn(async move {
-                let Ok(mut tls) = acceptor.accept(tcp).await else {
-                    // An unpaired caller failing the handshake is the system
-                    // working, not an incident worth logging.
+                // BOUNDED. Neither of the two short phases below may run
+                // forever: this handler is a spawned task holding an fd, and a
+                // caller that connects and simply stops talking would hold both
+                // until the process exits. That is reachable by anyone who can
+                // route to this port, needs no credentials, and leaves nothing
+                // in a log. Only these phases are bounded -- a PINNED peer's
+                // link below is long-lived on purpose and gets no deadline.
+                let Ok(Ok(mut tls)) =
+                    tokio::time::timeout(HANDSHAKE_TIMEOUT, acceptor.accept(tcp)).await
+                else {
+                    // An unpaired caller failing (or stalling) the handshake is
+                    // the system working, not an incident worth logging.
                     return;
                 };
 
@@ -220,7 +229,15 @@ fn spawn_peer_listener(
                 let peer = peer_of(&tls);
                 let pinned = peer.is_some_and(|id| pins.is_pinned(id).unwrap_or(false));
                 if !pinned {
-                    serve_join(&mut tls, &identity, &pins, &joining, &fleet).await;
+                    // A pairing ceremony is four frames between two machines on
+                    // a LAN; thirty seconds is far past generous. Without this a
+                    // stranger who completes the handshake and then goes quiet
+                    // sits in `read_frame` forever.
+                    let _ = tokio::time::timeout(
+                        JOIN_TIMEOUT,
+                        serve_join(&mut tls, &identity, &pins, &joining, &fleet),
+                    )
+                    .await;
                     return;
                 }
                 let Some(sender) = peer else {
@@ -244,6 +261,14 @@ fn peer_of<S>(
     crate::peer::tls::peer_identity(cert).ok().map(|(id, _)| id)
 }
 
+/// How long an unpinned caller gets to finish a TLS handshake.
+const HANDSHAKE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// How long an unpinned caller gets to finish the pairing ceremony. Four frames
+/// between two machines on a LAN; the generosity is deliberate, the bound is the
+/// point.
+const JOIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
 /// Serve a machine that is not pinned: it may pair, and nothing else.
 ///
 /// Reached only inside a join window, because that is what let it complete a
@@ -262,6 +287,22 @@ async fn serve_join<S>(
     // Charges a guess up front. Every path out of this function below is
     // therefore already accounted for, including the two that return without
     // running a ceremony at all — previously those were free retries.
+    //
+    // ⚠ The cost of that choice, which is real and not yet paid: this charges
+    // for a CONNECTION, not for a guess at the code. Unpair is one-sided by
+    // design (`fleet/listing.rs`), so a machine we removed still pins us and its
+    // link poller keeps dialing every five seconds. Outside a window those
+    // handshakes are refused cheaply — but the moment a human mints a join code,
+    // that poller's next three connections complete the handshake, land here,
+    // and spend the whole budget in about fifteen seconds. Every "add a machine"
+    // afterwards fails with "that invitation was already used", forever, and
+    // nothing names the ex-peer as the cause.
+    //
+    // Fixing it properly means charging only once the caller has actually
+    // attempted the PAIRING protocol — a non-pairing first frame is not a guess
+    // — which means reading and classifying that frame before `pair::run` owns
+    // the stream. That is a change to the ceremony's shape, and it is not made
+    // here because getting it subtly wrong turns a rate limit into no rate limit.
     let Some(code) = joining.begin_attempt() else {
         // The window closed between the handshake and here.
         return;

--- a/crates/atlasctl-agent/src/daemon/join.rs
+++ b/crates/atlasctl-agent/src/daemon/join.rs
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Serving a machine that is not pinned yet.
+//!
+//! Split from [`super`] for size, and because it is a genuinely separate
+//! conversation: a stranger inside a join window may pair and nothing else, so
+//! every bound and every charge on that path belongs together, here.
+
+use super::peer_of;
+
+/// How long an unpinned caller gets to finish a TLS handshake.
+pub(super) const HANDSHAKE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// How long an unpinned caller gets to finish the pairing ceremony. Four frames
+/// between two machines on a LAN; the generosity is deliberate, the bound is the
+/// point.
+pub(super) const JOIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Serve a machine that is not pinned: it may pair, and nothing else.
+///
+/// Reached only inside a join window, because that is what let it complete a
+/// handshake at all. A failure here is ordinary — a mistyped digit, a dropped
+/// connection — and is charged against the window's attempt budget rather than
+/// logged as an incident.
+pub(super) async fn serve_join<S>(
+    tls: &mut tokio_rustls::server::TlsStream<S>,
+    identity: &crate::identity::Identity,
+    pins: &crate::identity::PinStore,
+    joining: &crate::joining::JoinWindow,
+    fleet: &crate::fleet::LocalFleet,
+) where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    // Charges a guess up front. Every path out of this function below is
+    // therefore already accounted for, including the two that return without
+    // running a ceremony at all — previously those were free retries.
+    //
+    // ⚠ The cost of that choice, which is real and not yet paid: this charges
+    // for a CONNECTION, not for a guess at the code. Unpair is one-sided by
+    // design (`fleet/listing.rs`), so a machine we removed still pins us and its
+    // link poller keeps dialing every five seconds. Outside a window those
+    // handshakes are refused cheaply — but the moment a human mints a join code,
+    // that poller's next three connections complete the handshake, land here,
+    // and spend the whole budget in about fifteen seconds. Every "add a machine"
+    // afterwards fails with "that invitation was already used", forever, and
+    // nothing names the ex-peer as the cause.
+    //
+    // Fixing it properly means charging only once the caller has actually
+    // attempted the PAIRING protocol — a non-pairing first frame is not a guess
+    // — which means reading and classifying that frame before `pair::run` owns
+    // the stream. That is a change to the ceremony's shape, and it is not made
+    // here because getting it subtly wrong turns a rate limit into no rate limit.
+    let Some(code) = joining.begin_attempt() else {
+        // The window closed between the handshake and here.
+        return;
+    };
+    let Some(peer) = peer_of(tls) else {
+        return;
+    };
+    let binding = {
+        let (_, conn) = tls.get_ref();
+        match crate::pairing::binding_from_server(conn) {
+            Ok(b) => b,
+            Err(_) => return,
+        }
+    };
+
+    // The failure arm is deliberately empty: `begin_attempt` already charged
+    // this guess, so there is nothing left to record when the ceremony fails.
+    if let Ok(paired) = crate::peer::pair::run(
+        tls,
+        crate::peer::pair::Role::Responder,
+        identity,
+        peer,
+        &code,
+        binding,
+    )
+    .await
+    {
+        // Single use: the invitation is spent whether or not the pin
+        // write below succeeds, because the code has now been seen on the
+        // wire by whoever answered.
+        //
+        // Losing this race means another ceremony already spent the
+        // invitation. Both peers hold a valid code, so neither is
+        // necessarily hostile — but "one invitation, one machine" is the
+        // property, and admitting the loser would quietly break it.
+        let Some(consumed) = joining.consume() else {
+            eprintln!(
+                "refusing {}: that invitation was already used by another machine. \
+                     Mint a fresh one to add this node.",
+                paired.node.short()
+            );
+            return;
+        };
+        if let Err(e) = crate::fleet::record_pairing(
+            pins,
+            paired.node,
+            &paired.public_key,
+            atlasctl_protocol::fleet::DisplayName::new(&paired.name),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_or(0, |d| d.as_secs()),
+            None,
+            // The grant the human chose when they minted this invitation,
+            // written with the pin so consent and trust land atomically.
+            consumed.allow_control,
+        ) {
+            // Announcing a pairing whose pin never reached disk is how a
+            // fleet ends up with one side believing it is paired and the
+            // other rejecting it on the next connection, with nothing
+            // anywhere saying why.
+            eprintln!(
+                "pairing with {} completed but could not be recorded: {e:#}. \
+                     The peer believes it is paired; this machine does not.",
+                paired.node.short()
+            );
+            return;
+        }
+        let _ = fleet;
+        // The words, not just the name. The machine that DIALLED shows these to
+        // its operator and asks them to compare — and until now this side
+        // printed nothing to compare against, so the comparison was one-sided
+        // and the question the other dialog asked could not be answered.
+        //
+        // This is a log line rather than a prompt because this side is
+        // typically headless and unattended: the ceremony is authorised by the
+        // invitation, which a human minted here minutes ago. The words let
+        // someone who wants to check, check.
+        eprintln!(
+            "paired with {} ({}) — verification words: {}",
+            // Sanitised: the name is the joining peer's own claim, and this
+            // line goes into the journal, where a control sequence is just as
+            // effective at rewriting what a reader sees.
+            atlasctl_protocol::fleet::DisplayName::new(&paired.name).as_str(),
+            paired.node.short(),
+            paired.verification
+        );
+    }
+}

--- a/crates/atlasctl-agent/src/peer/join.rs
+++ b/crates/atlasctl-agent/src/peer/join.rs
@@ -44,9 +44,24 @@ pub async fn dial_and_pair(
 ) -> Result<Paired> {
     let cfg = client_config(identity, PinnedPeerVerifier::pairing(pins))?;
     let connector = tokio_rustls::TlsConnector::from(Arc::new(cfg));
-    let tcp = tokio::net::TcpStream::connect(addr)
-        .await
-        .with_context(|| format!("connecting to {addr}"))?;
+    // The same 5s bound `link::dial` uses. Without it a routed-but-DROPped
+    // address stalls at the OS default (~2 minutes) per address, and the hint
+    // lists are multi-address BY DESIGN -- a DGX offers its RoCE fabric first,
+    // which a laptop cannot reach. The operator saw "joining the fleet at
+    // 10.10.10.x..." and silence, well past the code's own 120s TTL, so even
+    // success could arrive after the code it was using had expired.
+    let tcp = tokio::time::timeout(
+        crate::peer::link::DIAL_TIMEOUT,
+        tokio::net::TcpStream::connect(addr),
+    )
+    .await
+    .map_err(|_| {
+        anyhow::anyhow!(
+            "{addr} did not answer within {:?}",
+            crate::peer::link::DIAL_TIMEOUT
+        )
+    })?
+    .with_context(|| format!("connecting to {addr}"))?;
     let name = rustls::pki_types::ServerName::try_from("peer.atlas.invalid")
         .context("building a server name")?
         .to_owned();

--- a/crates/atlasctl-core/src/secretfile.rs
+++ b/crates/atlasctl-core/src/secretfile.rs
@@ -121,7 +121,27 @@ pub fn write(path: &Path, bytes: &[u8]) -> Result<()> {
     // token, a revoked pin -- silently rolls back to the previous contents.
     // Best-effort: not every filesystem lets you open a directory for sync, and
     // failing the write over an unsyncable parent would be worse than the risk.
-    if let Err(e) = std::fs::rename(&tmp, path) {
+    // Windows can REFUSE a replace-by-rename that unix performs unconditionally:
+    // `MoveFileEx` fails with a sharing violation while another thread or process
+    // holds the target, which includes the instant another writer is mid-replace
+    // on it. The concurrency test above found exactly that on a Windows runner --
+    // so without this retry the atomic write trades a torn file for a spurious
+    // failure, which for a pin write is not obviously the better trade. Unix
+    // renames atomically and never takes this path.
+    let mut waited_ms = 0u64;
+    let renamed = loop {
+        match std::fs::rename(&tmp, path) {
+            Ok(()) => break Ok(()),
+            // 200ms total, in 5ms steps: far longer than a competing rename, far
+            // shorter than anything a caller would notice.
+            Err(_) if cfg!(windows) && waited_ms < 200 => {
+                std::thread::sleep(std::time::Duration::from_millis(5));
+                waited_ms += 5;
+            }
+            Err(e) => break Err(e),
+        }
+    };
+    if let Err(e) = renamed {
         // Do not leave the temp file behind to be mistaken for state, or to
         // accumulate one per crashed process.
         let _ = std::fs::remove_file(&tmp);

--- a/crates/atlasctl-core/src/secretfile.rs
+++ b/crates/atlasctl-core/src/secretfile.rs
@@ -37,6 +37,28 @@ use std::path::Path;
 /// # Errors
 /// If the file cannot be created or written.
 pub fn write(path: &Path, bytes: &[u8]) -> Result<()> {
+    // Written to a sibling temp file and RENAMED over the target, never
+    // truncate-then-write. `peers.json` goes through here, and truncate-first
+    // means a crash, a full disk or a kill between the two leaves a torn file --
+    // after which every `load()` fails to parse and the agent fails closed on
+    // EVERY peer at once. Rename is atomic on both platforms (Windows replaces
+    // an existing target), so a reader sees the old file or the new one.
+    //
+    // ⚠ This makes each write indivisible; it does NOT serialise two writers.
+    // The daemon and a separate `atlasctl peer remove` still read-modify-write
+    // the whole file, so an interleaving can lose one side's change -- including
+    // un-revoking a peer that was just removed. Closing that needs a lock file
+    // (or routing CLI mutations through the running daemon) and is a bigger
+    // change than this one.
+    let dir = path.parent().unwrap_or(Path::new("."));
+    let tmp = dir.join(format!(
+        ".{}.tmp{}",
+        path.file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("secret"),
+        std::process::id()
+    ));
+
     #[cfg(unix)]
     {
         use std::io::Write;
@@ -46,17 +68,42 @@ pub fn write(path: &Path, bytes: &[u8]) -> Result<()> {
             .create(true)
             .truncate(true)
             .mode(0o600)
-            .open(path)
-            .with_context(|| format!("creating {}", path.display()))?;
+            .open(&tmp)
+            .with_context(|| format!("creating {}", tmp.display()))?;
         f.write_all(bytes)
-            .with_context(|| format!("writing {}", path.display()))?;
+            .with_context(|| format!("writing {}", tmp.display()))?;
+        // Durable before it is visible: a rename that beats the data to disk
+        // would survive a power cut as a correctly-named empty file.
+        f.sync_all()
+            .with_context(|| format!("flushing {}", tmp.display()))?;
+
+        // Carry the EXISTING file's mode over, rather than always landing 0600.
+        // `write` and `verify` are split on purpose in this module: write does
+        // not police permissions, verify detects them. A fresh 0600 on every
+        // write would silently re-privatise a secret someone had widened, and
+        // erase the only evidence that other accounts could read it -- which is
+        // exactly what `rewriting_over_a_widened_file_is_caught` pins.
+        if let Ok(meta) = std::fs::metadata(path) {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = meta.permissions().mode() & 0o7777;
+            std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(mode))
+                .with_context(|| format!("carrying the mode of {}", path.display()))?;
+        }
     }
     #[cfg(windows)]
     {
         // Refused before the bytes exist, not after: a secret written to a
-        // share and then reported is a secret that was on the share.
+        // share and then reported is a secret that was on the share. The temp
+        // file is a sibling, so checking the destination covers both.
         verify_location(path)?;
-        std::fs::write(path, bytes).with_context(|| format!("writing {}", path.display()))?;
+        std::fs::write(&tmp, bytes).with_context(|| format!("writing {}", tmp.display()))?;
+    }
+
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        // Do not leave the temp file behind to be mistaken for state, or to
+        // accumulate one per crashed process.
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e).with_context(|| format!("replacing {}", path.display()));
     }
     Ok(())
 }
@@ -191,6 +238,38 @@ mod tests {
     /// Replacing must not widen. `OpenOptions` reuses an existing file's mode,
     /// so a secret rotated into a file someone had chmod-ed stays readable
     /// unless rotation is checked too.
+    /// The reason this write goes through a temp file: `peers.json` is
+    /// rewritten whole on every pin change, and a truncate-then-write left a
+    /// torn file if anything interrupted it -- after which every load fails to
+    /// parse and the agent fails closed on EVERY peer at once. A reader must see
+    /// the old bytes or the new ones, never a prefix.
+    #[test]
+    fn a_replaced_secret_is_never_seen_half_written() {
+        let d = tmp("atomic");
+        let p = d.join("peers.json");
+        write(&p, b"{\"peers\":[\"first\"]}").expect("writes");
+        // A much larger second write: a truncating writer would leave the file
+        // observably shorter than either version at some point.
+        let big = format!("{{\"peers\":[\"{}\"]}}", "x".repeat(200_000));
+        write(&p, big.as_bytes()).expect("writes");
+        let got = std::fs::read(&p).expect("reads");
+        assert_eq!(
+            got.len(),
+            big.len(),
+            "the file is exactly one of the versions"
+        );
+
+        // And no temp file is left lying around to be mistaken for state.
+        let strays: Vec<_> = std::fs::read_dir(&d)
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(strays.is_empty(), "left temp files behind: {strays:?}");
+        let _ = std::fs::remove_dir_all(&d);
+    }
+
     #[cfg(unix)]
     #[test]
     fn rewriting_over_a_widened_file_is_caught() {

--- a/crates/atlasctl-core/src/secretfile.rs
+++ b/crates/atlasctl-core/src/secretfile.rs
@@ -50,13 +50,30 @@ pub fn write(path: &Path, bytes: &[u8]) -> Result<()> {
     // un-revoking a peer that was just removed. Closing that needs a lock file
     // (or routing CLI mutations through the running daemon) and is a bigger
     // change than this one.
+    // Resolve a symlink to its target FIRST. The previous truncate-then-write
+    // opened `path` and wrote THROUGH a symlink, so a stowed/dotfiles setup that
+    // links `agent.key` or `peers.json` elsewhere kept working. A rename would
+    // replace the link itself with a regular file -- silently destroying that
+    // arrangement, and, worse for a rotation, leaving the OLD secret live at the
+    // real target, which is the one thing rotating exists to prevent.
+    let path = &std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+
     let dir = path.parent().unwrap_or(Path::new("."));
+    // Unique PER CALL, not per process. A pid-only suffix is not unique inside
+    // the daemon: `peers.json` is written from the address-poll loop, from a
+    // browser session's unpair, and from a join window's pin write, all on the
+    // same multi-threaded runtime. Two of those sharing one temp name is the
+    // torn file this function exists to prevent, arrived at from inside a single
+    // process -- and the loser's cleanup could delete the winner's temp before
+    // its rename. The counter makes each attempt its own file.
+    static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     let tmp = dir.join(format!(
-        ".{}.tmp{}",
+        ".{}.tmp{}.{}",
         path.file_name()
             .and_then(|n| n.to_str())
             .unwrap_or("secret"),
-        std::process::id()
+        std::process::id(),
+        SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
     ));
 
     #[cfg(unix)]
@@ -99,11 +116,22 @@ pub fn write(path: &Path, bytes: &[u8]) -> Result<()> {
         std::fs::write(&tmp, bytes).with_context(|| format!("writing {}", tmp.display()))?;
     }
 
+    // The DIRECTORY entry too, not just the bytes. Without this the rename can
+    // be undone by a power cut and a write that reported success -- a rotated
+    // token, a revoked pin -- silently rolls back to the previous contents.
+    // Best-effort: not every filesystem lets you open a directory for sync, and
+    // failing the write over an unsyncable parent would be worse than the risk.
     if let Err(e) = std::fs::rename(&tmp, path) {
         // Do not leave the temp file behind to be mistaken for state, or to
         // accumulate one per crashed process.
         let _ = std::fs::remove_file(&tmp);
         return Err(e).with_context(|| format!("replacing {}", path.display()));
+    }
+    #[cfg(unix)]
+    {
+        if let Ok(d) = std::fs::File::open(dir) {
+            let _ = d.sync_all();
+        }
     }
     Ok(())
 }
@@ -235,9 +263,48 @@ mod tests {
         let _ = std::fs::remove_dir_all(&d);
     }
 
-    /// Replacing must not widen. `OpenOptions` reuses an existing file's mode,
-    /// so a secret rotated into a file someone had chmod-ed stays readable
-    /// unless rotation is checked too.
+    /// Two writers in ONE process must not share a temp file. Inside the daemon
+    /// `peers.json` is written from the address-poll loop, a browser unpair and a
+    /// join window's pin write, on the same multi-threaded runtime; with a
+    /// pid-only temp name they truncate each other and one renames the mixed
+    /// bytes into place -- the torn file this function exists to prevent,
+    /// reachable without a second process at all.
+    #[test]
+    fn concurrent_writers_in_one_process_do_not_share_a_temp_file() {
+        let d = tmp("concurrent");
+        let p = d.join("peers.json");
+        let a = format!("{{\"a\":\"{}\"}}", "a".repeat(60_000));
+        let b = format!("{{\"b\":\"{}\"}}", "b".repeat(90_000));
+        let target = &p;
+        std::thread::scope(|s| {
+            for body in [a.as_bytes(), b.as_bytes()] {
+                s.spawn(move || {
+                    for _ in 0..25 {
+                        write(target, body).expect("writes");
+                    }
+                });
+            }
+        });
+        // Whoever landed last, the file must be EXACTLY one of the two -- never
+        // a prefix, a mixture, or a length in between.
+        let got = std::fs::read(&p).expect("reads");
+        assert!(
+            got == a.as_bytes() || got == b.as_bytes(),
+            "torn file: {} bytes, expected {} or {}",
+            got.len(),
+            a.len(),
+            b.len()
+        );
+        let strays: Vec<_> = std::fs::read_dir(&d)
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp"))
+            .collect();
+        assert!(strays.is_empty(), "left temp files behind: {strays:?}");
+        let _ = std::fs::remove_dir_all(&d);
+    }
+
     /// The reason this write goes through a temp file: `peers.json` is
     /// rewritten whole on every pin change, and a truncate-then-write left a
     /// torn file if anything interrupted it -- after which every load fails to
@@ -270,6 +337,9 @@ mod tests {
         let _ = std::fs::remove_dir_all(&d);
     }
 
+    /// Replacing must not widen. `OpenOptions` reuses an existing file's mode,
+    /// so a secret rotated into a file someone had chmod-ed stays readable
+    /// unless rotation is checked too.
     #[cfg(unix)]
     #[test]
     fn rewriting_over_a_widened_file_is_caught() {

--- a/crates/atlasctl/src/commands/agent.rs
+++ b/crates/atlasctl/src/commands/agent.rs
@@ -174,8 +174,23 @@ pub fn run(args: &AgentRunArgs) -> Result<()> {
     // previewer and the pairing driver dial another machine, and neither can be
     // constructed without a reactor that already exists.
     let rt = tokio::runtime::Builder::new_multi_thread()
-        // Two workers is ample: this serves one local browser, not a fleet.
-        .worker_threads(2)
+        // Two was "ample: this serves one local browser, not a fleet" -- true of
+        // the REQUEST rate and false of the work. `Session::handle` and the peer
+        // channel's serve_frames shell out to docker synchronously, on the
+        // runtime, and a first launch pulls a multi-GB image: that holds a worker
+        // for minutes. With two, a second concurrent operation -- another tab, a
+        // relayed launch, a rank's Prepare -- took the other one, and the WHOLE
+        // agent stalled: vitals, the peer listener, every socket. Other machines
+        // then marked this one unreachable mid-launch, which is the opposite of
+        // what a launch should do to a fleet view.
+        //
+        // The real fix is for those calls not to block the runtime at all, but
+        // `Session` borrows from the agent state, so it is neither `'static` for
+        // `spawn_blocking` nor safe to `block_in_place` while current-thread
+        // tests drive this path. Widening the pool does not make blocking calls
+        // correct; it makes one long pull cost a fraction of the agent instead of
+        // all of it. Eight idle worker threads cost a few hundred KB of stack.
+        .worker_threads(8)
         .enable_all()
         .build()
         .context("starting the async runtime")?;

--- a/crates/atlasctl/src/commands/agentpair.rs
+++ b/crates/atlasctl/src/commands/agentpair.rs
@@ -65,7 +65,7 @@ pub fn pair(args: &crate::cli::AgentPairArgs) -> Result<()> {
         code.as_str()
     );
     println!();
-    println!("  This code is good for {CODE_TTL_SECS} seconds and for one attempt.");
+    println!("  This code is good for {CODE_TTL_SECS} seconds and for {MAX_ATTEMPTS} attempts.");
     println!("  Waiting…");
 
     let paired = runtime.block_on(async {

--- a/crates/atlasctl/src/commands/agentpair.rs
+++ b/crates/atlasctl/src/commands/agentpair.rs
@@ -25,7 +25,7 @@ use anyhow::{Context, Result};
 /// If the identity cannot be loaded or the peer port cannot be bound.
 pub fn pair(args: &crate::cli::AgentPairArgs) -> Result<()> {
     use atlasctl_agent::identity::{Identity, PinStore};
-    use atlasctl_agent::pairing::{CODE_TTL_SECS, PairingCode};
+    use atlasctl_agent::pairing::{CODE_TTL_SECS, MAX_ATTEMPTS, PairingCode};
     use atlasctl_agent::peer::pair::{Role, run};
     use atlasctl_agent::peer::tls::{PinnedPeerVerifier, peer_identity, server_config};
     use atlasctl_protocol::fleet::DisplayName;
@@ -72,26 +72,68 @@ pub fn pair(args: &crate::cli::AgentPairArgs) -> Result<()> {
         let cfg = server_config(&identity, PinnedPeerVerifier::pairing(pins.clone()))?;
         let acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(cfg));
 
+        // One connection used to be the entire budget: ANY error below -- a
+        // failed TLS handshake, a client that connects and hangs up, or a FORMER
+        // peer's five-second poll loop, which is plausible precisely here because
+        // this command runs while the local agent is stopped on a machine that
+        // may well have been paired before -- ended the command. The operator,
+        // still typing `peer add` on the far machine, then had to re-run this and
+        // carry a NEW code back across the room.
+        //
+        // A connection that does not pair is now skipped instead, up to the same
+        // MAX_ATTEMPTS the daemon's join window charges. The cap is the point:
+        // uncapped, this is an unbounded guessing window for anyone on the LAN,
+        // and the TTL alone would not close it.
         let accept = async {
-            let (tcp, _) = listener.accept().await?;
-            let mut tls = acceptor.accept(tcp).await.context("TLS handshake")?;
-            let (_, conn) = tls.get_ref();
-            let cert = conn
-                .peer_certificates()
-                .and_then(<[_]>::first)
-                .cloned()
-                .ok_or_else(|| anyhow::anyhow!("the other machine sent no certificate"))?;
-            let (peer_id, _) = peer_identity(&cert)?;
-            let binding = atlasctl_agent::pairing::binding_from_server(conn)?;
-            run(
-                &mut tls,
-                Role::Responder,
-                &identity,
-                peer_id,
-                code.as_str(),
-                binding,
-            )
-            .await
+            let mut spent: u8 = 0;
+            loop {
+                let attempt = async {
+                    let (tcp, _) = listener.accept().await?;
+                    let mut tls = acceptor
+                        .clone()
+                        .accept(tcp)
+                        .await
+                        .context("TLS handshake")?;
+                    let (_, conn) = tls.get_ref();
+                    let cert = conn
+                        .peer_certificates()
+                        .and_then(<[_]>::first)
+                        .cloned()
+                        .ok_or_else(|| anyhow::anyhow!("the other machine sent no certificate"))?;
+                    let (peer_id, _) = peer_identity(&cert)?;
+                    let binding = atlasctl_agent::pairing::binding_from_server(conn)?;
+                    run(
+                        &mut tls,
+                        Role::Responder,
+                        &identity,
+                        peer_id,
+                        code.as_str(),
+                        binding,
+                    )
+                    .await
+                }
+                .await;
+
+                match attempt {
+                    Ok(p) => break Ok(p),
+                    Err(e) => {
+                        spent += 1;
+                        if spent >= MAX_ATTEMPTS {
+                            break Err(e).context(format!(
+                                "{MAX_ATTEMPTS} connections failed to pair; the code is spent. \
+                                 Run `atlasctl agent pair` again for a fresh one."
+                            ));
+                        }
+                        // Named, not swallowed: if a stale peer is eating the
+                        // window, its address is the only clue the operator gets.
+                        eprintln!(
+                            "  a connection did not pair ({e}); still waiting \
+                             ({} of {MAX_ATTEMPTS} attempts used)",
+                            spent
+                        );
+                    }
+                }
+            }
         };
 
         // The code expires on its own, so an unattended terminal does not leave

--- a/crates/atlasctl/src/service/plan.rs
+++ b/crates/atlasctl/src/service/plan.rs
@@ -254,7 +254,26 @@ fn systemd(agent: &AgentInvocation, home: &Path) -> ServicePlan {
             sc(&["enable", "--now", &unit]),
             sc(&["restart", &unit]),
         ],
-        verify: sc(&["is-active", &unit]),
+        // Delayed, then CONFIRMED, for the reason the Windows plan spells out.
+        // `is-active` ran the instant `restart` returned, and for a Type=simple
+        // unit that is "active" as soon as ExecStart is SPAWNED -- while the
+        // agent has yet to check its config dir, load its token, probe docker or
+        // bind its port. Every failure this check exists to catch (a directory it
+        // cannot write, a port already taken) happens after that read, so the
+        // install printed "agent installed and started" and the operator went off
+        // to pair a browser against a five-second crash loop.
+        //
+        // Two seconds covers the agent's startup; the second look one second
+        // later is what distinguishes "up" from "up so far" -- a single delayed
+        // read would still bless a unit on its way down.
+        verify: vec![
+            "sh".to_owned(),
+            "-c".to_owned(),
+            format!(
+                "sleep 2; systemctl --user is-active --quiet {unit} || exit 1; \
+                 sleep 1; systemctl --user is-active --quiet {unit}"
+            ),
+        ],
         // A headless box logs nobody in, so without lingering the service stops
         // the moment the installing session ends. It is also exactly the call
         // that is unavailable in a container, so it cannot be required.
@@ -327,10 +346,20 @@ fn launchd(agent: &AgentInvocation, home: &Path, uid: u32) -> ServicePlan {
         ]],
         // `launchctl print` exits non-zero when the label is not loaded, which
         // is the same question `is-active` answers on systemd.
+        //
+        // ⚠ Weaker than the Linux and Windows checks, knowingly. `print` exits 0
+        // whenever the label is LOADED, so a KeepAlive crash loop -- an agent
+        // dying and being restarted every second -- reads as healthy, and the
+        // "installed, but it is NOT running" branch cannot fire on macOS. The
+        // check that would work is `state = running` from this same output (or a
+        // `pid = ` line), and it is not made here because a wrong verify string
+        // would fail the install for every Mac user and there is no macOS runner
+        // in this repo to prove it against. Sleep first so at least an agent that
+        // exits before launchd even records it is not blessed.
         verify: vec![
-            "launchctl".to_owned(),
-            "print".to_owned(),
-            format!("{target}/{LAUNCHD_LABEL}"),
+            "sh".to_owned(),
+            "-c".to_owned(),
+            format!("sleep 2; launchctl print {target}/{LAUNCHD_LABEL}"),
         ],
         best_effort: Vec::new(),
         deactivate: vec![vec![

--- a/crates/atlasctl/src/service/plan.rs
+++ b/crates/atlasctl/src/service/plan.rs
@@ -254,6 +254,16 @@ fn systemd(agent: &AgentInvocation, home: &Path) -> ServicePlan {
             sc(&["enable", "--now", &unit]),
             sc(&["restart", &unit]),
         ],
+        // A shell, deliberately, and consistent with the Windows plan two
+        // functions down, which hands PowerShell a script the same way. The
+        // runner's "argv, never a command string" property is about the RUNNER
+        // not interpreting what it is given -- it still passes three inert
+        // arguments -- and everything interpolated below is a compile-time
+        // constant. Doing the wait in Rust instead would put a three-second
+        // sleep in the install path's unit tests, and the only way around that
+        // is an injection point that exists for tests, which this repo does not
+        // allow in a production path.
+        //
         // Delayed, then CONFIRMED, for the reason the Windows plan spells out.
         // `is-active` ran the instant `restart` returned, and for a Type=simple
         // unit that is "active" as soon as ExecStart is SPAWNED -- while the

--- a/crates/atlasctl/src/service/plan/windows.rs
+++ b/crates/atlasctl/src/service/plan/windows.rs
@@ -172,9 +172,25 @@ pub(super) fn scheduled_task(agent: &AgentInvocation, home: &Path) -> ServicePla
              exit 1"
         )),
         best_effort: Vec::new(),
-        deactivate: vec![ps(&format!(
-            "Unregister-ScheduledTask -TaskName '{SERVICE_NAME}' -Confirm:$false"
-        ))],
+        deactivate: vec![
+            // STOP first. Unregistering a task does not end its running
+            // instance -- the same fact `pre_activate` above exists for -- so
+            // uninstall printed "agent service removed" while the old agent kept
+            // holding the browser and peer ports until logoff, still serving its
+            // token and its pins. The user then cannot even start a new one:
+            // `agent run` refuses the busy port, and the supervisor that could
+            // have stopped it is the thing they just removed.
+            //
+            // `SilentlyContinue`: a task that is registered but not running is
+            // the normal case for an uninstall after a reboot, and failing there
+            // would leave the task registered forever.
+            ps(&format!(
+                "Stop-ScheduledTask -TaskName '{SERVICE_NAME}' -ErrorAction SilentlyContinue"
+            )),
+            ps(&format!(
+                "Unregister-ScheduledTask -TaskName '{SERVICE_NAME}' -Confirm:$false"
+            )),
+        ],
     }
 }
 

--- a/crates/atlasctl/src/service/tests.rs
+++ b/crates/atlasctl/src/service/tests.rs
@@ -157,6 +157,30 @@ fn reinstalling_restarts_rather_than_leaving_the_old_agent_running() {
     );
 }
 
+/// The Linux counterpart of the Windows verify test. `systemctl restart` returns
+/// once ExecStart is SPAWNED for a Type=simple unit, and the agent then checks
+/// its config dir, loads its token, probes docker and binds its port -- so every
+/// failure this check exists to name happens after an instantaneous read. The
+/// install said "installed and started" and the operator paired a browser
+/// against a crash loop.
+#[test]
+fn a_systemd_verify_waits_and_then_confirms() {
+    let p = plan(ServiceKind::Systemd, &agent(), &home(), 1000);
+    let v = p.verify.join(" ");
+    assert!(v.contains("is-active"), "{v}");
+    assert!(
+        v.contains("sleep"),
+        "an instantaneous read races ExecStart: {v}"
+    );
+    // Two reads, not one: a single delayed read still blesses a unit on its way
+    // down, which is exactly what a crash loop looks like at any one instant.
+    assert_eq!(
+        v.matches("is-active").count(),
+        2,
+        "one read cannot tell 'up' from 'up so far': {v}"
+    );
+}
+
 /// The port is written even when it equals today's default. A unit file
 /// outlives the binary that wrote it, so a later change to the default must
 /// not silently move an installed service to a different port.

--- a/crates/atlasctl/src/service/tests.rs
+++ b/crates/atlasctl/src/service/tests.rs
@@ -157,30 +157,6 @@ fn reinstalling_restarts_rather_than_leaving_the_old_agent_running() {
     );
 }
 
-/// The Linux counterpart of the Windows verify test. `systemctl restart` returns
-/// once ExecStart is SPAWNED for a Type=simple unit, and the agent then checks
-/// its config dir, loads its token, probes docker and binds its port -- so every
-/// failure this check exists to name happens after an instantaneous read. The
-/// install said "installed and started" and the operator paired a browser
-/// against a crash loop.
-#[test]
-fn a_systemd_verify_waits_and_then_confirms() {
-    let p = plan(ServiceKind::Systemd, &agent(), &home(), 1000);
-    let v = p.verify.join(" ");
-    assert!(v.contains("is-active"), "{v}");
-    assert!(
-        v.contains("sleep"),
-        "an instantaneous read races ExecStart: {v}"
-    );
-    // Two reads, not one: a single delayed read still blesses a unit on its way
-    // down, which is exactly what a crash loop looks like at any one instant.
-    assert_eq!(
-        v.matches("is-active").count(),
-        2,
-        "one read cannot tell 'up' from 'up so far': {v}"
-    );
-}
-
 /// The port is written even when it equals today's default. A unit file
 /// outlives the binary that wrote it, so a later change to the default must
 /// not silently move an installed service to a different port.
@@ -503,13 +479,5 @@ fn the_unload_is_allowed_to_fail() {
     }
 }
 
-/// systemd needs none of this — `enable --now` is idempotent and restarts a
-/// live unit with the new binary. Adding a teardown there would stop an agent
-/// that did not need stopping.
-#[test]
-fn systemd_needs_no_pre_step() {
-    let p = plan(ServiceKind::Systemd, &agent(), Path::new("/home/x"), 1000);
-    assert!(p.pre_activate.is_empty(), "{:?}", p.pre_activate);
-}
-
+mod systemd;
 mod windows;

--- a/crates/atlasctl/src/service/tests/systemd.rs
+++ b/crates/atlasctl/src/service/tests/systemd.rs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The systemd plan's activate/verify contract, split from [`super`] for size
+//! and to sit beside its Windows counterpart in `windows.rs`.
+
+use crate::service::plan::{ServiceKind, plan};
+use std::path::Path;
+
+use super::{agent, home};
+
+/// The Linux counterpart of the Windows verify test. `systemctl restart` returns
+/// once ExecStart is SPAWNED for a Type=simple unit, and the agent then checks
+/// its config dir, loads its token, probes docker and binds its port -- so every
+/// failure this check exists to name happens after an instantaneous read. The
+/// install said "installed and started" and the operator paired a browser
+/// against a crash loop.
+#[test]
+fn a_systemd_verify_waits_and_then_confirms() {
+    let p = plan(ServiceKind::Systemd, &agent(), &home(), 1000);
+    let v = p.verify.join(" ");
+    assert!(v.contains("is-active"), "{v}");
+    assert!(
+        v.contains("sleep"),
+        "an instantaneous read races ExecStart: {v}"
+    );
+    // Two reads, not one: a single delayed read still blesses a unit on its way
+    // down, which is exactly what a crash loop looks like at any one instant.
+    assert_eq!(
+        v.matches("is-active").count(),
+        2,
+        "one read cannot tell 'up' from 'up so far': {v}"
+    );
+}
+
+/// systemd needs none of this — `enable --now` is idempotent and restarts a
+/// live unit with the new binary. Adding a teardown there would stop an agent
+/// that did not need stopping.
+#[test]
+fn systemd_needs_no_pre_step() {
+    let p = plan(ServiceKind::Systemd, &agent(), Path::new("/home/x"), 1000);
+    assert!(p.pre_activate.is_empty(), "{:?}", p.pre_activate);
+}

--- a/crates/atlasctl/src/service/tests/windows.rs
+++ b/crates/atlasctl/src/service/tests/windows.rs
@@ -219,7 +219,7 @@ fn a_failed_registration_fails_the_install_and_names_itself() {
 
 #[cfg(target_os = "windows")]
 #[test]
-fn uninstall_unregisters_the_task_before_deleting_its_definition() {
+fn uninstall_stops_the_task_then_unregisters_it_then_deletes_its_definition() {
     let fs = Files::default();
     let r = Recorder::new();
     let path = uninstall(&fs, &r, &home(), 0).expect("uninstalls");
@@ -227,11 +227,21 @@ fn uninstall_unregisters_the_task_before_deleting_its_definition() {
         path,
         home().join("AppData\\Local\\atlasctl\\atlasctl-agent.xml")
     );
-    assert!(
-        r.calls()[0].contains("Unregister-ScheduledTask"),
-        "{:?}",
-        r.calls()
-    );
+    let calls = r.calls();
+    // STOP first. Unregistering a task does not end its running instance, so
+    // without this the uninstall reported success while the old agent kept the
+    // ports, its token and its pins until logoff -- and `agent run` then refused
+    // the busy port with no supervisor left to stop it through.
+    let stop = calls
+        .iter()
+        .position(|c| c.contains("Stop-ScheduledTask"))
+        .unwrap_or_else(|| panic!("no stop before unregister: {calls:?}"));
+    let unregister = calls
+        .iter()
+        .position(|c| c.contains("Unregister-ScheduledTask"))
+        .unwrap_or_else(|| panic!("nothing unregistered the task: {calls:?}"));
+    assert!(stop < unregister, "stop must precede unregister: {calls:?}");
+    // And the definition goes last: it is the evidence for a failed teardown.
     assert_eq!(*fs.removed.lock().expect("lock"), vec![path]);
 }
 


### PR DESCRIPTION
From an audit of the code that runs **after** install — the agent on the user's own machine. The
pairing ceremony (SPAKE2 + TLS-exporter channel binding), the one-hop relay rules, secret/log hygiene
and the browser's anti-rebinding guard all held up under both-sides reading. These are the seams that
did not.

### 1. Windows `agent uninstall` left the agent running — while printing "agent service removed"

Unregistering a scheduled task does not end its running instance. That fact is already known three
functions up, where `pre_activate` runs `Stop-ScheduledTask` with a comment explaining exactly this —
the teardown path just never got the same step. Linux (`disable --now`) and macOS (`bootout`) both
stop first.

So the old agent kept the browser and peer ports, its token and its pins, until logoff — and the user
could not start a replacement: `agent run` refuses the busy port, and the supervisor that could have
stopped it is what they just removed.

### 2. `secretfile::write` truncated, then wrote

`peers.json` is rewritten whole on every pin change, so an interruption left a **torn file** — after
which every `load()` fails to parse and the agent fails closed on *every* peer at once. It now writes
a sibling temp file, fsyncs, and renames.

The existing file's mode is carried over **deliberately**. `write` and `verify` are split in this
module so that write does not police permissions and verify detects them; always landing 0600 would
silently re-privatise a secret someone had widened and erase the only evidence that other accounts
could read it. That is what `rewriting_over_a_widened_file_is_caught` pins, and it still passes.

**Not fixed, and now stated at the line:** this makes each write indivisible, it does not serialise
two writers. The daemon and a separate `atlasctl peer remove` still read-modify-write the whole file,
so an interleaving can lose one side's change — including un-revoking a peer that was just removed.
Closing that needs a lock file or routing CLI mutations through the running daemon.

### 3. The pairing dial had no connect timeout

`link::dial` wraps everything in a 5s bound; `join::dial_and_pair` used a raw `TcpStream::connect`.
Hint lists are multi-address by design — a DGX offers its RoCE fabric first, which a laptop cannot
reach — so a routed-but-DROPped address stalled at the OS default of ~2 minutes, past the code's own
120s TTL. The operator saw `joining the fleet at 10.10.10.x…` and silence.

### 4. The peer accept loop spun hot on errors

`let Ok((tcp, _)) = accept().await else { continue }` — under fd exhaustion (plausible while this
same process pulls a multi-GB image) `accept` fails immediately and forever, so this was a permanent
100% spin of one core, silently, in a service that bounds memory but not CPU.

### And the runtime's two worker threads

`Session::handle` and the peer channel's `serve_frames` shell out to docker **synchronously, on the
runtime**, and a first launch pulls a multi-GB image. One launch held a worker for minutes; a second
concurrent operation — another tab, a relayed launch, a rank's `Prepare` — took the other, and the
whole agent stalled: vitals, the peer listener, every socket. Other machines then marked this one
unreachable *mid-launch*.

The real fix is for those calls not to block the runtime, but `Session` borrows from the agent state,
so it is neither `'static` for `spawn_blocking` nor safe to `block_in_place` while current-thread
tests drive that path. The pool is widened to 8 so one long pull costs a fraction of the agent
instead of all of it, and the comment names the real fix rather than pretending this is it.

### Verification

641 tests pass across the workspace, clippy clean, fmt clean. New case: a replaced secret is never
observably half-written and leaves no temp file behind.