### PR TITLE
docs(cluster): the endpoint we hand the operator is the fabric address

### DIFF
--- a/crates/atlasctl-agent/src/clusterdriver.rs
+++ b/crates/atlasctl-agent/src/clusterdriver.rs
@@ -277,6 +277,24 @@ impl ClusterControl for ClusterDriver {
                     container,
                     // Only rank 0 serves the API. A worker's URL would not
                     // answer, and offering one would cost the operator time.
+                    //
+                    // ⚠ KNOWN, and not fixable here. `master_addr` is the
+                    // RENDEZVOUS address -- deliberately the fastest link every
+                    // worker SHARES, which on a Spark pair is the point-to-point
+                    // RoCE fabric (10.10.10.x). That is the right choice for the
+                    // ranks talking to each other and the wrong one for the
+                    // human: the operator's laptop is not on that fabric, so the
+                    // one URL this product hands them times out while the
+                    // container serves perfectly.
+                    //
+                    // Swapping in `preferred_address` does not fix it -- that
+                    // also ranks by link class and picks the same fabric. The
+                    // address that works is the one the BROWSER reached this
+                    // agent on, which is known at the HTTP layer and not here.
+                    // Fixing it properly means the endpoint travelling as a port
+                    // plus a machine identity and the page composing the URL
+                    // from its own connection, which is a protocol and UI change
+                    // rather than a line in this function.
                     endpoint: (t.assignment.rank == 0)
                         .then(|| format!("http://{}:{}", t.assignment.master_addr, pending.port)),
                 }),


### PR DESCRIPTION
From the multi-node audit. A comment, not a fix — and the comment explains why.

After a successful cluster launch the operator is handed exactly one URL. It is built from
`master_addr`, the **rendezvous** address: deliberately the fastest link every worker *shares*, which
on a Spark pair is the point-to-point RoCE fabric (`10.10.10.x`). That is the right choice for the
ranks talking to each other, and the wrong one for the human — their laptop is not on that fabric, so
the URL times out while the container serves perfectly.

**Why this PR does not fix it.** There is no better address in scope. `preferred_address` also ranks
by link class and picks the same fabric. The address that actually works is the one the *browser*
used to reach this agent, which is known at the HTTP layer and not in the cluster driver. Fixing it
properly means the endpoint travelling as a port plus a machine identity, with the page composing the
URL from its own connection — a protocol and UI change, not a line in this function.

Replacing one unreachable URL with another unreachable URL would look like progress and be none, so
this records the finding where it is built, with the shape of the real fix, rather than guessing.