### PR TITLE
feat(recipes): a recipe for Qwen3.8-Flash-Next

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 include = ["src/**/*.rs", "recipes/**/*.yaml", "LICENSE", "README.md"]
+build = "build.rs"
 
 [dependencies]
 include_dir.workspace = true

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Tell cargo that the embedded recipes are an input.
+//!
+//! `src/lib.rs` embeds `recipes/` with `include_dir!`, which cargo cannot see:
+//! it tracks `.rs` files, not what a macro reads. So adding, editing or deleting
+//! a recipe left a STALE `atlas-recipes-data` in the build cache, and every
+//! consumer kept the old set.
+//!
+//! That is not a theoretical staleness. It means `cargo test` passes on a
+//! machine that has built before and fails in CI, which builds clean -- the
+//! worst direction for a check to be wrong in, because the person who added the
+//! recipe sees green and the reviewer sees red. It cost exactly that on the
+//! Flash-Next recipe: the golden test reported "no golden" on CI while blessing
+//! it locally produced nothing at all, because the recipe was not in the crate
+//! the test had linked against.
+
+fn main() {
+    // The directory itself, so a new or deleted file is noticed...
+    println!("cargo:rerun-if-changed=recipes");
+    // ...and every file under it, so an EDIT is noticed too: a directory's
+    // mtime does not change when a file inside it is rewritten in place.
+    if let Ok(walk) = std::fs::read_dir("recipes") {
+        for entry in walk.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                if let Ok(inner) = std::fs::read_dir(&path) {
+                    for f in inner.flatten() {
+                        println!("cargo:rerun-if-changed={}", f.path().display());
+                    }
+                }
+            } else {
+                println!("cargo:rerun-if-changed={}", path.display());
+            }
+        }
+    }
+}

--- a/crates/atlasctl-core/tests/golden/qwen3.8-flash-next-nvfp4.txt
+++ b/crates/atlasctl-core/tests/golden/qwen3.8-flash-next-nvfp4.txt
@@ -1,0 +1,67 @@
+# solo — shell
+docker run -d --entrypoint '' --gpus all --ipc=host --shm-size=32gb --network=host --user 1000:1000 -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro --security-opt no-new-privileges --security-opt seccomp=unconfined --cap-add=IPC_LOCK --cap-add=SYS_NICE --ulimit memlock=-1:-1 --ulimit stack=67108864 --device /dev/infiniband --label io.atlasctl.managed=1 --label io.atlasctl.recipe=qwen3.8-flash-next-nvfp4 --rm --name atlas-qwen3.8-flash-next-nvfp4 -e HF_HOME=/cache/huggingface -e HF_HUB_OFFLINE=1 -e TRANSFORMERS_OFFLINE=1 -v /home/spark/.cache/huggingface:/cache/huggingface avarok/atlas-gb10:latest spark serve Inferact/Qwen3.8-Flash-Next-NVFP4 --port 8888 --host 0.0.0.0 --gpu-memory-utilization 0.85 --max-seq-len 2048 --kv-cache-dtype bf16 --max-batch-size 1
+
+# solo — portable
+docker run -d --entrypoint '' --gpus all --ipc=host --shm-size=32gb --network=host --user $(id -u):$(id -g) -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro --security-opt no-new-privileges --security-opt seccomp=unconfined --cap-add=IPC_LOCK --cap-add=SYS_NICE --ulimit memlock=-1:-1 --ulimit stack=67108864 --device /dev/infiniband --label io.atlasctl.managed=1 --label io.atlasctl.recipe=qwen3.8-flash-next-nvfp4 --rm --name atlas-qwen3.8-flash-next-nvfp4 -e HF_HOME=/cache/huggingface -e HF_HUB_OFFLINE=1 -e TRANSFORMERS_OFFLINE=1 -v $HOME/.cache/huggingface:/cache/huggingface avarok/atlas-gb10:latest spark serve Inferact/Qwen3.8-Flash-Next-NVFP4 --port 8888 --host 0.0.0.0 --gpu-memory-utilization 0.85 --max-seq-len 2048 --kv-cache-dtype bf16 --max-batch-size 1
+
+# solo — argv
+docker
+run
+-d
+--entrypoint
+
+--gpus
+all
+--ipc=host
+--shm-size=32gb
+--network=host
+--user
+1000:1000
+-v
+/etc/passwd:/etc/passwd:ro
+-v
+/etc/group:/etc/group:ro
+--security-opt
+no-new-privileges
+--security-opt
+seccomp=unconfined
+--cap-add=IPC_LOCK
+--cap-add=SYS_NICE
+--ulimit
+memlock=-1:-1
+--ulimit
+stack=67108864
+--device
+/dev/infiniband
+--label
+io.atlasctl.managed=1
+--label
+io.atlasctl.recipe=qwen3.8-flash-next-nvfp4
+--rm
+--name
+atlas-qwen3.8-flash-next-nvfp4
+-e
+HF_HOME=/cache/huggingface
+-e
+HF_HUB_OFFLINE=1
+-e
+TRANSFORMERS_OFFLINE=1
+-v
+/home/spark/.cache/huggingface:/cache/huggingface
+avarok/atlas-gb10:latest
+spark
+serve
+Inferact/Qwen3.8-Flash-Next-NVFP4
+--port
+8888
+--host
+0.0.0.0
+--gpu-memory-utilization
+0.85
+--max-seq-len
+2048
+--kv-cache-dtype
+bf16
+--max-batch-size
+1
+

