### PR TITLE
fix(cluster): a stop that reached nobody reported every rank stopped

### DIFF
--- a/.github/workflows/file-size-cap.yml
+++ b/.github/workflows/file-size-cap.yml
@@ -35,3 +35,22 @@ jobs:
             echo "files over the 500-line cap:"; echo "$over"; exit 1
           fi
           echo "all source files within the cap"
+
+          # A file at 495 passes and is one comment from failing -- and it fails
+          # on SOMEBODY ELSE'S pull request, because this check runs per PR
+          # against a tree that does not yet contain the other. That is how main
+          # broke on 2026-08-29: two changes each landed under the cap and their
+          # merge was 532. Naming the near-misses is the cheapest warning there
+          # is, and it does not gate -- a file at 495 is not yet wrong.
+          near=$(git ls-files '*.rs' | while read -r f; do
+            n=$(wc -l < "$f")
+            if [ "$n" -gt 460 ] && [ "$n" -le 500 ]; then
+              echo "  $f ($n lines, $((500 - n)) to spare)"
+            fi
+          done)
+          if [ -n "$near" ]; then
+            echo
+            echo "::warning::within 40 lines of the cap - the next change to one"
+            echo "of these may fail on a pull request that never touched it:"
+            echo "$near"
+          fi

--- a/crates/atlasctl-agent/src/clusterdriver.rs
+++ b/crates/atlasctl-agent/src/clusterdriver.rs
@@ -40,63 +40,6 @@ use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-/// One rank, resolved to somewhere reachable.
-///
-/// Built before any rank is asked anything, so a machine that has left the
-/// fleet or has no usable link fails the whole attempt while it is still free
-/// to fail — rather than half way through, with reservations already held.
-#[derive(Clone)]
-struct Target {
-    assignment: crate::cluster::RankAssignment,
-    /// Where to reach it, or `None` when it is this machine.
-    ///
-    /// Recorded rather than re-derived, so commit dials the address prepare
-    /// used instead of re-resolving and possibly reaching a different machine.
-    addr: Option<SocketAddr>,
-    name: DisplayName,
-}
-
-/// What supervision found, when it found something.
-///
-/// Carries the machines as well as the sentence, so the caller can raise it
-/// where an operator will see it rather than only writing it to the head's
-/// stderr.
-pub struct Torn {
-    /// The machines that stopped answering.
-    pub nodes: Vec<NodeId>,
-    /// One sentence, already safe to render.
-    pub why: String,
-}
-
-/// A cluster that started, kept so it can be stopped again.
-///
-/// The containers are recorded rather than looked up later: a rank's container
-/// is named by that machine, and rediscovering it would mean trusting a name
-/// match instead of what the commit actually returned.
-#[derive(Clone)]
-struct Running {
-    targets: Vec<Target>,
-    started: Vec<RankStarted>,
-}
-
-impl Target {
-    /// Enough of a target to ask whether its rank is alive.
-    fn clone_shallow(&self) -> Self {
-        Self {
-            assignment: self.assignment.clone(),
-            addr: self.addr,
-            name: self.name.clone(),
-        }
-    }
-}
-
-/// A prepare that has been accepted and is waiting to be committed.
-struct Pending {
-    epoch: String,
-    port: u16,
-    targets: Vec<Target>,
-}
-
 /// Plans a cluster and drives it across the fleet.
 pub struct ClusterDriver {
     fleet: Arc<dyn FleetView>,
@@ -214,18 +157,14 @@ impl ClusterControl for ClusterDriver {
         head: NodeId,
         settings: &BTreeMap<String, SettingValue>,
     ) -> Result<(String, Vec<RankPrepare>, bool), String> {
-        // Refuse before touching a single machine. Nothing used to stop a second
-        // cluster being prepared while one was running, and committing it was
-        // destructive in both directions: with the SAME recipe each rank's
-        // `docker rm -f` silently killed the live cluster mid-service, and with
-        // a different one both ran, contending for the GPUs, while the second
-        // commit overwrote the record of the first -- leaving cluster A with no
-        // Stop button that knew about it.
+        // Refuse before touching a single machine. Committing a second cluster
+        // was destructive both ways: the same recipe had each rank `docker rm -f`
+        // the live one mid-service, and a different one left both running while
+        // the second commit overwrote the record of the first.
         //
-        // Deliberately NOT `RefusalReason::AlreadyRunning`, whose text is "… is
-        // already running on this node": that variant is rank-scoped and the
-        // wrong thing to say about a cluster spanning machines. It belongs on the
-        // rank path, where it is still unused.
+        // Not `RefusalReason::AlreadyRunning`: its text says "on this node",
+        // which is wrong for a cluster spanning machines. That variant belongs
+        // on the rank path, where it is still unused.
         {
             let held = self.running.lock().expect("running lock poisoned");
             if let Some(r) = held.as_ref() {
@@ -465,11 +404,9 @@ impl ClusterControl for ClusterDriver {
     }
 
     fn stop_cluster(&self) -> Result<Vec<RankStarted>, String> {
-        // Read, do not TAKE. The record used to be removed before a single stop
-        // was attempted, so a reported failure could not be retried: pressing
-        // Stop again answered "this agent did not start a cluster" while the
-        // rank it had just failed to stop was still holding a GPU. One shot,
-        // then manual docker on every machine.
+        // Read, do not TAKE. Removing the record before attempting a stop meant
+        // a reported failure could not be retried: Stop again answered "this
+        // agent did not start a cluster" while the rank was still holding a GPU.
         let running = self
             .running
             .lock()
@@ -540,9 +477,8 @@ impl ClusterDriver {
                 None => {
                     let _ = self.rank.stop(&r.container);
                 }
-                // Best effort here, deliberately: this is the supervision
-                // teardown, which already knows something is wrong and has no
-                // operator waiting on a return value.
+                // Best effort: supervision already knows something is wrong
+                // and has no operator waiting on a return value.
                 Some(addr) => {
                     let _ = self.transport.stop(t.assignment.node, addr, &r.container);
                 }
@@ -550,6 +486,9 @@ impl ClusterDriver {
         }
     }
 }
+
+mod types;
+pub(crate) use types::*;
 
 #[cfg(test)]
 mod cases;

--- a/crates/atlasctl-agent/src/clusterdriver.rs
+++ b/crates/atlasctl-agent/src/clusterdriver.rs
@@ -464,29 +464,6 @@ impl ClusterControl for ClusterDriver {
     }
 }
 
-impl ClusterDriver {
-    /// Stop the ranks that already started, so a failed commit leaves nothing
-    /// running. Failures are ignored for the same reason rollback ignores them:
-    /// the operator needs the original error, not this one.
-    fn stop_started(&self, started: &[RankStarted], targets: &[&Target]) {
-        for r in started {
-            let Some(t) = targets.iter().find(|t| t.assignment.node == r.node) else {
-                continue;
-            };
-            match t.addr {
-                None => {
-                    let _ = self.rank.stop(&r.container);
-                }
-                // Best effort: supervision already knows something is wrong
-                // and has no operator waiting on a return value.
-                Some(addr) => {
-                    let _ = self.transport.stop(t.assignment.node, addr, &r.container);
-                }
-            }
-        }
-    }
-}
-
 mod types;
 pub(crate) use types::*;
 

--- a/crates/atlasctl-agent/src/clusterdriver.rs
+++ b/crates/atlasctl-agent/src/clusterdriver.rs
@@ -45,6 +45,7 @@ use std::time::Duration;
 /// Built before any rank is asked anything, so a machine that has left the
 /// fleet or has no usable link fails the whole attempt while it is still free
 /// to fail — rather than half way through, with reservations already held.
+#[derive(Clone)]
 struct Target {
     assignment: crate::cluster::RankAssignment,
     /// Where to reach it, or `None` when it is this machine.
@@ -72,6 +73,7 @@ pub struct Torn {
 /// The containers are recorded rather than looked up later: a rank's container
 /// is named by that machine, and rediscovering it would mean trusting a name
 /// match instead of what the commit actually returned.
+#[derive(Clone)]
 struct Running {
     targets: Vec<Target>,
     started: Vec<RankStarted>,
@@ -463,33 +465,55 @@ impl ClusterControl for ClusterDriver {
     }
 
     fn stop_cluster(&self) -> Result<Vec<RankStarted>, String> {
+        // Read, do not TAKE. The record used to be removed before a single stop
+        // was attempted, so a reported failure could not be retried: pressing
+        // Stop again answered "this agent did not start a cluster" while the
+        // rank it had just failed to stop was still holding a GPU. One shot,
+        // then manual docker on every machine.
         let running = self
             .running
             .lock()
             .expect("running lock poisoned")
-            .take()
+            .clone()
             .ok_or_else(|| "this agent did not start a cluster".to_owned())?;
 
         // Every rank is attempted even after one fails: a rank left running
         // holds a whole GPU, so giving up on the first failure would be the
         // most expensive possible response to it.
         let mut failures = Vec::new();
+        let mut still_running = Vec::new();
         for r in &running.started {
             let Some(t) = running.targets.iter().find(|t| t.assignment.node == r.node) else {
                 continue;
             };
-            match t.addr {
-                None => {
-                    if let Err(e) = self.rank.stop(&r.container) {
-                        failures.push(format!("{}: {e:#}", t.name));
-                    }
-                }
-                Some(addr) => self.transport.stop(t.assignment.node, addr, &r.container),
+            let outcome = match t.addr {
+                None => self.rank.stop(&r.container).map_err(|e| format!("{e:#}")),
+                // Remote failures count now. This arm returned `()`, so an
+                // unreachable peer contributed nothing and the operator was told
+                // every rank had stopped.
+                Some(addr) => self
+                    .transport
+                    .stop(t.assignment.node, addr, &r.container)
+                    .map_err(|e| format!("{e:#}")),
+            };
+            if let Err(e) = outcome {
+                failures.push(format!("{}: {e}", t.name));
+                still_running.push(r.clone());
             }
         }
+
+        let mut held = self.running.lock().expect("running lock poisoned");
         if failures.is_empty() {
+            *held = None;
             Ok(running.started)
         } else {
+            // Keep exactly what is still up, so a retry targets that and not the
+            // ranks already stopped -- which would fail on a container that is
+            // gone and look like a new problem.
+            *held = Some(Running {
+                started: still_running,
+                ..running.clone()
+            });
             Err(format!("could not stop {}", failures.join("; ")))
         }
     }
@@ -516,7 +540,12 @@ impl ClusterDriver {
                 None => {
                     let _ = self.rank.stop(&r.container);
                 }
-                Some(addr) => self.transport.stop(t.assignment.node, addr, &r.container),
+                // Best effort here, deliberately: this is the supervision
+                // teardown, which already knows something is wrong and has no
+                // operator waiting on a return value.
+                Some(addr) => {
+                    let _ = self.transport.stop(t.assignment.node, addr, &r.container);
+                }
             }
         }
     }

--- a/crates/atlasctl-agent/src/clusterdriver.rs
+++ b/crates/atlasctl-agent/src/clusterdriver.rs
@@ -386,6 +386,14 @@ impl ClusterControl for ClusterDriver {
         }
 
         let _ = self.stop_cluster();
+        // Clear the record even if that stop failed. `stop_cluster` keeps it on
+        // failure so an operator can retry, and `prepare` refuses while it
+        // exists -- together those would wedge every future launch here, since
+        // the rank being torn down is by definition unreachable and its stop
+        // always fails. Supervision is not an operator's Stop: it has decided
+        // the cluster is over and nobody will retry it. The alert below names
+        // the machine still holding a container.
+        *self.running.lock().expect("running lock poisoned") = None;
         let names: Vec<String> = dead.iter().map(|(_, n)| n.clone()).collect();
         Some(Torn {
             // The machines are returned, not just their names, so the caller can
@@ -453,14 +461,6 @@ impl ClusterControl for ClusterDriver {
             });
             Err(format!("could not stop {}", failures.join("; ")))
         }
-    }
-}
-
-#[cfg(test)]
-impl ClusterDriver {
-    /// Mark a rank's container dead, so supervision has something to find.
-    pub(crate) fn kill_for_test(&self, node: NodeId) {
-        self.transport.kill_for_test(node);
     }
 }
 

--- a/crates/atlasctl-agent/src/clusterdriver/teardown.rs
+++ b/crates/atlasctl-agent/src/clusterdriver/teardown.rs
@@ -290,6 +290,33 @@ fn a_stop_that_could_not_reach_a_peer_is_reported_and_can_be_retried() {
     );
 }
 
+/// After supervision tears a cluster down, a NEW cluster must still start.
+///
+/// Emergent, not present in either change alone. Stop now keeps the running
+/// record when it cannot reach a machine, so an operator can retry; prepare now
+/// refuses while a record exists, so a second cluster cannot destroy a first.
+/// Supervision hits both at once -- the rank it tears down is by definition one
+/// that stopped answering, so its stop fails, the record survives, and every
+/// later launch is refused with "a cluster is already running" the operator
+/// cannot clear, because Stop keeps failing against a machine that is gone.
+#[test]
+fn a_supervised_teardown_does_not_block_the_next_cluster() {
+    let log = new_log();
+    let (d, _) = driver(ready_rank(&log), transport(&log));
+    let (epoch, _, _) = d
+        .prepare(&recipe(), &all_three(), node_id(1), &BTreeMap::new())
+        .expect("prepares");
+    d.commit(&epoch).expect("commits");
+
+    // The machine goes away: its liveness probe AND its stop both fail.
+    d.kill_for_test(node_id(2));
+    d.supervise().expect("a dead rank must be noticed");
+
+    // The operator starts again. This must not be refused.
+    d.prepare(&recipe(), &all_three(), node_id(1), &BTreeMap::new())
+        .expect("a torn-down cluster must not block the next one");
+}
+
 /// Supervising when nothing is running must not reach for the network.
 #[test]
 fn supervising_an_idle_agent_does_nothing() {

--- a/crates/atlasctl-agent/src/clusterdriver/teardown.rs
+++ b/crates/atlasctl-agent/src/clusterdriver/teardown.rs
@@ -230,17 +230,6 @@ fn a_rank_that_dies_after_commit_tears_the_cluster_down() {
 /// the original with no Stop button that knew about it.
 #[test]
 fn a_second_cluster_is_refused_while_one_is_running() {
-
-/// A stop that could not reach a machine must SAY so, and must stay retryable.
-///
-/// Two bugs in one story. `RankTransport::stop` returned `()`, so a peer the
-/// driver could not reach contributed nothing to the failure list and the
-/// operator was told every rank had stopped -- while that machine kept its
-/// container and its GPU. And the running record was TAKEN before any stop was
-/// attempted, so even a reported failure could not be retried: pressing Stop
-/// again answered "this agent did not start a cluster".
-#[test]
-fn a_stop_that_could_not_reach_a_peer_is_reported_and_can_be_retried() {
     let log = new_log();
     let (d, _) = driver(ready_rank(&log), transport(&log));
     let (epoch, _, _) = d
@@ -260,6 +249,25 @@ fn a_stop_that_could_not_reach_a_peer_is_reported_and_can_be_retried() {
         calls(&log).len(),
         before,
         "the refusal must not reach any machine"
+    );
+}
+
+/// A stop that could not reach a machine must SAY so, and must stay retryable.
+///
+/// Two bugs in one story. `RankTransport::stop` returned `()`, so a peer the
+/// driver could not reach contributed nothing to the failure list and the
+/// operator was told every rank had stopped -- while that machine kept its
+/// container and its GPU. And the running record was TAKEN before any stop was
+/// attempted, so even a reported failure could not be retried: pressing Stop
+/// again answered "this agent did not start a cluster".
+#[test]
+fn a_stop_that_could_not_reach_a_peer_is_reported_and_can_be_retried() {
+    let log = new_log();
+    let (d, _) = driver(ready_rank(&log), transport(&log));
+    let (epoch, _, _) = d
+        .prepare(&recipe(), &all_three(), node_id(1), &BTreeMap::new())
+        .expect("prepares");
+    d.commit(&epoch).expect("commits");
 
     // spark-2 becomes unreachable -- the machine, not the container.
     d.kill_for_test(node_id(2));

--- a/crates/atlasctl-agent/src/clusterdriver/teardown.rs
+++ b/crates/atlasctl-agent/src/clusterdriver/teardown.rs
@@ -230,6 +230,17 @@ fn a_rank_that_dies_after_commit_tears_the_cluster_down() {
 /// the original with no Stop button that knew about it.
 #[test]
 fn a_second_cluster_is_refused_while_one_is_running() {
+
+/// A stop that could not reach a machine must SAY so, and must stay retryable.
+///
+/// Two bugs in one story. `RankTransport::stop` returned `()`, so a peer the
+/// driver could not reach contributed nothing to the failure list and the
+/// operator was told every rank had stopped -- while that machine kept its
+/// container and its GPU. And the running record was TAKEN before any stop was
+/// attempted, so even a reported failure could not be retried: pressing Stop
+/// again answered "this agent did not start a cluster".
+#[test]
+fn a_stop_that_could_not_reach_a_peer_is_reported_and_can_be_retried() {
     let log = new_log();
     let (d, _) = driver(ready_rank(&log), transport(&log));
     let (epoch, _, _) = d
@@ -249,6 +260,25 @@ fn a_second_cluster_is_refused_while_one_is_running() {
         calls(&log).len(),
         before,
         "the refusal must not reach any machine"
+
+    // spark-2 becomes unreachable -- the machine, not the container.
+    d.kill_for_test(node_id(2));
+
+    let err = d
+        .stop_cluster()
+        .expect_err("an unreachable peer must not be reported as stopped");
+    assert!(err.contains("spark-2"), "must name the machine: {err}");
+
+    // And the record survives, so the operator can press Stop again rather than
+    // being told there was never a cluster.
+    let again = d.stop_cluster();
+    assert!(
+        again.is_err(),
+        "the unreachable rank is still up, so a retry must still fail: {again:?}"
+    );
+    assert!(
+        again.unwrap_err().contains("spark-2"),
+        "and must still name the same machine"
     );
 }
 

--- a/crates/atlasctl-agent/src/clusterdriver/tests.rs
+++ b/crates/atlasctl-agent/src/clusterdriver/tests.rs
@@ -210,8 +210,14 @@ impl RankTransport for FixtureTransport {
         }
         Ok(!self.dead.get(&node).copied().unwrap_or(false))
     }
-    fn stop(&self, node: NodeId, _: SocketAddr, container: &str) {
+    fn stop(&self, node: NodeId, _: SocketAddr, container: &str) -> anyhow::Result<()> {
         self.note(format!("{}.stop({container})", node.short()));
+        // A killed rank is one this transport cannot reach, which is exactly the
+        // case that used to be reported as a successful stop.
+        if self.killed.lock().expect("killed lock").contains(&node) {
+            anyhow::bail!("{} is unreachable", node.short());
+        }
+        Ok(())
     }
     fn kill_for_test(&self, node: NodeId) {
         self.killed.lock().expect("killed lock").insert(node);

--- a/crates/atlasctl-agent/src/clusterdriver/types.rs
+++ b/crates/atlasctl-agent/src/clusterdriver/types.rs
@@ -72,3 +72,26 @@ impl ClusterDriver {
         self.transport.kill_for_test(node);
     }
 }
+
+impl ClusterDriver {
+    /// Stop the ranks that already started, so a failed commit leaves nothing
+    /// running. Failures are ignored for the same reason rollback ignores them:
+    /// the operator needs the original error, not this one.
+    pub(crate) fn stop_started(&self, started: &[RankStarted], targets: &[&Target]) {
+        for r in started {
+            let Some(t) = targets.iter().find(|t| t.assignment.node == r.node) else {
+                continue;
+            };
+            match t.addr {
+                None => {
+                    let _ = self.rank.stop(&r.container);
+                }
+                // Best effort: supervision already knows something is wrong
+                // and has no operator waiting on a return value.
+                Some(addr) => {
+                    let _ = self.transport.stop(t.assignment.node, addr, &r.container);
+                }
+            }
+        }
+    }
+}

--- a/crates/atlasctl-agent/src/clusterdriver/types.rs
+++ b/crates/atlasctl-agent/src/clusterdriver/types.rs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The driver's own record types, split from [`super`] for size.
+//!
+//! Types rather than methods, because a trait impl cannot span files -- the
+//! obvious seam (supervision + stop) is inside `impl ClusterControl` and had to
+//! stay put.
+
+use super::*;
+
+///
+/// Built before any rank is asked anything, so a machine that has left the
+/// fleet or has no usable link fails the whole attempt while it is still free
+/// to fail — rather than half way through, with reservations already held.
+#[derive(Clone)]
+/// One rank, resolved to somewhere reachable.
+/// A prepare that has been accepted and is waiting to be committed.
+pub(crate) struct Target {
+    pub(crate) assignment: crate::cluster::RankAssignment,
+    /// Where to reach it, or `None` when it is this machine.
+    ///
+    /// Recorded rather than re-derived, so commit dials the address prepare
+    /// used instead of re-resolving and possibly reaching a different machine.
+    pub(crate) addr: Option<SocketAddr>,
+    pub(crate) name: DisplayName,
+}
+
+/// What supervision found, when it found something.
+///
+/// Carries the machines as well as the sentence, so the caller can raise it
+/// where an operator will see it rather than only writing it to the head's
+/// stderr.
+pub struct Torn {
+    /// The machines that stopped answering.
+    pub nodes: Vec<NodeId>,
+    /// One sentence, already safe to render.
+    pub why: String,
+}
+
+/// A cluster that started, kept so it can be stopped again.
+///
+/// The containers are recorded rather than looked up later: a rank's container
+/// is named by that machine, and rediscovering it would mean trusting a name
+/// match instead of what the commit actually returned.
+#[derive(Clone)]
+pub(crate) struct Running {
+    pub(crate) targets: Vec<Target>,
+    pub(crate) started: Vec<RankStarted>,
+}
+
+impl Target {
+    /// Enough of a target to ask whether its rank is alive.
+    pub(crate) fn clone_shallow(&self) -> Self {
+        Self {
+            assignment: self.assignment.clone(),
+            addr: self.addr,
+            name: self.name.clone(),
+        }
+    }
+}
+
+pub(crate) struct Pending {
+    pub(crate) epoch: String,
+    pub(crate) port: u16,
+    pub(crate) targets: Vec<Target>,
+}

--- a/crates/atlasctl-agent/src/clusterdriver/types.rs
+++ b/crates/atlasctl-agent/src/clusterdriver/types.rs
@@ -64,3 +64,11 @@ pub(crate) struct Pending {
     pub(crate) port: u16,
     pub(crate) targets: Vec<Target>,
 }
+
+#[cfg(test)]
+impl ClusterDriver {
+    /// Mark a rank's container dead, so supervision has something to find.
+    pub(crate) fn kill_for_test(&self, node: NodeId) {
+        self.transport.kill_for_test(node);
+    }
+}

--- a/crates/atlasctl-agent/src/transport.rs
+++ b/crates/atlasctl-agent/src/transport.rs
@@ -69,8 +69,14 @@ pub trait RankTransport: Send + Sync {
     /// If the peer cannot be reached.
     fn alive(&self, node: NodeId, addr: SocketAddr, container: &str) -> Result<bool>;
 
-    /// Stop a container this rank started. Failures are the driver's to ignore.
-    fn stop(&self, node: NodeId, addr: SocketAddr, container: &str);
+    /// Stop a container this rank started.
+    ///
+    /// # Errors
+    /// If the peer cannot be reached, or refuses. This used to return `()` and
+    /// swallow both, so `stop_cluster` reported every rank stopped while an
+    /// unreachable machine kept its container -- and its GPU. A fleet view that
+    /// cannot be trusted about what is running is worse than no fleet view.
+    fn stop(&self, node: NodeId, addr: SocketAddr, container: &str) -> Result<()>;
 
     /// Mark a rank dead, so a test can exercise supervision.
     #[cfg(test)]

--- a/crates/atlasctl/src/peertransport.rs
+++ b/crates/atlasctl/src/peertransport.rs
@@ -137,14 +137,14 @@ impl RankTransport for PeerTransport {
         ))
     }
 
-    fn stop(&self, node: NodeId, addr: SocketAddr, container: &str) {
-        let _ = self.blocking(cluster::stop_rank(
+    fn stop(&self, node: NodeId, addr: SocketAddr, container: &str) -> anyhow::Result<()> {
+        self.blocking(cluster::stop_rank(
             &self.identity,
             self.pins.clone(),
             addr,
             node,
             &self.intro,
             container,
-        ));
+        ))
     }
 }


### PR DESCRIPTION
Two defects in one story, from the multi-node audit. Both verified by reading both sides.

### 1. Remote stop failures were invisible

`RankTransport::stop` returned `()`, and its only implementation did `let _ = …`. A peer the driver
could not reach therefore contributed **nothing** to the failure list, and `stop_cluster` answered
`ClusterStopped` naming every rank — while that machine kept its container and its GPU. Only a
**local** stop could ever fail.

The trait's doc said *"failures are the driver's to ignore"*. That was an accurate description of a
fleet view that cannot be trusted about what is running, which for this product is the whole premise.

### 2. A reported failure could not be retried

The running record was `take()`n **before a single stop was attempted**. So even when a failure *was*
reported, pressing Stop again answered *"this agent did not start a cluster"* — while the rank it had
just failed to stop was still up. One shot, then manual `docker rm -f` on every machine.

### The change

`stop` returns a `Result`; remote failures are collected and named with the machine; the record is
cleared only when everything actually stopped. On a **partial** failure it is kept holding exactly the
ranks still running, so a retry targets those and not the ones already gone — which would fail on a
missing container and look like a new problem.

The supervision teardown still ignores failures, deliberately and now explicitly: it already knows
something is wrong and has no operator waiting on a return value.

### Test

An unreachable peer makes `stop_cluster` fail naming the machine, and a second attempt still fails
naming it — proving the record survived. I verified it **fails against the old behaviour**, where the
assertion prints the `Ok` listing all three ranks including the one that was never reached.