### PR TITLE
fix(cluster): a reservation whose head vanished bricked the machine forever

### DIFF
--- a/crates/atlasctl-agent/src/cluster.rs
+++ b/crates/atlasctl-agent/src/cluster.rs
@@ -326,11 +326,19 @@ pub enum RefusalReason {
     /// What they actually need to do is abandon the other launch.
     #[error(
         "this node is already reserved for a launch of {recipe}; \
-         abort that launch, or wait for it to finish, before starting another"
+         abort that launch, or wait {expires_in_s}s for the reservation to \
+         lapse, before starting another"
     )]
     Reserved {
         /// Which recipe the outstanding reservation is for.
         recipe: String,
+        /// Seconds until this machine will release the hold on its own.
+        ///
+        /// Named in the message because the old text said "wait for it to
+        /// finish" of something that never finished: a reservation whose head
+        /// went away was permanent, and abort needs the epoch that went away
+        /// with it. Telling an operator to wait is only fair if waiting works.
+        expires_in_s: u64,
     },
     /// The rendezvous address is on a link this node is not attached to.
     ///

--- a/crates/atlasctl/src/rankservice/commit_tests.rs
+++ b/crates/atlasctl/src/rankservice/commit_tests.rs
@@ -1,0 +1,298 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The commit half of the rank-service tests, split from `tests.rs` for size.
+//! The helpers (`service`, `agreeing`, `RecordingRunner`) stay in that module
+//! and are used from here.
+
+use super::tests::{RECIPE, agreeing, host, node, service};
+use super::*;
+use atlasctl_core::docker::{NvidiaDevices, ROOTLESS_V1};
+use atlasctl_core::io::RecordingRunner;
+use atlasctl_core::io::process::Output;
+use std::sync::Arc;
+
+/// A reservation is spent by its commit, so a replayed frame cannot start a
+/// second container on a machine already running the first.
+#[test]
+fn a_replayed_commit_starts_nothing_twice() {
+    let runner = Arc::new(RecordingRunner::new());
+    let svc = service(&runner, Ok(()));
+    let a = agreeing(&svc, 1);
+    svc.prepare("e1", &a);
+    svc.commit("e1").expect("first commit");
+
+    let before = runner.call_count();
+    assert!(svc.commit("e1").is_err(), "the reservation is spent");
+    assert_eq!(runner.call_count(), before, "nothing may run again");
+}
+
+/// An abort for a stale epoch arriving late must not release a reservation made
+/// since — that would silently cancel a launch the operator is watching.
+#[test]
+fn a_stale_abort_does_not_release_a_newer_reservation() {
+    let runner = Arc::new(RecordingRunner::new());
+    let svc = service(&runner, Ok(()));
+    let a = agreeing(&svc, 1);
+
+    svc.prepare("old", &a);
+    svc.abort("old");
+    svc.prepare("new", &a);
+    svc.abort("old");
+
+    assert!(
+        svc.commit("new").is_ok(),
+        "the newer reservation must survive"
+    );
+}
+
+/// Rollback asking about a container that never started is an ordinary race,
+/// not a failure to show instead of the real reason.
+#[test]
+fn stopping_a_container_that_is_already_gone_succeeds() {
+    let runner = Arc::new(RecordingRunner::new());
+    runner.push_result(Output {
+        status: 1,
+        stdout: String::new(),
+        stderr: "Error response from daemon: No such container: atlas-x".to_owned(),
+    });
+    let svc = service(&runner, Ok(()));
+    svc.stop("atlas-x")
+        .expect("already gone is the wanted outcome");
+}
+
+#[test]
+fn a_container_runtime_failure_on_stop_is_reported() {
+    let runner = Arc::new(RecordingRunner::new());
+    runner.push_result(Output {
+        status: 1,
+        stdout: String::new(),
+        stderr: "permission denied while trying to connect to the Docker daemon".to_owned(),
+    });
+    let svc = service(&runner, Ok(()));
+    let err = svc
+        .stop("atlas-x")
+        .expect_err("a real failure must surface");
+    assert!(err.to_string().contains("permission denied"), "{err}");
+}
+
+/// A machine that cannot run models says so before rendering anything, rather
+/// than reserving and failing at commit.
+#[test]
+fn a_client_only_agent_refuses_to_be_a_rank() {
+    let runner = Arc::new(RecordingRunner::new());
+    let svc = service(&runner, Err("this agent runs in --client mode".to_owned()));
+    let a = RankAssignment {
+        node: node(),
+        rank: 1,
+        world_size: 2,
+        master_addr: "10.0.0.1".to_owned(),
+        master_port: 29500,
+        recipe: RECIPE.to_owned(),
+        recipe_hash: svc.content_hash(RECIPE).expect("a shipped recipe"),
+        settings: BTreeMap::new(),
+    };
+
+    let PrepareReply::Refused { reason } = svc.prepare("e1", &a) else {
+        panic!("a control-only node must refuse");
+    };
+    assert!(reason.contains("--client mode"), "{reason}");
+    assert_eq!(runner.call_count(), 0, "it must not even probe docker");
+}
+
+/// `docker run -d` returning 0 means the container was created, not that the
+/// workload survived. This is the question that catches the difference.
+#[test]
+fn a_running_container_reports_alive() {
+    let runner = Arc::new(RecordingRunner::new());
+    runner.push_result(Output {
+        status: 0,
+        stdout: "true\n".to_owned(),
+        stderr: String::new(),
+    });
+    let svc = service(&runner, Ok(()));
+    assert!(svc.alive("atlas-x").expect("asks"));
+
+    let asked = runner.calls().into_iter().next().expect("one call");
+    assert_eq!(asked[0], "docker");
+    assert_eq!(asked[1], "inspect");
+    assert_eq!(asked.last().expect("the container"), "atlas-x");
+}
+
+#[test]
+fn a_stopped_container_reports_not_alive() {
+    let runner = Arc::new(RecordingRunner::new());
+    runner.push_result(Output {
+        status: 0,
+        stdout: "false\n".to_owned(),
+        stderr: String::new(),
+    });
+    let svc = service(&runner, Ok(()));
+    assert!(!svc.alive("atlas-x").expect("asks"));
+}
+
+/// A rank that died under `--rm` has already been removed, so `docker inspect`
+/// fails. That is the exact case this exists to catch, and it is an answer
+/// rather than an error.
+#[test]
+fn a_container_removed_after_dying_reports_not_alive() {
+    let runner = Arc::new(RecordingRunner::new());
+    runner.push_result(Output {
+        status: 1,
+        stdout: String::new(),
+        stderr: "Error: No such object: atlas-x".to_owned(),
+    });
+    let svc = service(&runner, Ok(()));
+    assert!(
+        !svc.alive("atlas-x")
+            .expect("a missing container is an answer")
+    );
+}
+
+/// The failure that hung a real two-node launch.
+///
+/// A DGX Spark carries several point-to-point RoCE links. The head offered its
+/// address on one this machine is not attached to, and the rank started, waited
+/// at the collective barrier, and retried `Connection timed out` every second
+/// while the operator saw two healthy containers and no server.
+///
+/// It is a refusal now, at prepare, before anything starts.
+#[test]
+fn a_rendezvous_address_on_a_link_this_node_lacks_is_refused() {
+    let runner = Arc::new(RecordingRunner::new());
+    let svc = service(&runner, Ok(()));
+    let mut a = agreeing(&svc, 1);
+    // The fixture node is on 10.0.0.2/30; this is the head's *other* link.
+    a.master_addr = "10.10.10.13".to_owned();
+
+    let PrepareReply::Refused { reason } = svc.prepare("e1", &a) else {
+        panic!("an unreachable rendezvous must be refused, not reserved");
+    };
+    assert!(reason.contains("10.10.10.13"), "{reason}");
+    assert!(
+        reason.contains("10.0.0.2/30"),
+        "must name this node's links: {reason}"
+    );
+    assert!(
+        svc.commit("e1").is_err(),
+        "a refused prepare must reserve nothing"
+    );
+}
+
+/// The address on the shared link still works — the check must not refuse
+/// everything.
+#[test]
+fn a_rendezvous_address_on_the_shared_link_is_accepted() {
+    let runner = Arc::new(RecordingRunner::new());
+    let svc = service(&runner, Ok(()));
+    let mut a = agreeing(&svc, 1);
+    a.master_addr = "10.0.0.1".to_owned();
+    assert_eq!(svc.prepare("e1", &a), PrepareReply::Prepared);
+}
+
+/// The collective has to be told which link to use, or it picks one itself.
+///
+/// Nothing set NCCL_SOCKET_IFNAME or NCCL_IB_HCA, on the reasoning that
+/// guessing a NIC name silently uses the wrong fabric. True of guessing — but
+/// leaving them unset delegates the guess to NCCL, which on a machine with four
+/// RoCE ports chose the one that reaches nobody and died at `ibv_modify_qp`
+/// with `Connection timed out`, then took the process with it via
+/// `CUDA_ERROR_ILLEGAL_ADDRESS`.
+mod collective_binding {
+    use super::*;
+
+    #[test]
+    fn a_rank_pins_the_collective_to_the_rendezvous_link() {
+        let runner = Arc::new(RecordingRunner::new());
+        let svc = service(&runner, Ok(()));
+        let mut a = agreeing(&svc, 1);
+        a.master_addr = "10.0.0.1".to_owned(); // the fixture's shared /30
+
+        let (cmd, _) = svc.render(&a).expect("renders");
+        assert!(
+            cmd.contains("NCCL_SOCKET_IFNAME=enp1s0f0np0"),
+            "must name the interface carrying the rendezvous: {cmd}"
+        );
+        assert!(
+            cmd.contains("NCCL_IB_HCA=rocep1s0f0"),
+            "must name that interface's own RDMA device: {cmd}"
+        );
+        assert!(
+            !cmd.contains("rocep1s0f1"),
+            "the other port must not appear: {cmd}"
+        );
+    }
+
+    /// A solo launch has no collective, so pinning one would be noise that
+    /// also constrains a single-node server for no reason.
+    #[test]
+    fn a_solo_launch_pins_nothing() {
+        let recipe = atlasctl_core::registry::RegistrySet::builtin_only()
+            .resolve(&atlasctl_core::registry::RecipeRef::parse(
+                "qwen3.6-35b-a3b-fp8-bf16head",
+            ))
+            .expect("a shipped solo recipe");
+        let plan = atlasctl_core::docker::translate::translate(
+            &recipe,
+            &BTreeMap::new(),
+            &atlasctl_core::chain::UserConfig::default(),
+            &host(),
+            &atlasctl_core::docker::translate::Placement::Solo,
+            &atlasctl_core::docker::translate::LaunchContext {
+                profile: &ROOTLESS_V1,
+                devices: &NvidiaDevices,
+                collective: &atlasctl_core::docker::collective::NcclRoce,
+            },
+        )
+        .expect("translates");
+        assert!(!plan.docker.env.contains_key("NCCL_SOCKET_IFNAME"));
+        assert!(!plan.docker.env.contains_key("NCCL_IB_HCA"));
+    }
+
+    /// A routed rendezvous has no single local interface to name, and inventing
+    /// one would be exactly the guess this avoids.
+    #[test]
+    fn a_rendezvous_off_every_local_subnet_pins_nothing() {
+        let runner = Arc::new(RecordingRunner::new());
+        let svc = service(&runner, Ok(()));
+        let mut a = agreeing(&svc, 1);
+        a.master_addr = "203.0.113.7".to_owned();
+
+        let (cmd, _) = svc.render(&a).expect("renders");
+        assert!(!cmd.contains("NCCL_SOCKET_IFNAME"), "{cmd}");
+        assert!(!cmd.contains("NCCL_IB_HCA"), "{cmd}");
+    }
+}
+
+/// `stop` runs `docker rm -f` on a name that arrives from whichever node is
+/// acting as head. Unbounded, that is a peer holding the `controller` grant
+/// force-removing ANY container on this machine — well past "drive its own
+/// launch, one hop". The browser's own stop has always been scoped to
+/// `atlas-{recipe}`; this path had no equivalent.
+#[test]
+fn a_rank_may_only_stop_a_container_this_fleet_launched() {
+    use crate::rankservice::is_ours;
+    for foreign in [
+        "postgres",
+        "someone-elses-db",
+        "ATLAS-shouty",
+        "atlas-",
+        "atlas-../evil",
+        "",
+    ] {
+        assert!(!is_ours(foreign), "{foreign:?} was not launched by us");
+    }
+}
+
+/// And the names this fleet really produces must still be stoppable, or a
+/// cluster launch could never be torn down.
+#[test]
+fn the_names_translate_actually_produces_are_still_ours() {
+    use crate::rankservice::is_ours;
+    for mine in [
+        "atlas-qwen3.6-27b-nvfp4-unsloth",
+        "atlas-qwen3.6-35b-a3b-fp8-bf16head-rank0",
+        "atlas-qwen3.6-35b-a3b-fp8-bf16head-rank11",
+    ] {
+        assert!(is_ours(mine), "{mine:?} is a name translate produces");
+    }
+}