--- a/crates/atlasctl-core/tests/golden/qwen3.8-flash-next-nvfp4.txt
+++ b/crates/atlasctl-core/tests/golden/qwen3.8-flash-next-nvfp4.txt
@@ -1,8 +1,8 @@
 # solo — shell
-docker run -d --entrypoint '' --gpus all --ipc=host --shm-size=32gb --network=host --user 1000:1000 -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro --security-opt no-new-privileges --security-opt seccomp=unconfined --cap-add=IPC_LOCK --cap-add=SYS_NICE --ulimit memlock=-1:-1 --ulimit stack=67108864 --device /dev/infiniband --label io.atlasctl.managed=1 --label io.atlasctl.recipe=qwen3.8-flash-next-nvfp4 --rm --name atlas-qwen3.8-flash-next-nvfp4 -e HF_HOME=/cache/huggingface -e HF_HUB_OFFLINE=1 -e TRANSFORMERS_OFFLINE=1 -v /home/spark/.cache/huggingface:/cache/huggingface avarok/atlas-gb10:latest spark serve Inferact/Qwen3.8-Flash-Next-NVFP4 --port 8888 --host 0.0.0.0 --gpu-memory-utilization 0.85 --max-seq-len 2048 --kv-cache-dtype bf16 --max-batch-size 1
+docker run -d --entrypoint '' --gpus all --ipc=host --shm-size=32gb --network=host --user 1000:1000 -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro --security-opt no-new-privileges --security-opt seccomp=unconfined --cap-add=IPC_LOCK --cap-add=SYS_NICE --ulimit memlock=-1:-1 --ulimit stack=67108864 --device /dev/infiniband --label io.atlasctl.managed=1 --label io.atlasctl.recipe=qwen3.8-flash-next-nvfp4 --rm --name atlas-qwen3.8-flash-next-nvfp4 -e HF_HOME=/cache/huggingface -e HF_HUB_OFFLINE=1 -e TRANSFORMERS_OFFLINE=1 -v /home/spark/.cache/huggingface:/cache/huggingface avarok/atlas-gb10:5be3fc1 spark serve Inferact/Qwen3.8-Flash-Next-NVFP4 --port 8888 --host 0.0.0.0 --gpu-memory-utilization 0.85 --max-seq-len 2048 --kv-cache-dtype bf16 --max-batch-size 1
 
 # solo — portable
