### PR TITLE
ci(release): the crates in the linked group were never being released

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,10 +6,13 @@
       "package-name": "atlas-recipes-data",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        "Cargo.toml",
-        "crates/atlasctl/Cargo.toml"
+        "Cargo.toml"
       ]
-    }
+    },
+    "crates/atlasctl-protocol": {},
+    "crates/atlasctl-core": {},
+    "crates/atlasctl-agent": {},
+    "crates/atlasctl": {}
   },
   "plugins": [
     "cargo-workspace",

--- a/scripts/check-version-sync.py
+++ b/scripts/check-version-sync.py
@@ -120,6 +120,38 @@ def check_release_config() -> int:
         else:
             print(f"::error::linked-versions names {component!r}, which is no crate here")
             bad = 1
+
+    # Naming a real crate is not enough: release-please only bumps paths listed
+    # in `packages`. A component that is a real crate but NOT a package is
+    # grouped with things that move and then never moves itself -- silently,
+    # because an unlisted path is not an error to release-please either.
+    #
+    # That is not hypothetical. It froze `crates/atlasctl` at 0.1.7 while the
+    # root went to 0.4.1, so `atlasctl --version` reported the same string for
+    # builds an entire wire-protocol revision apart -- and the installer, which
+    # compared those strings, told an operator "already installed here" forever
+    # while the control page kept telling them to upgrade. The version string
+    # cannot be an identity for a build if releases never move it.
+    declared = {}
+    for path, spec in cfg.get("packages", {}).items():
+        name = spec.get("package-name")
+        if not name:
+            manifest = ROOT / path / "Cargo.toml"
+            if manifest.exists():
+                with manifest.open("rb") as fh:
+                    name = tomllib.load(fh)["package"]["name"]
+        if name:
+            declared[name] = path
+    for component in linked_components(cfg):
+        if component in declared:
+            print(f"ok   {component} is a released package ({declared[component]})")
+        else:
+            print(
+                f"::error::linked-versions groups {component!r}, but no `packages` "
+                f"entry covers it -- release-please will never bump it, so it will "
+                f"sit at whatever version it has today while the group moves on"
+            )
+            bad = 1
     return bad
 
 


### PR DESCRIPTION
**The second half of the "already installed here" report.** The installer fix (#122) makes the
symptom go away; this is the cause.

`crates/atlasctl` has been pinned at **0.1.7 across every release** while the root tag advanced to
**v0.4.1**. So `atlasctl --version` is not an identity for a build, and two binaries an entire wire
protocol apart (1 vs 4) both answer `atlasctl 0.1.7` — which is precisely how the operator got told
"already installed here — keeping it" forever.

### One line of config

`release-please-config.json` declares exactly one package (`.`) while `linked-versions` groups five
components. **Naming a component that is not a package is not an error to release-please** — it is
silently ignored, and that crate never gets bumped. Four of five sat still while the group moved.

`check_release_config` already verified each linked component *names* a real crate — the 2026-08-26
failure. It never checked that anything *releases* it. It does now, and the error states the
consequence rather than the malformation:

```
::error::linked-versions groups 'atlasctl', but no `packages` entry covers it --
release-please will never bump it, so it will sit at whatever version it has
today while the group moves on
```

I confirmed it fails against the current config (four errors, one per unmanaged crate) and passes
after.

### ★ Merging this changes published version numbers

The next release lifts the four crates from `0.1.7` to the group's version instead of leaving them
behind. That is the intended end state — it is what `linked-versions` exists for — but it is a
**versioning decision, not a bug fix**, which is why it is a separate PR rather than folded into
#122. #122 stands on its own and needs nothing from this.

The root's `extra-files` no longer rewrites `crates/atlasctl/Cargo.toml`, since that crate manages its
own version now and two writers of one field is how they drift in the first place.