--- a/crates/atlasctl/src/rankservice/mod.rs
+++ b/crates/atlasctl/src/rankservice/mod.rs
@@ -484,4 +484,6 @@ pub(crate) fn is_ours(container: &str) -> bool {
 }
 
 #[cfg(test)]
+mod commit_tests;
+#[cfg(test)]
 mod tests;

--- a/crates/atlasctl/src/rankservice/mod.rs
+++ b/crates/atlasctl/src/rankservice/mod.rs
@@ -41,7 +41,24 @@ struct Reservation {
     epoch: String,
     recipe: String,
     plan: atlasctl_core::docker::LaunchPlan,
+    /// When this machine agreed. Without it a reservation is immortal: the head
+    /// that made it can close its tab, crash, or be restarted for an upgrade,
+    /// and nothing on this machine ever releases the hold. The refusal below
+    /// tells the operator to "abort that launch, or wait for it to finish" --
+    /// abort needs the lost epoch, and it never finishes, so every future
+    /// cluster launch on this machine is refused until someone restarts the
+    /// agent by hand. On a fleet that is every machine at once.
+    made: std::time::Instant,
 }
+
+/// How long a reservation outlives the head that made it.
+///
+/// It only has to cover prepare -> commit, which is a few round trips plus
+/// whatever `docker rm -f` takes; commit consumes the reservation, so a live
+/// launch is never at risk from this. Ten minutes is far past that and still
+/// short enough that an operator who lost a head can simply try again rather
+/// than ssh to every machine.
+const RESERVATION_TTL: std::time::Duration = std::time::Duration::from_secs(600);
 
 /// What this machine can do, as opposed to what it ships.
 ///
