### PR TITLE
fix(install): upgrade on CONTENT, not on the version string

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -175,6 +175,25 @@ function Get-Version {
     try { return (& $Exe --version 2>$null | Select-Object -First 1) } catch { return '' }
 }
 
+# Should the downloaded binary replace the installed one? CONTENT, not version.
+#
+# `--version` reports the crate semver, which release tooling bumps only
+# sometimes, so two builds separated by an entire wire-protocol revision can
+# both report "atlasctl 0.1.7". A user hit exactly that: their agent spoke
+# protocol 1, the published build spoke 4, both said 0.1.7, and the installer
+# answered "already installed" every time while the control page kept sending
+# them back to it. Bytes cannot lie about this.
+function Test-BinaryDiffers {
+    param($Installed, $Downloaded)
+    if (-not (Test-Path -LiteralPath $Installed)) { return $true }
+    try {
+        return (Get-Sha256 $Installed) -ne (Get-Sha256 $Downloaded)
+    } catch {
+        # Unreadable installed binary: replacing it is the safe direction.
+        return $true
+    }
+}
+
 function Install-Agent {
     param($Exe, $SameVersion, $JoinTarget, [bool]$Grant)
 
@@ -313,12 +332,21 @@ try {
     # changes.
     $newVersion = Get-Version $staged
     $oldVersion = Get-Version $exe
-    $sameVersion = $newVersion -and ($oldVersion -eq $newVersion)
+    # Versions are for the OPERATOR to read; the decision is content -- see
+    # Test-BinaryDiffers.
+    $differs = Test-BinaryDiffers -Installed $exe -Downloaded $staged
+    $sameVersion = -not $differs
 
     if ($sameVersion) {
         Write-Info "$newVersion is already installed here - keeping it."
     } else {
-        if ($oldVersion) { Write-Info "upgrading $oldVersion -> $newVersion" }
+        if ($oldVersion -and $oldVersion -eq $newVersion) {
+            # Same version string, different build: say so rather than printing
+            # "upgrading 0.1.7 -> 0.1.7", which reads like a bug.
+            Write-Info "$oldVersion is installed, but the published build differs - replacing it."
+        } elseif ($oldVersion) {
+            Write-Info "upgrading $oldVersion -> $newVersion"
+        }
         # Replacing a RUNNING exe fails with "file in use", and the agent this
         # installer is upgrading is exactly such a process. Move it aside first:
         # Windows permits renaming a running image, and the stale copy is

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -57,6 +57,38 @@ detect_target() {
 }
 
 # Verify a downloaded archive against the release's SHA256SUMS.
+# The SHA256 of a file, or "" when it cannot be read. One implementation, used
+# both by the download check and by `binary_differs` below.
+sha256_of() {
+    [ -r "$1" ] || return 0
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | awk '{print $1}'
+    fi
+}
+
+# Should the downloaded binary replace the installed one? CONTENT, not version.
+#
+# This used to compare `atlasctl --version` strings, and that is not an identity:
+# the crate version is bumped by release tooling only sometimes, so two builds
+# that differ by an entire wire-protocol revision can BOTH report "atlasctl
+# 0.1.7". That is not hypothetical -- it is exactly what a user hit: their agent
+# spoke protocol 1, the published build spoke 4, both said 0.1.7, and this
+# script answered "already installed here -- keeping it" every single time. The
+# control page told them to run the installer; the installer told them they were
+# fine; nothing could break the loop short of deleting the binary by hand.
+#
+# Bytes cannot lie about this. Same file -> nothing to do. Different file ->
+# install it, whatever the two version strings happen to say.
+binary_differs() { # installed_path downloaded_path
+    [ -x "$1" ] || return 0          # nothing installed: yes, install
+    old=$(sha256_of "$1")
+    new=$(sha256_of "$2")
+    [ -n "$new" ] || return 0        # cannot hash the download: prefer installing
+    [ "$old" != "$new" ]
+}
+
 verify_checksum() {
     archive="$1"
     sums="$2"
@@ -402,10 +434,16 @@ main() {
     old_version=""
     [ -x "$dir/$BIN_NAME" ] && old_version=$("$dir/$BIN_NAME" --version 2>/dev/null || true)
 
+    # Versions are for the OPERATOR to read. The decision is made on content --
+    # see `binary_differs`.
     same_version=""
-    if [ -n "$new_version" ] && [ "$old_version" = "$new_version" ]; then
+    if ! binary_differs "$dir/$BIN_NAME" "$tmp/$BIN_NAME"; then
         same_version="yes"
         info "$new_version is already installed here — keeping it."
+    elif [ -n "$old_version" ] && [ "$old_version" = "$new_version" ]; then
+        # Same version string, different build. Say so plainly rather than
+        # printing "upgrading 0.1.7 -> 0.1.7", which reads like a bug.
+        info "$old_version is installed, but the published build differs — replacing it."
     else
         [ -z "$old_version" ] || info "upgrading $old_version -> $new_version"
         # Install to a temp name and rename, so an interrupted install cannot leave

--- a/scripts/tests/install-ps1.test.ps1
+++ b/scripts/tests/install-ps1.test.ps1
@@ -150,6 +150,33 @@ Write-Host 'REACHED-THE-LINE-AFTER'
 $t = Get-Target
 Should-Contain 'this runner resolves to a real target' $t 'pc-windows-msvc'
 
+# ── the upgrade decision is content, not version ───────────────────────────────
+# Same bug as install.sh: two builds an entire wire-protocol apart can both
+# report "atlasctl 0.1.7", and comparing version strings left the operator
+# permanently on the old one while the control page kept sending them back here.
+$bd = Join-Path ([System.IO.Path]::GetTempPath()) ("bd-" + [System.Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Force -Path $bd | Out-Null
+Set-Content -LiteralPath (Join-Path $bd 'old') -Value 'BUILD-protocol-1' -NoNewline
+Set-Content -LiteralPath (Join-Path $bd 'new') -Value 'BUILD-protocol-4' -NoNewline
+Set-Content -LiteralPath (Join-Path $bd 'same') -Value 'BUILD-protocol-1' -NoNewline
+
+if (Test-BinaryDiffers -Installed (Join-Path $bd 'old') -Downloaded (Join-Path $bd 'new')) {
+    Ok 'a different build is replaced even when the version string matches'
+} else {
+    Bad 'a different build is replaced even when the version string matches' 'it was kept'
+}
+if (-not (Test-BinaryDiffers -Installed (Join-Path $bd 'old') -Downloaded (Join-Path $bd 'same'))) {
+    Ok 'identical bytes are not reinstalled'
+} else {
+    Bad 'identical bytes are not reinstalled' 'it reinstalled the same file'
+}
+if (Test-BinaryDiffers -Installed (Join-Path $bd 'absent') -Downloaded (Join-Path $bd 'new')) {
+    Ok 'nothing installed yet installs'
+} else {
+    Bad 'nothing installed yet installs' 'it skipped a machine with no binary'
+}
+Remove-Item -Recurse -Force $bd -ErrorAction SilentlyContinue
+
 # ── what the script does to the CALLER'S session ───────────────────────────────
 # `irm | iex` executes in the caller's scope, so these are properties of the
 # shipped TEXT, not of anything a loaded function can be asked. An operator whose

--- a/scripts/tests/install-sh.test.sh
+++ b/scripts/tests/install-sh.test.sh
@@ -288,6 +288,29 @@ out=$(agent_fail no)
 contains "no held port: offers the foreground command" "$out" "agent run"
 contains "and names the platform's real log"          "$out" "journalctl"
 
+# --- binary_differs: the upgrade decision ------------------------------------
+# The bug this encodes, reported from a real machine: the agent spoke wire
+# protocol 1, the published build spoke 4, and BOTH reported "atlasctl 0.1.7"
+# because the crate version had not been bumped between them. Comparing version
+# STRINGS answered "already installed here — keeping it" forever, while the
+# control page kept telling the operator to run this installer. Nothing short of
+# deleting the binary could break that loop.
+differs_case() { # name  installed_bytes  downloaded_bytes  expect(yes|no)
+    ( . "$WORK/lib.sh"
+      d=$(mktemp -d); printf '%s' "$2" > "$d/old"; chmod +x "$d/old"
+      printf '%s' "$3" > "$d/new"
+      if binary_differs "$d/old" "$d/new"; then got=yes; else got=no; fi
+      rm -rf "$d"
+      [ "$got" = "$4" ] && echo ok || echo "got=$got" )
+}
+check "identical bytes are not reinstalled" "ok" \
+    "$(differs_case x 'BUILD-A' 'BUILD-A' no)"
+check "SAME version string, different build, IS replaced" "ok" \
+    "$(differs_case x 'BUILD-protocol-1' 'BUILD-protocol-4' yes)"
+check "nothing installed yet installs" "ok" \
+    "$( . "$WORK/lib.sh"; d=$(mktemp -d); printf 'NEW' > "$d/new"; \
+        if binary_differs "$d/absent" "$d/new"; then echo ok; else echo no; fi; rm -rf "$d" )"
+
 # --- option parsing -----------------------------------------------------------
 # The REAL script, as a subprocess. Both of these decisions happen in main()
 # before anything is fetched, so this cannot reach the network — and running the


### PR DESCRIPTION
**Reported from a real machine.** The control page said *"your agent is out of date — it speaks
protocol 1, this page speaks 4. Update it on that machine: `curl -fsSL … | sh`"*. The operator ran
exactly that, and got:

```
[atlas] checksum verified
[atlas] build provenance verified
[atlas] atlasctl 0.1.7 is already installed here — keeping it.
[atlas] the agent is already running as a service — this machine is ready.
```

Running it again did the same. There was no way out of that loop short of deleting the binary by hand.

### The page was right; the installer was wrong

The upgrade decision compared `atlasctl --version` between the installed and downloaded binary. That
string is the crate semver, which release tooling bumps only sometimes — it is **not an identity for
the build**:

| | |
|---|---|
| wire protocol 1 → 4 | #63, landed 2026-08-27 17:34 |
| release **v0.4.1** (2026-08-28 05:45) | **contains** that commit (`git merge-base --is-ancestor`) |
| its published binary reports | `atlasctl 0.1.7` — verified by downloading and running the artifact |
| the operator's installed binary reports | `atlasctl 0.1.7` |

Equal strings, different builds, so the installer skipped — forever, and with perfect confidence.
**The fix was already published and the installer was refusing to deliver it.**

### The change

Both installers now compare the **SHA256 of the two files**. Identical bytes: keep, exactly as
before. Different bytes: install, whatever the version strings say. When the versions match but the
builds differ, the message says precisely that, instead of printing `upgrading 0.1.7 -> 0.1.7`,
which reads like a bug.

The decision moves into `binary_differs` / `Test-BinaryDiffers` so it can be tested at all — it was
previously inline in `main`.

### Tests, in both suites

- identical bytes are not reinstalled
- **a build that differs IS installed even when the version string matches** ← the reported bug
- a machine with no binary still installs

I verified the middle case **fails against the old version-string logic** (45 passed, 1 failed) and
passes after, so it reproduces the report rather than merely asserting the new behaviour.

_This does not re-version anything by itself; it makes the installer able to deliver a build that is
already published. The crate version not moving across a protocol change is a separate problem, at
the source._