### PR TITLE
fix(cluster): refuse a second cluster while one is running

### DIFF
--- a/crates/atlasctl-agent/src/clusterdriver.rs
+++ b/crates/atlasctl-agent/src/clusterdriver.rs
@@ -200,6 +200,29 @@ impl ClusterControl for ClusterDriver {
         head: NodeId,
         settings: &BTreeMap<String, SettingValue>,
     ) -> Result<(String, Vec<RankPrepare>, bool), String> {
+        // Refuse before touching a single machine. Nothing used to stop a second
+        // cluster being prepared while one was running, and committing it was
+        // destructive in both directions: with the SAME recipe each rank's
+        // `docker rm -f` silently killed the live cluster mid-service, and with
+        // a different one both ran, contending for the GPUs, while the second
+        // commit overwrote the record of the first -- leaving cluster A with no
+        // Stop button that knew about it.
+        //
+        // Deliberately NOT `RefusalReason::AlreadyRunning`, whose text is "… is
+        // already running on this node": that variant is rank-scoped and the
+        // wrong thing to say about a cluster spanning machines. It belongs on the
+        // rank path, where it is still unused.
+        {
+            let held = self.running.lock().expect("running lock poisoned");
+            if let Some(r) = held.as_ref() {
+                let names: Vec<String> = r.started.iter().map(|s| s.name.to_string()).collect();
+                return Err(format!(
+                    "a cluster is already running on {}; stop it before starting another",
+                    names.join(", ")
+                ));
+            }
+        }
+
         let epoch = new_epoch();
         let pending = self.resolve(recipe, nodes, head, settings, epoch.clone())?;
 

--- a/crates/atlasctl-agent/src/clusterdriver/teardown.rs
+++ b/crates/atlasctl-agent/src/clusterdriver/teardown.rs
@@ -211,6 +211,37 @@ fn a_rank_that_dies_after_commit_tears_the_cluster_down() {
     );
 }
 
+/// A second cluster must be refused while one is running.
+///
+/// Nothing used to stop it, and committing was destructive in both directions:
+/// with the SAME recipe each rank's `docker rm -f` silently killed the live
+/// cluster mid-service, and with a different one both ran, contending for the
+/// GPUs, while the second commit overwrote the record of the first -- leaving
+/// the original with no Stop button that knew about it.
+#[test]
+fn a_second_cluster_is_refused_while_one_is_running() {
+    let log = new_log();
+    let (d, _) = driver(ready_rank(&log), transport(&log));
+    let (epoch, _, _) = d
+        .prepare(&recipe(), &all_three(), node_id(1), &BTreeMap::new())
+        .expect("prepares");
+    d.commit(&epoch).expect("commits");
+
+    let before = calls(&log).len();
+    let err = d
+        .prepare(&recipe(), &all_three(), node_id(1), &BTreeMap::new())
+        .expect_err("a second cluster must be refused while one runs");
+    assert!(err.contains("already running"), "{err}");
+    assert!(err.contains("stop it"), "must say what to do: {err}");
+    // And it must refuse BEFORE touching a machine: a refusal that has already
+    // dialled three peers has already done the damage it was avoiding.
+    assert_eq!(
+        calls(&log).len(),
+        before,
+        "the refusal must not reach any machine"
+    );
+}
+
 /// Supervising when nothing is running must not reach for the network.
 #[test]
 fn supervising_an_idle_agent_does_nothing() {


### PR DESCRIPTION
From the multi-node audit. Nothing stopped a second cluster being prepared while one was already
running, and committing it was destructive **in both directions**:

- **Same recipe** — each rank's `docker rm -f` silently destroyed the live cluster mid-service. No
  warning, no record, just a model that stopped answering.
- **Different recipe** — both ran, contending for the same GPUs, and the second commit **overwrote
  the head's record of the first**. Cluster A was then unstoppable from the interface, because the
  only thing that knew its container names had been replaced.

Two operators, or one operator in a second tab, is all it took.

### The change

The refusal happens **before any machine is dialled** — a refusal that has already prepared three
peers has done the damage it was meant to avoid — and it names the machines and says what to do.

Deliberately **not** `RefusalReason::AlreadyRunning`, whose text is *"… is already running on this
node"*. That variant is rank-scoped, and saying "on this node" about a cluster spanning three
machines would be worse than saying nothing. It belongs on the rank path, where it is still unused and
where a rank refusing because *its* container is up would be exactly right — a good follow-up.

### Test

Asserts both halves: that the second prepare is refused, and that **no call reached any machine**.
Verified it fails with the guard removed.