@@ -294,13 +311,24 @@ impl RankService for LocalRankService {
         // the SAME epoch is allowed, because a retried prepare after a dropped
         // connection is an ordinary thing and not a second cluster.
         {
-            let held = self.reserved.lock().expect("reservation lock poisoned");
+            let mut held = self.reserved.lock().expect("reservation lock poisoned");
             if let Some(r) = held.as_ref()
                 && r.epoch != epoch
             {
-                return refuse(RefusalReason::Reserved {
-                    recipe: r.recipe.clone(),
-                });
+                if r.made.elapsed() >= RESERVATION_TTL {
+                    // The head that made this is gone -- it would have committed
+                    // or aborted long ago. Releasing here is what makes the
+                    // refusal's "wait for it to finish" true, and it is the
+                    // behaviour `RankService::abort`'s own doc already claims:
+                    // "a stale reservation is released by the next prepare
+                    // regardless".
+                    *held = None;
+                } else {
+                    return refuse(RefusalReason::Reserved {
+                        recipe: r.recipe.clone(),
+                        expires_in_s: (RESERVATION_TTL - r.made.elapsed()).as_secs(),
+                    });
+                }
             }
         }
 
@@ -334,6 +362,7 @@ impl RankService for LocalRankService {
             epoch: epoch.to_owned(),
             recipe: assignment.recipe.clone(),
             plan,
+            made: std::time::Instant::now(),
         });
         PrepareReply::Prepared
     }

