### PR TITLE
test(relay): widen the budget-vs-launch margin that went red on Windows

### DIFF
--- a/crates/atlasctl-agent/src/daemon/relay_grant_tests.rs
+++ b/crates/atlasctl-agent/src/daemon/relay_grant_tests.rs
@@ -291,10 +291,17 @@ async fn a_retried_launch_after_a_lost_reply_is_already_running_not_doubled() {
     pin(&relay, &target, false);
     pin(&target, &relay, true);
 
-    let relay_budget = Duration::from_millis(300);
+    // The margin between these two is the whole test: the relay must give up
+    // BEFORE the launch returns, or the reply is not lost and there is nothing
+    // to recover from. It used to be 3x (300ms vs 900ms), and a loaded Windows
+    // runner lost that race -- the launch answered `Started`, the assertion for
+    // the relay's refusal failed, and a pull request that had not touched any
+    // Rust went red. 20x is not a tuned number; it is far enough outside any
+    // plausible scheduling delay that the ordering stops being a coin flip.
+    let relay_budget = Duration::from_millis(150);
     let launcher = Arc::new(SlowThenBusy {
         launches: AtomicUsize::new(0),
-        delay: relay_budget * 3,
+        delay: relay_budget * 20,
     });
     let port = {
         let launcher = std::sync::Arc::clone(&relay.launcher);

--- a/crates/atlasctl/src/service/plan/windows.rs
+++ b/crates/atlasctl/src/service/plan/windows.rs
@@ -158,8 +158,17 @@ pub(super) fn scheduled_task(agent: &AgentInvocation, home: &Path) -> ServicePla
         // an agent that dies after a second would be seen alive on the way
         // past. So the first sighting only starts a second look a second
         // later, and both have to agree.
+        //
+        // THIRTY seconds, not ten. Ten was enough on a warm machine and not on
+        // a cold CI runner, where the agent has to start, read its config dir,
+        // load a token and probe docker before it reports Running -- and where
+        // probing for a docker that is not there is itself slow. The install
+        // then announced "installed, but it is NOT running" for an agent that
+        // was merely still starting, which is the exact false alarm this poll
+        // was written to prevent. The only cost of the larger deadline is that a
+        // genuinely dead agent takes longer to be called dead.
         verify: ps(&format!(
-            "$deadline = (Get-Date).AddSeconds(10); \
+            "$deadline = (Get-Date).AddSeconds(30); \
              $running = {{ (Get-ScheduledTask -TaskName '{SERVICE_NAME}' \
                  -ErrorAction SilentlyContinue).State -eq 'Running' }}; \
              do {{ \


### PR DESCRIPTION
`a_retried_launch_after_a_lost_reply_is_already_running_not_doubled` failed on a Windows runner
against **#122, a pull request that touches only shell scripts**. A flake that reds an unrelated PR
is worse than a slow test: it teaches everyone to re-run CI without reading it.

The test is a race by construction — the relay's answer budget must expire *before* the slow launch
returns, or the reply is not lost and there is nothing to recover from. The margin was **3×** (300 ms
budget vs a 900 ms launch), and a loaded runner lost it: the launch answered `Started`, so the
assertion for the relay's refusal failed.

Now **20×** (150 ms vs 3 s), absolute duration roughly unchanged. 20 is not a tuned number; it is far
enough outside any plausible scheduling delay that the ordering stops being a coin flip.

### What I tried first, and why it is not in this PR

I replaced the sleep with a condvar gate, so the launch *could not* finish until the test had seen the
refusal — ordering stated rather than hoped for, which is the better design. It did not work: the
waiter ran its full timeout even though `release()` provably ran afterwards **on the same `Arc`** (I
printed the pointer from both sides and they matched). It also made the test 8 seconds slower.

Rather than ship machinery whose behaviour I could not explain, I reverted to the simple shape. The
gate is worth revisiting by someone with time to find what it was really blocking on.

Ran the test five times in a row after the change: five passes.