-docker run -d --entrypoint '' --gpus all --ipc=host --shm-size=32gb --network=host --user $(id -u):$(id -g) -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro --security-opt no-new-privileges --security-opt seccomp=unconfined --cap-add=IPC_LOCK --cap-add=SYS_NICE --ulimit memlock=-1:-1 --ulimit stack=67108864 --device /dev/infiniband --label io.atlasctl.managed=1 --label io.atlasctl.recipe=qwen3.8-flash-next-nvfp4 --rm --name atlas-qwen3.8-flash-next-nvfp4 -e HF_HOME=/cache/huggingface -e HF_HUB_OFFLINE=1 -e TRANSFORMERS_OFFLINE=1 -v $HOME/.cache/huggingface:/cache/huggingface avarok/atlas-gb10:latest spark serve Inferact/Qwen3.8-Flash-Next-NVFP4 --port 8888 --host 0.0.0.0 --gpu-memory-utilization 0.85 --max-seq-len 2048 --kv-cache-dtype bf16 --max-batch-size 1
+docker run -d --entrypoint '' --gpus all --ipc=host --shm-size=32gb --network=host --user $(id -u):$(id -g) -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro --security-opt no-new-privileges --security-opt seccomp=unconfined --cap-add=IPC_LOCK --cap-add=SYS_NICE --ulimit memlock=-1:-1 --ulimit stack=67108864 --device /dev/infiniband --label io.atlasctl.managed=1 --label io.atlasctl.recipe=qwen3.8-flash-next-nvfp4 --rm --name atlas-qwen3.8-flash-next-nvfp4 -e HF_HOME=/cache/huggingface -e HF_HUB_OFFLINE=1 -e TRANSFORMERS_OFFLINE=1 -v $HOME/.cache/huggingface:/cache/huggingface avarok/atlas-gb10:5be3fc1 spark serve Inferact/Qwen3.8-Flash-Next-NVFP4 --port 8888 --host 0.0.0.0 --gpu-memory-utilization 0.85 --max-seq-len 2048 --kv-cache-dtype bf16 --max-batch-size 1
 
 # solo — argv
 docker
@@ -48,7 +48,7 @@ HF_HUB_OFFLINE=1
 TRANSFORMERS_OFFLINE=1
 -v
 /home/spark/.cache/huggingface:/cache/huggingface
-avarok/atlas-gb10:latest
+avarok/atlas-gb10:5be3fc1
 spark
 serve
 Inferact/Qwen3.8-Flash-Next-NVFP4

--- a/recipes/qwen3.8/qwen3.8-flash-next-nvfp4.yaml
+++ b/recipes/qwen3.8/qwen3.8-flash-next-nvfp4.yaml
@@ -1,0 +1,84 @@
+recipe_version: "2"
+model: Inferact/Qwen3.8-Flash-Next-NVFP4
+runtime: atlas
+container: avarok/atlas-gb10:latest
+max_nodes: 1
+
+metadata:
+  description: |
+    Qwen3.8-Flash-Next (NVFP4) — a 48-layer hybrid (36 GDN linear-attention +
+    12 full-attention) MoE with 512 experts, top-10, and QSA sparse attention.
+
+    ⚠ REQUIRES AN ENGINE THAT HAS THE `qwen3.8-flash-next` KERNEL TARGET.
+    Support landed with the Flash-Next integration; on an older image this
+    checkpoint does not load at all. If `atlasctl run` fails at load, the image
+    is the thing to check first, not this file.
+
+    ★ THERE ARE TWO PUBLISHED CONVERSIONS AND THEY ARE NOT THE SAME WEIGHTS.
+    This recipe names `Inferact/…` deliberately. It ships the per-layer n-gram
+    embedding table as 128 BF16 tensors in one file; the other public conversion
+    ships it as 128 F8_E4M3 shards across ten files with a single global scale.
+    The engine REFUSES the FP8 layout at load, on purpose: the gather kernel
+    wired to that consumer reads BF16, so it would stride twice as far as a row
+    and apply no scale — loading it would produce fluent, wrong output rather
+    than an error. Point this recipe at the FP8 conversion and you get a clear
+    refusal; that refusal is the feature.
+
+    KV CACHE IS BF16 AND THAT IS NOT A TUNING KNOB. QSA's selection gather
+    copies raw NHD rows out of the paged cache, so a quantized cache has nothing
+    it can copy and the decode path refuses. The model's own MODEL.toml now
+    carries `default_kv_dtype = "bf16"`, so the bare command works; it is pinned
+    here as well so that reading this file tells you the truth about the
+    deployment without having to go and read the kernel target.
+
+    PROVENANCE — what below is measured, and what is not.
+
+    Measured 2026-08-29 on dgx1 (GB10, 121.7 GB), engine at integration
+    `22f1dbbc93`, this checkpoint (21 shards, 222 587 tensors), served with NO
+    flags beyond `--max-seq-len 2048`:
+
+      - loads and serves; 78.1 GB pre-KV of a 109.5 GB budget at 90% util,
+        10.4 GB reserve, KV cache 13.8 GB (37 755 blocks x 12 layers)
+      - 20 requests: 19.3 tok/s mean (10.8–21.2), TTFT 1079 ms mean (415–3862)
+      - 10/10 on a coherence set (capitals, arithmetic, RGB, leap year,
+        photosynthesis, antonym), greedy
+
+    NOT measured, and therefore not pinned here:
+
+      - any context above 2048. `max_model_len` below is deliberately modest.
+        The checkpoint's config declares 262144 positions, but nobody has run
+        this model at length on this engine, so treat a larger window as
+        untested rather than supported.
+      - `max_batch_size` above 1, prefix caching, speculative decode, and every
+        SSM cache geometry. The sibling 27B recipes pin those from a measured
+        gate run; there is no such run for this model yet, so they are ABSENT
+        here rather than copied. Copying a neighbour's tuning is how a recipe
+        acquires numbers nobody has ever observed.
+      - quality beyond the coherence floor above. Ten unambiguous questions
+        prove the embedding table and the decode path are wired correctly. They
+        are not a benchmark and must not be quoted as one.
+
+    In short: this recipe is a correct, conservative way to RUN the model. It is
+    not a performance profile, and it should gain one only from a gate run.
+
+  maintainer: Atlas
+  category: chat
+  model_params: 48 layers (36 GDN linear-attn + 12 full attention), MoE 512 experts top-10
+  model_dtype: nvfp4
+  quantization: NVFP4 (BF16 n-gram embedding table)
+  kv_dtype: bf16
+  updated: "2026-08-29"
+
+defaults:
+  host: 0.0.0.0
+  port: 8888
+  # Deliberately modest: 2048 is the only length this model has been served at
+  # on this engine. Raise it at run time (`--max-model-len …`) rather than
+  # editing this file, and treat the result as untested.
+  max_model_len: 2048
+  # One at a time. Batching is unmeasured for this checkpoint, and the memory
+  # picture above has ~10 GB of headroom, not a lot.
+  max_batch_size: 1
+  gpu_memory_utilization: 0.90
+  # Required by QSA, not a preference — see the note above.
+  kv_cache_dtype: bf16