--- a/crates/atlasctl/src/rankservice/tests.rs
+++ b/crates/atlasctl/src/rankservice/tests.rs
@@ -176,6 +176,49 @@ fn a_second_clusters_prepare_is_refused_while_one_is_held() {
     assert!(reason.contains("abort that launch"), "{reason}");
 }
 
+/// A reservation whose head went away must not hold this machine forever.
+///
+/// The failure it prevents: an operator prepares, then the tab closes or the
+/// head agent restarts before commit or abort. Nothing on this machine ever
+/// released the hold, so every later cluster launch was refused -- and the
+/// refusal said "abort that launch, or wait for it to finish", when abort
+/// needs the epoch that went away with the head and it never finished. On a
+/// fleet that bricks every machine at once until each agent is restarted by
+/// hand.
+#[test]
+fn a_reservation_whose_head_vanished_lapses_and_the_refusal_says_when() {
+    let runner = Arc::new(RecordingRunner::new());
+    let svc = service(&runner, Ok(()));
+    let a = agreeing(&svc, 1);
+
+    assert_eq!(svc.prepare("abandoned", &a), PrepareReply::Prepared);
+
+    // While it is fresh, another cluster is still refused -- and now the
+    // refusal states how long waiting would take, which is the only reason
+    // telling someone to wait is fair.
+    let PrepareReply::Refused { reason } = svc.prepare("other", &a) else {
+        panic!("a fresh reservation must still block another cluster");
+    };
+    assert!(reason.contains("already reserved"), "{reason}");
+    assert!(
+        reason.contains("lapse"),
+        "the refusal must say waiting works: {reason}"
+    );
+
+    // Age it past the TTL, exactly as an abandoned head would.
+    {
+        let mut held = svc.reserved.lock().expect("reservation lock poisoned");
+        let r = held.as_mut().expect("still reserved");
+        r.made = std::time::Instant::now()
+            - (super::RESERVATION_TTL + std::time::Duration::from_secs(1));
+    }
+    assert_eq!(
+        svc.prepare("other", &a),
+        PrepareReply::Prepared,
+        "a lapsed reservation must not keep refusing new clusters"
+    );
+}
+
 /// A retried prepare after a dropped connection is ordinary, not a second
 /// cluster.
 #[test]

