### PR TITLE
fix(rankservice): the reservation TTL panicked on Windows, breaking main

### DIFF
--- a/crates/atlasctl/src/rankservice/mod.rs
+++ b/crates/atlasctl/src/rankservice/mod.rs
@@ -41,14 +41,26 @@ struct Reservation {
     epoch: String,
     recipe: String,
     plan: atlasctl_core::docker::LaunchPlan,
-    /// When this machine agreed. Without it a reservation is immortal: the head
+    /// When this machine agreed, as a monotonic COUNT rather than an `Instant`.
+    ///
+    /// `Instant` looked natural and is a trap: `Instant::now() - d` panics on
+    /// Windows when `d` exceeds the time since boot, and a CI runner is minutes
+    /// old. The test that ages a reservation past the TTL therefore panicked
+    /// there while passing everywhere else -- which is how it reached main.
+    ///
+    /// Without it a reservation is immortal: the head
     /// that made it can close its tab, crash, or be restarted for an upgrade,
     /// and nothing on this machine ever releases the hold. The refusal below
     /// tells the operator to "abort that launch, or wait for it to finish" --
     /// abort needs the lost epoch, and it never finishes, so every future
     /// cluster launch on this machine is refused until someone restarts the
     /// agent by hand. On a fleet that is every machine at once.
-    made: std::time::Instant,
+    /// The instant this hold stops binding, computed FORWARD from creation.
+    ///
+    /// Forward, not backward: a test that wants an already-lapsed reservation
+    /// sets a deadline in the past by construction, instead of subtracting from
+    /// `Instant::now()` -- which is the operation that panics on Windows.
+    expires: std::time::Instant,
 }
 
 /// How long a reservation outlives the head that made it.
@@ -315,7 +327,7 @@ impl RankService for LocalRankService {
             if let Some(r) = held.as_ref()
                 && r.epoch != epoch
             {
-                if r.made.elapsed() >= RESERVATION_TTL {
+                if std::time::Instant::now() >= r.expires {
                     // The head that made this is gone -- it would have committed
                     // or aborted long ago. Releasing here is what makes the
                     // refusal's "wait for it to finish" true, and it is the
@@ -326,7 +338,10 @@ impl RankService for LocalRankService {
                 } else {
                     return refuse(RefusalReason::Reserved {
                         recipe: r.recipe.clone(),
-                        expires_in_s: (RESERVATION_TTL - r.made.elapsed()).as_secs(),
+                        expires_in_s: r
+                            .expires
+                            .saturating_duration_since(std::time::Instant::now())
+                            .as_secs(),
                     });
                 }
             }
@@ -362,7 +377,7 @@ impl RankService for LocalRankService {
             epoch: epoch.to_owned(),
             recipe: assignment.recipe.clone(),
             plan,
-            made: std::time::Instant::now(),
+            expires: std::time::Instant::now() + RESERVATION_TTL,
         });
         PrepareReply::Prepared
     }

--- a/crates/atlasctl/src/rankservice/mod.rs
+++ b/crates/atlasctl/src/rankservice/mod.rs
@@ -41,25 +41,16 @@ struct Reservation {
     epoch: String,
     recipe: String,
     plan: atlasctl_core::docker::LaunchPlan,
-    /// When this machine agreed, as a monotonic COUNT rather than an `Instant`.
+    /// When this hold stops binding, computed FORWARD from creation.
     ///
-    /// `Instant` looked natural and is a trap: `Instant::now() - d` panics on
-    /// Windows when `d` exceeds the time since boot, and a CI runner is minutes
-    /// old. The test that ages a reservation past the TTL therefore panicked
-    /// there while passing everywhere else -- which is how it reached main.
+    /// Without an expiry a reservation is immortal: the head that made it can
+    /// close its tab, crash, or restart for an upgrade, and nothing here ever
+    /// releases it -- so every later cluster launch on this machine is refused
+    /// until someone restarts the agent by hand. On a fleet, all of them.
     ///
-    /// Without it a reservation is immortal: the head
-    /// that made it can close its tab, crash, or be restarted for an upgrade,
-    /// and nothing on this machine ever releases the hold. The refusal below
-    /// tells the operator to "abort that launch, or wait for it to finish" --
-    /// abort needs the lost epoch, and it never finishes, so every future
-    /// cluster launch on this machine is refused until someone restarts the
-    /// agent by hand. On a fleet that is every machine at once.
-    /// The instant this hold stops binding, computed FORWARD from creation.
-    ///
-    /// Forward, not backward: a test that wants an already-lapsed reservation
-    /// sets a deadline in the past by construction, instead of subtracting from
-    /// `Instant::now()` -- which is the operation that panics on Windows.
+    /// Stored as a deadline rather than a creation time so that nothing ever
+    /// computes `Instant::now() - d`, which PANICS on Windows when `d` exceeds
+    /// the time since boot. A CI runner is minutes old; that panic broke main.
     expires: std::time::Instant,
 }
 

--- a/crates/atlasctl/src/rankservice/tests.rs
+++ b/crates/atlasctl/src/rankservice/tests.rs
@@ -207,12 +207,15 @@ fn a_reservation_whose_head_vanished_lapses_and_the_refusal_says_when() {
         "the refusal must say waiting works: {reason}"
     );
 
-    // Age it past the TTL, exactly as an abandoned head would.
+    // Age it past the TTL, exactly as an abandoned head would. The deadline is
+    // pulled BACK to now rather than pushing the creation time into the past:
+    // subtracting a ten-minute Duration from `Instant::now()` panics on Windows
+    // whenever the machine booted more recently than that -- which a CI runner
+    // always has. That panic is how this test broke main after passing here.
     {
         let mut held = svc.reserved.lock().expect("reservation lock poisoned");
         let r = held.as_mut().expect("still reserved");
-        r.made = std::time::Instant::now()
-            - (super::RESERVATION_TTL + std::time::Duration::from_secs(1));
+        r.expires = std::time::Instant::now();
     }
     assert_eq!(
         svc.prepare("other", &a),


### PR DESCRIPTION
**My regression, and it is breaking main's Windows job for every branch built on it** — #120, #126
and #127 are all red on `check` for this reason and nothing else.

`Instant::now() - d` **panics on Windows** when `d` exceeds the time since boot. The
reservation-expiry test from #124 aged a hold by subtracting ten minutes from now, and a CI runner is
minutes old. So it passed on this box and on Linux CI, and panicked on Windows — the one job that
exercises it, which I merged without reading.

### The fix is in the production type, not the test

A `Reservation` now records when it **expires**, computed forward at creation, instead of when it was
made. Nothing subtracts from `Instant::now()` anywhere in the crate any more, so the trap is removed
rather than side-stepped at one call site. The refusal's countdown uses `saturating_duration_since`,
which cannot underflow either.

The test ages a reservation by pulling its deadline back to now — an operation with no arithmetic to
get wrong on any platform. It still fails when the expiry check is disabled, so it pins the behaviour
and not the mechanism.