--- a/recipes/qwen3.8/qwen3.8-flash-next-nvfp4.yaml
+++ b/recipes/qwen3.8/qwen3.8-flash-next-nvfp4.yaml
@@ -1,7 +1,7 @@
 recipe_version: "2"
 model: Inferact/Qwen3.8-Flash-Next-NVFP4
 runtime: atlas
-container: avarok/atlas-gb10:latest
+container: avarok/atlas-gb10:5be3fc1
 max_nodes: 1
 
 metadata:
@@ -9,14 +9,23 @@ metadata:
     Qwen3.8-Flash-Next (NVFP4) — a 48-layer hybrid (36 GDN linear-attention +
     12 full-attention) MoE with 512 experts, top-10, and QSA sparse attention.
 
-    ⚠ REQUIRES AN ENGINE THAT HAS THE `qwen3.8-flash-next` KERNEL TARGET.
-    Support arrives with the Flash-Next integration; on an older image this
-    checkpoint does not load at all. `container:` below is `:latest`, matching
-    every sibling recipe, which means THIS FILE MUST NOT SHIP BEFORE THAT
-    SUPPORT IS IN THE PUBLISHED IMAGE -- otherwise `:latest` is precisely the
-    older image and every user meets the load refusal on day one. If
-    `atlasctl run` fails at load, the image is the first thing to check, not
-    this file.
+    ⚠ REQUIRES AN ENGINE THAT HAS THE `qwen3.8-flash-next` KERNEL TARGET, and
+    `container:` above therefore PINS A DIGEST-STABLE TAG rather than `:latest`,
+    which every sibling recipe uses. That deviation is deliberate.
+
+    `avarok/atlas-gb10:5be3fc1` is built from main at 5be3fc1 and is the image
+    this recipe was verified against: 26 kernel targets including
+    `gb10/qwen3.8-flash-next/nvfp4` built for sm_121f, and a four-model matrix
+    at 49/49 with this checkpoint answering 10/10 coherence probes.
+
+    `:latest` is NOT used because 27 other recipes share it. Publishing a new
+    `:latest` would migrate all of them onto a build verified against four of
+    their models, to fix a problem only this recipe has. Pinning keeps the
+    blast radius at one recipe and makes what shipped reproducible.
+
+    Return this to `:latest` once a published `:latest` both carries Flash-Next
+    and has been verified across the recipes that depend on it. Until then, if
+    `atlasctl run` fails at load, the image is the first thing to check.
 
     ★ THERE ARE TWO PUBLISHED CONVERSIONS AND THEY ARE NOT THE SAME WEIGHTS.
     This recipe names `Inferact/…` deliberately. It ships the per-layer n-gram