--- a/crates/atlasctl/src/rankservice/tests.rs
+++ b/crates/atlasctl/src/rankservice/tests.rs
@@ -6,15 +6,14 @@ use super::*;
 use atlasctl_core::docker::{NvidiaDevices, ROOTLESS_V1};
 use atlasctl_core::host::PosixUser;
 use atlasctl_core::io::RecordingRunner;
-use atlasctl_core::io::process::Output;
 use atlasctl_protocol::fleet::NodeId;
 use std::collections::BTreeMap;
 
 /// A real two-node recipe, so the assignment being rendered is one that
 /// actually exists rather than one invented for the test.
-const RECIPE: &str = "qwen3.5-122b-a10b-nvfp4-ep2";
+pub(super) const RECIPE: &str = "qwen3.5-122b-a10b-nvfp4-ep2";
 
-fn host() -> atlasctl_core::host::HostSnapshot {
+pub(super) fn host() -> atlasctl_core::host::HostSnapshot {
     atlasctl_core::host::HostSnapshot {
         posix_user: Some(PosixUser {
             uid: 1000,
@@ -47,11 +46,14 @@ fn local_link() -> atlasctl_protocol::fleet::NodeAddress {
     }
 }
 
-fn node() -> NodeId {
+pub(super) fn node() -> NodeId {
     NodeId::parse(&"ab".repeat(32)).expect("64 hex chars")
 }
 
-fn service(runner: &Arc<RecordingRunner>, can_launch: Result<(), String>) -> LocalRankService {
+pub(super) fn service(
+    runner: &Arc<RecordingRunner>,
+    can_launch: Result<(), String>,
+) -> LocalRankService {
     LocalRankService::new(
         atlasctl_core::registry::RegistrySet::builtin_only(),
         host(),
@@ -81,7 +83,7 @@ fn service(runner: &Arc<RecordingRunner>, can_launch: Result<(), String>) -> Loc
 }
 
 /// An assignment carrying the hash this machine itself computes.
-fn agreeing(svc: &LocalRankService, rank: u16) -> RankAssignment {
+pub(super) fn agreeing(svc: &LocalRankService, rank: u16) -> RankAssignment {
     RankAssignment {
         node: node(),
         rank,
@@ -253,290 +255,4 @@ fn a_commit_quoting_another_epoch_starts_nothing() {
     let err = svc.commit("e2").expect_err("wrong epoch");
     assert!(err.to_string().contains("not e2"), "{err}");
     assert_eq!(runner.call_count(), before, "nothing may be started");
-}
-
-/// A reservation is spent by its commit, so a replayed frame cannot start a
-/// second container on a machine already running the first.
-#[test]
-fn a_replayed_commit_starts_nothing_twice() {
-    let runner = Arc::new(RecordingRunner::new());
-    let svc = service(&runner, Ok(()));
-    let a = agreeing(&svc, 1);
-    svc.prepare("e1", &a);
-    svc.commit("e1").expect("first commit");
-
-    let before = runner.call_count();
-    assert!(svc.commit("e1").is_err(), "the reservation is spent");
-    assert_eq!(runner.call_count(), before, "nothing may run again");
-}
-
-/// An abort for a stale epoch arriving late must not release a reservation made
-/// since — that would silently cancel a launch the operator is watching.
-#[test]
-fn a_stale_abort_does_not_release_a_newer_reservation() {
-    let runner = Arc::new(RecordingRunner::new());
-    let svc = service(&runner, Ok(()));
-    let a = agreeing(&svc, 1);
-
-    svc.prepare("old", &a);
-    svc.abort("old");
-    svc.prepare("new", &a);
-    svc.abort("old");
-
-    assert!(
-        svc.commit("new").is_ok(),
-        "the newer reservation must survive"
-    );
-}
-
-/// Rollback asking about a container that never started is an ordinary race,
-/// not a failure to show instead of the real reason.
-#[test]
-fn stopping_a_container_that_is_already_gone_succeeds() {
-    let runner = Arc::new(RecordingRunner::new());
-    runner.push_result(Output {
-        status: 1,
-        stdout: String::new(),
-        stderr: "Error response from daemon: No such container: atlas-x".to_owned(),
-    });
-    let svc = service(&runner, Ok(()));
-    svc.stop("atlas-x")
-        .expect("already gone is the wanted outcome");
-}
-
-#[test]
-fn a_container_runtime_failure_on_stop_is_reported() {
-    let runner = Arc::new(RecordingRunner::new());
-    runner.push_result(Output {
-        status: 1,
-        stdout: String::new(),
-        stderr: "permission denied while trying to connect to the Docker daemon".to_owned(),
-    });
-    let svc = service(&runner, Ok(()));
-    let err = svc
-        .stop("atlas-x")
-        .expect_err("a real failure must surface");
-    assert!(err.to_string().contains("permission denied"), "{err}");
-}
-
-/// A machine that cannot run models says so before rendering anything, rather
-/// than reserving and failing at commit.
-#[test]
-fn a_client_only_agent_refuses_to_be_a_rank() {
-    let runner = Arc::new(RecordingRunner::new());
-    let svc = service(&runner, Err("this agent runs in --client mode".to_owned()));
-    let a = RankAssignment {
-        node: node(),
-        rank: 1,
-        world_size: 2,
-        master_addr: "10.0.0.1".to_owned(),
-        master_port: 29500,
-        recipe: RECIPE.to_owned(),
-        recipe_hash: svc.content_hash(RECIPE).expect("a shipped recipe"),
-        settings: BTreeMap::new(),
-    };
-
-    let PrepareReply::Refused { reason } = svc.prepare("e1", &a) else {
-        panic!("a control-only node must refuse");
-    };
-    assert!(reason.contains("--client mode"), "{reason}");
-    assert_eq!(runner.call_count(), 0, "it must not even probe docker");
-}
-
-/// `docker run -d` returning 0 means the container was created, not that the
-/// workload survived. This is the question that catches the difference.
-#[test]
-fn a_running_container_reports_alive() {
-    let runner = Arc::new(RecordingRunner::new());
-    runner.push_result(Output {
-        status: 0,
-        stdout: "true\n".to_owned(),
-        stderr: String::new(),
-    });
-    let svc = service(&runner, Ok(()));
-    assert!(svc.alive("atlas-x").expect("asks"));
-
-    let asked = runner.calls().into_iter().next().expect("one call");
-    assert_eq!(asked[0], "docker");
-    assert_eq!(asked[1], "inspect");
-    assert_eq!(asked.last().expect("the container"), "atlas-x");
-}
-
-#[test]
-fn a_stopped_container_reports_not_alive() {
-    let runner = Arc::new(RecordingRunner::new());
-    runner.push_result(Output {
-        status: 0,
-        stdout: "false\n".to_owned(),
-        stderr: String::new(),
-    });
-    let svc = service(&runner, Ok(()));
-    assert!(!svc.alive("atlas-x").expect("asks"));
-}
-
-/// A rank that died under `--rm` has already been removed, so `docker inspect`
-/// fails. That is the exact case this exists to catch, and it is an answer
-/// rather than an error.
-#[test]
-fn a_container_removed_after_dying_reports_not_alive() {
-    let runner = Arc::new(RecordingRunner::new());
-    runner.push_result(Output {
-        status: 1,
-        stdout: String::new(),
-        stderr: "Error: No such object: atlas-x".to_owned(),
-    });
-    let svc = service(&runner, Ok(()));
-    assert!(
-        !svc.alive("atlas-x")
-            .expect("a missing container is an answer")
-    );
-}
-
-/// The failure that hung a real two-node launch.
-///
-/// A DGX Spark carries several point-to-point RoCE links. The head offered its
-/// address on one this machine is not attached to, and the rank started, waited
-/// at the collective barrier, and retried `Connection timed out` every second
-/// while the operator saw two healthy containers and no server.
-///
-/// It is a refusal now, at prepare, before anything starts.
-#[test]
-fn a_rendezvous_address_on_a_link_this_node_lacks_is_refused() {
-    let runner = Arc::new(RecordingRunner::new());
-    let svc = service(&runner, Ok(()));
-    let mut a = agreeing(&svc, 1);
-    // The fixture node is on 10.0.0.2/30; this is the head's *other* link.
-    a.master_addr = "10.10.10.13".to_owned();
-
-    let PrepareReply::Refused { reason } = svc.prepare("e1", &a) else {
-        panic!("an unreachable rendezvous must be refused, not reserved");
-    };
-    assert!(reason.contains("10.10.10.13"), "{reason}");
-    assert!(
-        reason.contains("10.0.0.2/30"),
-        "must name this node's links: {reason}"
-    );
-    assert!(
-        svc.commit("e1").is_err(),
-        "a refused prepare must reserve nothing"
-    );
-}
-
-/// The address on the shared link still works — the check must not refuse
-/// everything.
-#[test]
-fn a_rendezvous_address_on_the_shared_link_is_accepted() {
-    let runner = Arc::new(RecordingRunner::new());
-    let svc = service(&runner, Ok(()));
-    let mut a = agreeing(&svc, 1);
-    a.master_addr = "10.0.0.1".to_owned();
-    assert_eq!(svc.prepare("e1", &a), PrepareReply::Prepared);
-}
-
-/// The collective has to be told which link to use, or it picks one itself.
-///
-/// Nothing set NCCL_SOCKET_IFNAME or NCCL_IB_HCA, on the reasoning that
-/// guessing a NIC name silently uses the wrong fabric. True of guessing — but
-/// leaving them unset delegates the guess to NCCL, which on a machine with four
-/// RoCE ports chose the one that reaches nobody and died at `ibv_modify_qp`
-/// with `Connection timed out`, then took the process with it via
-/// `CUDA_ERROR_ILLEGAL_ADDRESS`.
-mod collective_binding {
-    use super::*;
-
-    #[test]
-    fn a_rank_pins_the_collective_to_the_rendezvous_link() {
-        let runner = Arc::new(RecordingRunner::new());
-        let svc = service(&runner, Ok(()));
-        let mut a = agreeing(&svc, 1);
-        a.master_addr = "10.0.0.1".to_owned(); // the fixture's shared /30
-
-        let (cmd, _) = svc.render(&a).expect("renders");
-        assert!(
-            cmd.contains("NCCL_SOCKET_IFNAME=enp1s0f0np0"),
-            "must name the interface carrying the rendezvous: {cmd}"
-        );
-        assert!(
-            cmd.contains("NCCL_IB_HCA=rocep1s0f0"),
-            "must name that interface's own RDMA device: {cmd}"
-        );
-        assert!(
-            !cmd.contains("rocep1s0f1"),
-            "the other port must not appear: {cmd}"
-        );
-    }
-
-    /// A solo launch has no collective, so pinning one would be noise that
-    /// also constrains a single-node server for no reason.
-    #[test]
-    fn a_solo_launch_pins_nothing() {
-        let recipe = atlasctl_core::registry::RegistrySet::builtin_only()
-            .resolve(&atlasctl_core::registry::RecipeRef::parse(
-                "qwen3.6-35b-a3b-fp8-bf16head",
-            ))
-            .expect("a shipped solo recipe");
-        let plan = atlasctl_core::docker::translate::translate(
-            &recipe,
-            &BTreeMap::new(),
-            &atlasctl_core::chain::UserConfig::default(),
-            &host(),
-            &atlasctl_core::docker::translate::Placement::Solo,
-            &atlasctl_core::docker::translate::LaunchContext {
-                profile: &ROOTLESS_V1,
-                devices: &NvidiaDevices,
-                collective: &atlasctl_core::docker::collective::NcclRoce,
-            },
-        )
-        .expect("translates");
-        assert!(!plan.docker.env.contains_key("NCCL_SOCKET_IFNAME"));
-        assert!(!plan.docker.env.contains_key("NCCL_IB_HCA"));
-    }
-
-    /// A routed rendezvous has no single local interface to name, and inventing
-    /// one would be exactly the guess this avoids.
-    #[test]
-    fn a_rendezvous_off_every_local_subnet_pins_nothing() {
-        let runner = Arc::new(RecordingRunner::new());
-        let svc = service(&runner, Ok(()));
-        let mut a = agreeing(&svc, 1);
-        a.master_addr = "203.0.113.7".to_owned();
-
-        let (cmd, _) = svc.render(&a).expect("renders");
-        assert!(!cmd.contains("NCCL_SOCKET_IFNAME"), "{cmd}");
-        assert!(!cmd.contains("NCCL_IB_HCA"), "{cmd}");
-    }
-}
-
-/// `stop` runs `docker rm -f` on a name that arrives from whichever node is
-/// acting as head. Unbounded, that is a peer holding the `controller` grant
-/// force-removing ANY container on this machine — well past "drive its own
-/// launch, one hop". The browser's own stop has always been scoped to
-/// `atlas-{recipe}`; this path had no equivalent.
-#[test]
-fn a_rank_may_only_stop_a_container_this_fleet_launched() {
-    use crate::rankservice::is_ours;
-    for foreign in [
-        "postgres",
-        "someone-elses-db",
-        "ATLAS-shouty",
-        "atlas-",
-        "atlas-../evil",
-        "",
-    ] {
-        assert!(!is_ours(foreign), "{foreign:?} was not launched by us");
-    }
-}
-
-/// And the names this fleet really produces must still be stoppable, or a
-/// cluster launch could never be torn down.
-#[test]
-fn the_names_translate_actually_produces_are_still_ours() {
-    use crate::rankservice::is_ours;
-    for mine in [
-        "atlas-qwen3.6-27b-nvfp4-unsloth",
-        "atlas-qwen3.6-35b-a3b-fp8-bf16head-rank0",
-        "atlas-qwen3.6-35b-a3b-fp8-bf16head-rank11",
-    ] {
-        assert!(is_ours(mine), "{mine:?} is a name translate produces");
-    }
 }


### PR DESCRIPTION
From an audit of the multi-node launch path. Verified by reading both sides: `Reservation` carried no
timestamp, and nothing else released it.

### What happens today

A rank that has agreed to a launch refuses any prepare with a different epoch. That part is right —
two clusters must not fight over one GPU. But the hold is **immortal**:

1. operator prepares a cluster
2. the tab closes, or the head agent restarts for an upgrade, before commit or abort
3. every later cluster launch on that machine is refused — from **any** operator, **any** head

and the refusal says:

> this node is already reserved for a launch of X; **abort that launch, or wait for it to finish**

Abort takes the epoch, which went away with the head. And it never finishes — there is no TTL
anywhere in the file. The head driver's own `abort` is a no-op after a restart, because it only dials
peers while its in-memory `pending` still matches. So the remedy was to ssh to every machine and
restart the agent — on a fleet, **all of them**, because one tab was closed.

### The fix the code already claimed

`RankService::abort`'s doc says: *"A stale reservation is released by the next prepare regardless."*
Nothing implemented that. Now a prepare from a different epoch releases a hold older than **ten
minutes** — comfortably past prepare→commit, which is a few round trips, and commit consumes the
reservation, so a live launch is never at risk from this.

The refusal now names the seconds remaining. Telling an operator to wait is only fair if waiting
works.

### Test

A fresh reservation still blocks another cluster, and the refusal states how long; aged past the TTL,
the next prepare succeeds. I verified it **fails with the expiry disabled** (148 passed, 1 failed), so
it pins the behaviour rather than the code I happened to write.

_The same audit found seven more defects on this path — orphaned containers after a head restart, a
5s commit timeout racing `docker rm -f` + `docker run`, a teardown that reports success for peers it
never reached. They are separate fixes; this is the one that strands a whole fleet._