### PR TITLE
fix(install.ps1): stop leaving the operator's PowerShell session altered

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -22,8 +22,19 @@
 # `irm | iex` cannot pass arguments; `[scriptblock]::Create` can, and is the
 # idiom every Windows installer that takes options uses.
 
+# `irm | iex` runs this in the CALLER'S SCOPE, so anything set here is still set
+# in the operator's session afterwards. `$ErrorActionPreference` is saved and put
+# back at the end for that reason: without it, a successful install silently left
+# every later command in the window failing on the first non-terminating error.
+$__atlasPrevEap = $ErrorActionPreference
 $ErrorActionPreference = 'Stop'
-Set-StrictMode -Version Latest
+
+# NOT `Set-StrictMode` here, for the same reason and one more: there is no way to
+# read the caller's current strict mode, so it cannot be restored -- turning it
+# off at the end would be a change in its own right for anyone who had it on. The
+# test harness sets it before loading these functions, so the strictness this
+# script is written under is still enforced where it can be observed, and not
+# imposed on a session that did not ask for it.
 
 # Deliberately NO `param()` block, and every option parsed by hand.
 #
@@ -354,4 +365,11 @@ try {
     Write-Info "    $BinName run qwen3.6-35b-a3b-fp8-mtp"
 } finally {
     Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
+    # Hand the session back as it was found. This runs on the success path and on
+    # a thrown failure; it does NOT run when `Die` calls `exit`, which is the
+    # right trade -- the operator is looking at an error message there, and
+    # restructuring the whole script to catch that case would put `exit`
+    # semantics inside a script block, where a failed checksum might stop halting
+    # the install. That is a far worse bug than a preference left set.
+    $ErrorActionPreference = $__atlasPrevEap
 }

--- a/scripts/tests/install-ps1.test.ps1
+++ b/scripts/tests/install-ps1.test.ps1
@@ -13,6 +13,10 @@
 # test-specific code in a production path; this file is where that cost belongs.
 
 $ErrorActionPreference = 'Stop'
+# The shipped script no longer sets this itself: `irm | iex` runs in the caller's
+# scope and it cannot be restored. The strictness the script is WRITTEN under is
+# enforced here instead, where it costs no one their session.
+Set-StrictMode -Version Latest
 
 $root = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 $src = Get-Content -Raw -Encoding UTF8 -LiteralPath (Join-Path $root 'scripts/install.ps1')
@@ -145,6 +149,28 @@ Write-Host 'REACHED-THE-LINE-AFTER'
 # x86_64 download that would run under emulation against an untested Docker.
 $t = Get-Target
 Should-Contain 'this runner resolves to a real target' $t 'pc-windows-msvc'
+
+# ── what the script does to the CALLER'S session ───────────────────────────────
+# `irm | iex` executes in the caller's scope, so these are properties of the
+# shipped TEXT, not of anything a loaded function can be asked. An operator whose
+# window is left in Stop-on-everything, or in strict mode, finds their next
+# pasted snippet failing for reasons that have nothing to do with them.
+$src = Get-Content -Raw -Encoding UTF8 -LiteralPath (Join-Path $root 'scripts/install.ps1')
+
+# Only the comment explaining its absence may mention it.
+$strictCalls = [regex]::Matches($src, '(?m)^\s*Set-StrictMode').Count
+if ($strictCalls -eq 0) {
+    Ok 'the installer does not impose strict mode on the caller''s session'
+} else {
+    Bad 'the installer does not impose strict mode on the caller''s session' "found $strictCalls Set-StrictMode call(s); iex cannot undo them"
+}
+
+if ($src -match '\$__atlasPrevEap = \$ErrorActionPreference' -and
+    $src -match '\$ErrorActionPreference = \$__atlasPrevEap') {
+    Ok 'ErrorActionPreference is saved and put back'
+} else {
+    Bad 'ErrorActionPreference is saved and put back' 'a successful install must hand the session back as it found it'
+}
 
 Write-Host ""
 Write-Host "  $script:pass passed, $script:fail failed"


### PR DESCRIPTION
The last finding from the onboarding audit, and the one I deferred at the time because the obvious
fix was worse than the bug.

`irm … | iex` executes in the **caller's scope**. So a successful install left
`$ErrorActionPreference = 'Stop'` and `Set-StrictMode -Version Latest` set in the operator's window,
and the next thing they pasted failed for reasons that had nothing to do with it — an unset variable,
or a non-terminating error suddenly fatal.

**`$ErrorActionPreference`** is saved and put back in the existing `finally`, covering the success
path and a thrown failure.

It does **not** cover `Die`, which calls `exit`. That is deliberate. The alternative — moving the
100-line main section into `& { … }` so the exit could be contained — changes what `exit` means, and
`Die` is what halts the install on a **checksum mismatch**. Trading a stray preference for a possible
silent execution of unverified bytes is not a trade worth making, least of all unattended and with no
Windows box to test the semantics on. The operator is looking at an error message in that path
anyway.

**`Set-StrictMode`** is no longer set by the shipped script at all. There is no way to read a
caller's current strict mode, so it cannot be restored, and turning it *off* at the end would be its
own unwanted change for anyone who had it on. The test harness now sets it before loading the
functions, so the strictness the script is written under is still enforced where it can be observed —
and is not imposed on a session that never asked for it.

### Tests

Both are properties of the shipped **text**, not of anything a loaded function can be asked, so the
two new cases assert against the file itself: no `Set-StrictMode` call survives (the comment
explaining its absence does not match), and the preference is both saved and restored. I simulated
both assertions against the real file before pushing; `install-sh` remains 43/43.