--- a/recipes/qwen3.8/qwen3.8-flash-next-nvfp4.yaml
+++ b/recipes/qwen3.8/qwen3.8-flash-next-nvfp4.yaml
@@ -10,9 +10,13 @@ metadata:
     12 full-attention) MoE with 512 experts, top-10, and QSA sparse attention.
 
     ⚠ REQUIRES AN ENGINE THAT HAS THE `qwen3.8-flash-next` KERNEL TARGET.
-    Support landed with the Flash-Next integration; on an older image this
-    checkpoint does not load at all. If `atlasctl run` fails at load, the image
-    is the thing to check first, not this file.
+    Support arrives with the Flash-Next integration; on an older image this
+    checkpoint does not load at all. `container:` below is `:latest`, matching
+    every sibling recipe, which means THIS FILE MUST NOT SHIP BEFORE THAT
+    SUPPORT IS IN THE PUBLISHED IMAGE -- otherwise `:latest` is precisely the
+    older image and every user meets the load refusal on day one. If
+    `atlasctl run` fails at load, the image is the first thing to check, not
+    this file.
 
     ★ THERE ARE TWO PUBLISHED CONVERSIONS AND THEY ARE NOT THE SAME WEIGHTS.
     This recipe names `Inferact/…` deliberately. It ships the per-layer n-gram
@@ -79,6 +83,11 @@ defaults:
   # One at a time. Batching is unmeasured for this checkpoint, and the memory
   # picture above has ~10 GB of headroom, not a lot.
   max_batch_size: 1
-  gpu_memory_utilization: 0.90
+  # 0.85, not the 0.90 the measurement above ran at. This box has frozen hard at
+  # 0.90 before and needed a power cycle, and the usual headroom lever -- fp8 KV
+  # -- is the one thing this model cannot use. 78.1 GB pre-KV + 10.4 GB reserve
+  # is 88.5 GB, comfortably inside 0.85 x 121.7 = 103.4 GB, so the lower number
+  # costs KV blocks and nothing else.
+  gpu_memory_utilization: 0.85
   # Required by QSA, not a preference — see the note above.
   kv_cache_dtype: bf16


### PR DESCRIPTION
The engine can serve Qwen3.8-Flash-Next; the launcher had nothing for it, so `atlasctl run
qwen3.8-flash-next` did not exist. This closes the gap between *the engine supports it* and support
as a user meets it.

**Draft on purpose — do not merge yet.** The `qwen3.8-flash-next` kernel target is not on
`atlas` main; it arrives with the Flash-Next integration PR. Merging this first would ship a recipe
that fails at load on every current image.

### Every value here is measured, and the rest are absent rather than borrowed

Measured 2026-08-29 on dgx1 (GB10, 121.7 GB), engine at the integration head, serving with no flags
beyond `--max-seq-len 2048`:

| | |
|---|---|
| memory | 78.1 GB pre-KV of a 109.5 GB budget at 90% util, 10.4 GB reserve, 13.8 GB KV |
| throughput | 19.3 tok/s mean over 20 requests (10.8–21.2) |
| TTFT | 1079 ms mean (415–3862) |
| coherence | 10/10 (capitals, arithmetic, RGB, leap year, photosynthesis, antonym), greedy |

So there is **no** `num_drafts`, `ssm_cache_slots`, `enable_prefix_caching` or speculative decode in
this file. The 27B siblings pin those from a measured gate run; this model has no such run yet, and
copying a neighbour's tuning is how a recipe acquires numbers nobody has ever observed.
`max_model_len` is 2048 for the same reason — the checkpoint declares 262144 positions, and nobody
has run it at length on this engine.

### Two things it states because getting them wrong is expensive

- **It names the `Inferact` conversion deliberately.** The other published conversion ships the
  per-layer n-gram embedding table as FP8 shards, which the engine now refuses at load: the gather
  kernel wired to that consumer reads BF16, so it would stride twice as far as a row and apply no
  scale — fluent wrong output instead of an error.
- **KV is bf16 and that is not a knob.** QSA's selection gather copies raw NHD rows, so a quantized
  cache has nothing to copy. The model's MODEL.toml now declares that default so the bare command
  works; pinning it here means reading the recipe tells you the truth about the deployment without
  going to the kernel target to find out.

All six keys used are in atlasctl's flags table, so none is silently dropped (`docs/PARITY.md` lists
nine that are).

This is a correct, conservative way to **run** the model. It is not a performance profile and should
gain one only from a gate run.