### PR TITLE
fix(cluster): a cluster that died told nobody

### DIFF
--- a/crates/atlasctl-agent/src/clusterdriver.rs
+++ b/crates/atlasctl-agent/src/clusterdriver.rs
@@ -55,6 +55,18 @@ struct Target {
     name: DisplayName,
 }
 
+/// What supervision found, when it found something.
+///
+/// Carries the machines as well as the sentence, so the caller can raise it
+/// where an operator will see it rather than only writing it to the head's
+/// stderr.
+pub struct Torn {
+    /// The machines that stopped answering.
+    pub nodes: Vec<NodeId>,
+    /// One sentence, already safe to render.
+    pub why: String,
+}
+
 /// A cluster that started, kept so it can be stopped again.
 ///
 /// The containers are recorded rather than looked up later: a rank's container
@@ -352,7 +364,7 @@ impl ClusterControl for ClusterDriver {
         }
     }
 
-    fn supervise(&self) -> Option<String> {
+    fn supervise(&self) -> Option<Torn> {
         // Read the roster under the lock, then release it: asking a peer
         // whether it is alive dials the network, and holding the lock across
         // that would block a stop the operator asked for.
@@ -384,7 +396,7 @@ impl ClusterControl for ClusterDriver {
                     .unwrap_or(false),
             };
             if !alive {
-                dead.push(t.name.to_string());
+                dead.push((t.assignment.node, t.name.to_string()));
             }
         }
         if dead.is_empty() {
@@ -392,11 +404,21 @@ impl ClusterControl for ClusterDriver {
         }
 
         let _ = self.stop_cluster();
-        Some(format!(
-            "{} stopped, so the cluster was torn down. A half cluster waits at a \
-             rendezvous that will never complete while its survivors hold their GPUs.",
-            dead.join(" and ")
-        ))
+        let names: Vec<String> = dead.iter().map(|(_, n)| n.clone()).collect();
+        Some(Torn {
+            // The machines are returned, not just their names, so the caller can
+            // raise this against the node in the fleet view. Previously this
+            // returned prose that went to `eprintln!` on the head's own process
+            // and nowhere else: the browser went on showing a running cluster
+            // whose endpoint had quietly died, and the Stop button then answered
+            // "this agent did not start a cluster".
+            nodes: dead.iter().map(|(id, _)| *id).collect(),
+            why: format!(
+                "{} stopped, so the cluster was torn down. A half cluster waits at a \
+                 rendezvous that will never complete while its survivors hold their GPUs.",
+                names.join(" and ")
+            ),
+        })
     }
 
     fn stop_cluster(&self) -> Result<Vec<RankStarted>, String> {

--- a/crates/atlasctl-agent/src/clusterdriver/teardown.rs
+++ b/crates/atlasctl-agent/src/clusterdriver/teardown.rs
@@ -197,8 +197,18 @@ fn a_rank_that_dies_after_commit_tears_the_cluster_down() {
 
     // Now rank 2 dies.
     d.kill_for_test(node_id(2));
-    let why = d.supervise().expect("a dead rank must be noticed");
-    assert!(why.contains("spark-2"), "must name what died: {why}");
+    let torn = d.supervise().expect("a dead rank must be noticed");
+    assert!(
+        torn.why.contains("spark-2"),
+        "must name what died: {}",
+        torn.why
+    );
+    // The machines travel with the sentence, so the caller can raise this
+    // against a node rather than only printing it on the head's stderr.
+    assert!(
+        !torn.nodes.is_empty(),
+        "supervision must say WHICH machine, not only that something died"
+    );
 
     let c = calls(&log);
     assert!(

--- a/crates/atlasctl-agent/src/session/cluster_control.rs
+++ b/crates/atlasctl-agent/src/session/cluster_control.rs
@@ -89,5 +89,5 @@ pub trait ClusterControl: Send + Sync {
     ///
     /// Returns a description of what it tore down, or `None` when the cluster
     /// is whole or absent.
-    fn supervise(&self) -> Option<String>;
+    fn supervise(&self) -> Option<crate::clusterdriver::Torn>;
 }

--- a/crates/atlasctl/src/commands/agent.rs
+++ b/crates/atlasctl/src/commands/agent.rs
@@ -331,6 +331,7 @@ pub fn run(args: &AgentRunArgs) -> Result<()> {
     // serving nothing.
     {
         let cluster = Arc::clone(&cluster);
+        let events = events.clone();
         rt.spawn(async move {
             let mut tick = tokio::time::interval(std::time::Duration::from_secs(20));
             tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -340,8 +341,26 @@ pub fn run(args: &AgentRunArgs) -> Result<()> {
                 // Asking a peer dials the network, so it must not run on the
                 // async runtime's worker threads.
                 let torn = tokio::task::spawn_blocking(move || cluster.supervise()).await;
-                if let Ok(Some(why)) = torn {
-                    eprintln!("cluster: {why}");
+                if let Ok(Some(torn)) = torn {
+                    eprintln!("cluster: {}", torn.why);
+                    // And say it where an operator is looking. This used to go
+                    // only to the head agent's stderr, so a cluster could die
+                    // and the browser went on showing it running -- with a Stop
+                    // button that then answered "this agent did not start a
+                    // cluster". A fleet view that silently goes stale is worse
+                    // than one that says it does not know.
+                    for node in torn.nodes {
+                        let _ = events.send(atlasctl_protocol::msg::ServerMsg::FleetEvent {
+                            event: atlasctl_protocol::msg::fleet::FleetEvent::AlertRaised {
+                                node,
+                                alert: atlasctl_protocol::fleet::NodeAlert {
+                                    kind: atlasctl_protocol::fleet::AlertKind::PeerLost,
+                                    severity: atlasctl_protocol::fleet::Severity::Critical,
+                                    detail: torn.why.clone(),
+                                },
+                            },
+                        });
+                    }
                 }
             }
         });


### PR DESCRIPTION
From the multi-node audit.

Supervision does the right thing when a rank stops answering — it tears the cluster down, because a
half cluster waits at a rendezvous that never completes while its survivors hold GPUs. Then it
reports that with a single `eprintln!` **on the head agent's own process**.

Nothing reached the events channel. So:

- the browser went on showing a **running cluster** whose endpoint had quietly died, and
- the Stop button answered *"this agent did not start a cluster"*, because supervision had already
  cleared the record.

The operator's next clue was a model that would not respond.

### The change

`supervise` returns the machines alongside the sentence, and the caller raises
`AlertRaised { kind: PeerLost, severity: Critical }` against each — an alert kind that **already
existed for exactly this** ("a paired peer stopped responding") and that the fleet view already knows
how to draw. The stderr line stays: a headless operator reading `journalctl` is also a real reader.

A fleet view that silently goes stale is worse than one that says it does not know. This product's
premise is that the fleet is legible.

The teardown test now asserts the machines travel with the sentence, rather than that a name appears
somewhere in prose.