### PR TITLE
fix(launcher): stop could not reach a cluster rank's container

### DIFF
--- a/crates/atlasctl-agent/src/launcher/docker.rs
+++ b/crates/atlasctl-agent/src/launcher/docker.rs
@@ -6,7 +6,9 @@ use super::{Launcher, Preview, Started};
 use atlasctl_core::chain::UserConfig;
 use atlasctl_core::docker::collective::NcclRoce;
 use atlasctl_core::docker::profile::{DeviceProfile, LaunchProfile};
-use atlasctl_core::docker::translate::{LABEL_MANAGED, LaunchContext, Placement, translate};
+use atlasctl_core::docker::translate::{
+    LABEL_MANAGED, LABEL_RECIPE, LaunchContext, Placement, translate,
+};
 use atlasctl_core::host::HostSnapshot;
 use atlasctl_core::io::ProcessRunner;
 use atlasctl_core::{Recipe, ScalarValue};
@@ -137,9 +139,64 @@ impl Launcher for DockerLauncher {
     }
 
     fn stop(&self, recipe: &str) -> Result<(), AgentError> {
+        // By LABEL, not by name. A solo launch is `atlas-{recipe}`, but a rank of
+        // a cluster is `atlas-{recipe}-rank{n}` -- so stopping by name found the
+        // solo container and never a rank. That is the state an operator is left
+        // in when the head agent restarts while a cluster runs: the driver's
+        // record is memory-only, `StopCluster` answers "this agent did not start
+        // a cluster", and this path -- the only other one -- could not see the
+        // containers either. Both GPUs held, no button that works, `docker rm -f`
+        // on every machine by hand.
+        //
+        // The label is already on every container this agent starts, put there
+        // by the launch plan for exactly this kind of question.
+        let listed = self
+            .runner
+            .run(&[
+                "docker".into(),
+                "ps".into(),
+                "-q".into(),
+                "--filter".into(),
+                format!("label={LABEL_RECIPE}={recipe}"),
+            ])
+            .map_err(|e| AgentError::LaunchFailed {
+                detail: format!("{e:#}"),
+            })?;
+        if !listed.success() {
+            return Err(AgentError::LaunchFailed {
+                detail: listed.stderr.trim().to_string(),
+            });
+        }
+        let ids: Vec<String> = listed
+            .stdout
+            .lines()
+            .map(str::trim)
+            .filter(|l| !l.is_empty())
+            .map(str::to_owned)
+            .collect();
+        if ids.is_empty() {
+            // Nothing labelled. Fall back to the name so a container started by
+            // an older agent, before this label existed, is still stoppable.
+            let out = self
+                .runner
+                .run(&["docker".into(), "stop".into(), format!("atlas-{recipe}")])
+                .map_err(|e| AgentError::LaunchFailed {
+                    detail: format!("{e:#}"),
+                })?;
+            return if out.success() {
+                Ok(())
+            } else {
+                Err(AgentError::LaunchFailed {
+                    detail: out.stderr.trim().to_string(),
+                })
+            };
+        }
+
+        let mut argv: Vec<String> = vec!["docker".into(), "stop".into()];
+        argv.extend(ids);
         let out = self
             .runner
-            .run(&["docker".into(), "stop".into(), format!("atlas-{recipe}")])
+            .run(&argv)
             .map_err(|e| AgentError::LaunchFailed {
                 detail: format!("{e:#}"),
             })?;

--- a/crates/atlasctl-agent/src/launcher/docker/tests.rs
+++ b/crates/atlasctl-agent/src/launcher/docker/tests.rs
@@ -143,11 +143,47 @@ fn an_override_reaches_the_executed_command() {
     assert!(run.windows(2).any(|w| w == ["--port", "9100"]));
 }
 
+/// Nothing labelled: fall back to our own name, and never a wider pattern.
+///
+/// A container started by an older agent predates the recipe label, and must
+/// still be stoppable -- but the fallback is an exact name, so an unrelated
+/// container can never be caught by it.
 #[test]
-fn stop_targets_only_our_own_container_name() {
+fn stop_falls_back_to_our_own_container_name_when_nothing_is_labelled() {
     let runner = Arc::new(RecordingRunner::new());
     launcher(runner.clone()).stop("r").expect("stops");
-    assert_eq!(runner.calls(), [["docker", "stop", "atlas-r"]]);
+    let calls = runner.calls();
+    assert!(
+        calls[0].iter().any(|a| a.contains("io.atlasctl.recipe=r")),
+        "must ask docker by OUR label first: {calls:?}"
+    );
+    assert_eq!(
+        calls.last().expect("a stop"),
+        &["docker", "stop", "atlas-r"],
+        "and fall back to the exact name, not a pattern: {calls:?}"
+    );
+}
+
+/// A cluster rank is `atlas-{recipe}-rank{n}`, so stopping by NAME never found
+/// one. That is the state after a head agent restarts mid-cluster: the driver's
+/// record is memory-only and gone, `StopCluster` says it never started one, and
+/// this path was the only other way to reach the containers. Both GPUs held,
+/// no button that works.
+#[test]
+fn stop_reaches_rank_containers_a_name_match_would_miss() {
+    let runner = Arc::new(RecordingRunner::new());
+    runner.push_result(Output {
+        status: 0,
+        stdout: "abc123\ndef456\n".into(),
+        stderr: String::new(),
+    });
+    launcher(runner.clone()).stop("r").expect("stops");
+    let calls = runner.calls();
+    assert_eq!(
+        calls.last().expect("a stop"),
+        &["docker", "stop", "abc123", "def456"],
+        "every labelled container must be stopped, ranks included: {calls:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
From the multi-node audit. A solo launch is `atlas-{recipe}`; a cluster rank is
`atlas-{recipe}-rank{n}`. `stop` matched the name **exactly**, so it found the solo container and
never a rank.

That is precisely the state an operator is left in when the head agent restarts while a cluster runs:

- the driver's record of what it started is memory-only and gone, so `StopCluster` answers *"this
  agent did not start a cluster"*, and
- this path — the only other way to reach those containers — could not see them either.

Both machines hold their GPUs, no button in the interface works, and the remedy is `docker rm -f` on
each box by hand.

### The change

`stop` asks docker for containers carrying `io.atlasctl.recipe=<recipe>` — a label the launch plan
**already puts on every container this agent starts**, for exactly this kind of question — and stops
all of them.

When nothing is labelled it falls back to the exact name, so a container started by an older agent
stays stoppable. The fallback is a name, never a pattern, so an unrelated container still cannot be
caught by it.

### Tests

A rank container a name match would miss is stopped; the no-label case falls back to the exact name
after asking by label first. Both **fail against name-only stopping** — and I verified the mutation
*compiled*, because my first attempt at it didn't, and a test that fails to build proves nothing.