### PR TITLE
fix(install): the "published build differs" path replaced nothing

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -347,6 +347,53 @@ do_uninstall() {
     exit 0
 }
 
+# Put the downloaded binary in place and report which of the two things
+# happened: echoes "yes" when the installed copy was KEPT, and nothing when it
+# was replaced. All operator-facing text goes to stderr through `info`, so that
+# word is the only thing ever written to stdout.
+#
+# The wording and the copying are deliberately not in the same branch chain.
+# They were, once: the "published build differs" case was an `elif` that
+# announced a replacement while the `install`/`mv` sat in the `else`, so it
+# printed "replacing it" and replaced nothing. That is the worst failure this
+# script has available -- the operator is told the upgrade they came for
+# succeeded, and their agent keeps speaking the old protocol. Here every path
+# that decides to replace falls through to one copy, so the two cannot diverge.
+place_binary() { # dir tmp -> "yes" on stdout if kept
+    pb_dir="$1"; pb_tmp="$2"
+
+    # Ask the two binaries their versions rather than parsing a release tag: the
+    # downloaded one is already here and already checksum-verified, so this
+    # needs no second endpoint and cannot be fooled by a tag naming scheme that
+    # changes. An unreadable or non-answering existing binary compares unequal,
+    # which lands on the upgrade path -- the safe direction.
+    pb_new=$("$pb_tmp/$BIN_NAME" --version 2>/dev/null || true)
+    pb_old=""
+    [ -x "$pb_dir/$BIN_NAME" ] && pb_old=$("$pb_dir/$BIN_NAME" --version 2>/dev/null || true)
+
+    # Versions are for the OPERATOR to read. The decision is made on content --
+    # see `binary_differs`.
+    if ! binary_differs "$pb_dir/$BIN_NAME" "$pb_tmp/$BIN_NAME"; then
+        info "$pb_new is already installed here — keeping it."
+        echo "yes"
+        return 0
+    fi
+
+    if [ -n "$pb_old" ] && [ "$pb_old" = "$pb_new" ]; then
+        # Same version string, different build. Say so plainly rather than
+        # printing "upgrading 0.1.7 -> 0.1.7", which reads like a bug.
+        info "$pb_old is installed, but the published build differs — replacing it."
+    else
+        [ -z "$pb_old" ] || info "upgrading $pb_old -> $pb_new"
+    fi
+
+    # Install to a temp name and rename, so an interrupted install cannot leave
+    # a half-written binary on PATH.
+    install -m 0755 "$pb_tmp/$BIN_NAME" "$pb_dir/.$BIN_NAME.new"
+    mv -f "$pb_dir/.$BIN_NAME.new" "$pb_dir/$BIN_NAME"
+    info "installed $pb_dir/$BIN_NAME"
+}
+
 main() {
     [ "${1:-}" = "--uninstall" ] && do_uninstall
 
@@ -425,33 +472,7 @@ main() {
     mkdir -p "$dir"
     [ -f "$tmp/$BIN_NAME" ] || die "the archive did not contain $BIN_NAME"
 
-    # Ask the two binaries their versions rather than parsing a release tag: the
-    # downloaded one is already here and already checksum-verified, so this
-    # needs no second endpoint and cannot be fooled by a tag naming scheme that
-    # changes. An unreadable or non-answering existing binary compares unequal,
-    # which lands on the upgrade path -- the safe direction.
-    new_version=$("$tmp/$BIN_NAME" --version 2>/dev/null || true)
-    old_version=""
-    [ -x "$dir/$BIN_NAME" ] && old_version=$("$dir/$BIN_NAME" --version 2>/dev/null || true)
-
-    # Versions are for the OPERATOR to read. The decision is made on content --
-    # see `binary_differs`.
-    same_version=""
-    if ! binary_differs "$dir/$BIN_NAME" "$tmp/$BIN_NAME"; then
-        same_version="yes"
-        info "$new_version is already installed here — keeping it."
-    elif [ -n "$old_version" ] && [ "$old_version" = "$new_version" ]; then
-        # Same version string, different build. Say so plainly rather than
-        # printing "upgrading 0.1.7 -> 0.1.7", which reads like a bug.
-        info "$old_version is installed, but the published build differs — replacing it."
-    else
-        [ -z "$old_version" ] || info "upgrading $old_version -> $new_version"
-        # Install to a temp name and rename, so an interrupted install cannot leave
-        # a half-written binary on PATH.
-        install -m 0755 "$tmp/$BIN_NAME" "$dir/.$BIN_NAME.new"
-        mv -f "$dir/.$BIN_NAME.new" "$dir/$BIN_NAME"
-        info "installed $dir/$BIN_NAME"
-    fi
+    same_version=$(place_binary "$dir" "$tmp")
 
     case ":$PATH:" in
         *":$dir:"*) ;;

--- a/scripts/tests/install-sh.test.sh
+++ b/scripts/tests/install-sh.test.sh
@@ -210,6 +210,46 @@ case "$out" in *"was not found"*) bad "a stopped docker must not be called missi
 contains "no nvidia runtime: named separately" "$(docker_state nogpu)" "NVIDIA container runtime"
 check "a healthy docker says nothing" "" "$(docker_state fine)"
 
+# --- place_binary -------------------------------------------------------------
+# The point of these is that the FILE moved, not that a message was printed.
+# The bug they exist for printed exactly the right sentence and left the old
+# binary in place, so asserting on output alone would have passed it.
+
+# Version string and file content are set SEPARATELY on purpose: the bug lives
+# in the branch taken when the two binaries report the same version and differ
+# in content, so a helper that could not express that could not catch it.
+# `mark` becomes a comment line -- invisible to --version, visible to sha256.
+pb() { # old_version new_version mark -> "<kept>|<version on disk>|<mark on disk>"
+    d=$(mktemp -d); t=$(mktemp -d)
+    if [ -n "$1" ]; then
+        printf '#!/bin/sh\n# installed\necho "atlasctl %s"\n' "$1" > "$d/atlasctl"
+        chmod +x "$d/atlasctl"
+    fi
+    printf '#!/bin/sh\n# %s\necho "atlasctl %s"\n' "$3" "$2" > "$t/atlasctl"
+    chmod +x "$t/atlasctl"
+    kept=$( . "$WORK/lib.sh"; place_binary "$d" "$t" 2>/dev/null )
+    printf '%s|%s|%s' "$kept" "$("$d/atlasctl")" "$(sed -n 2p "$d/atlasctl")"
+    rm -rf "$d" "$t"
+}
+
+# Byte-identical: keep it, and say so.
+check "identical build is kept" \
+    "yes|atlasctl 1.0.0|# installed" "$(pb 1.0.0 1.0.0 installed)"
+
+# THE REGRESSION, and the reason this helper separates version from content.
+# Same version string, different build -- the shape of EVERY atlasctl release
+# before 0.2.0, so it is the case the operator actually hit. The old code
+# announced "replacing it" and replaced nothing; the mark on disk is what
+# proves the file moved, since the version output is identical either way.
+check "same version, different build: the binary is REPLACED" \
+    "|atlasctl 1.0.0|# fresh" "$(pb 1.0.0 1.0.0 fresh)"
+
+# An ordinary upgrade, and a first install with nothing there before.
+check "a newer version replaces the old" \
+    "|atlasctl 2.0.0|# fresh" "$(pb 1.0.0 2.0.0 fresh)"
+check "a first install lands the binary" \
+    "|atlasctl 2.0.0|# fresh" "$(pb '' 2.0.0 fresh)"
+
 # --- install_agent ------------------------------------------------------------
 cat > "$WORK/fake-atlasctl" <<'EOF'
 #!/bin/sh


### PR DESCRIPTION
## The bug

#122 (mine, tonight) taught the installer to decide on **content** rather than the version string, and added a branch so the operator reads *"the published build differs — replacing it"* instead of a nonsensical `upgrading 0.1.7 -> 0.1.7`.

That branch prints the sentence and stops. The `install`/`mv` pair sits in the sibling `else`:

```sh
elif [ -n "$old_version" ] && [ "$old_version" = "$new_version" ]; then
    info "... the published build differs — replacing it."   # <- and nothing else
else
    [ -z "$old_version" ] || info "upgrading $old_version -> $new_version"
    install -m 0755 ...; mv -f ...                            # <- the only copy
fi
```

So the case the branch was written for is the one case that never copies anything.

## Why it is the case that matters

Every `atlasctl` release to date reports **0.1.7** — the crate was never bumped, which is the root cause #122 addressed and which [#88](https://github.com/Avarok-Cybersecurity/atlas-recipes/pull/88) finally fixes (0.1.7 → 0.2.0). Until that release ships, an operator on a stale build hits **identical version strings with differing content** — exactly this branch. They would read that their agent was replaced and keep running the old protocol.

That is worse than the failure it replaced: the previous behaviour said "keeping it", which is at least true. **This has not yet reached production** — the site still serves the pre-#122 installer — so it can be fixed before anyone meets it.

## The fix

Extract `place_binary()`. The branches choose a *message*; every path that decides to replace falls through to a single `install`/`mv`, so the two cannot diverge again. It echoes `"yes"` when the binary was kept — the signal `install_agent` already consumes as `$4` — and since `info` writes to stderr, that word is alone on stdout.

The extraction is also what makes this testable: the logic was inside `main`, which the test loader strips before sourcing.

## Tests

Four cases asserting on **the file that ends up on disk**, not on the message — the bug printed exactly the right message, so output-only assertions cannot see it.

The helper sets version string and file content *separately*, which is the entire point. An earlier draft varied both together, quietly took the `else` branch, and **passed against the bug**. Verified by reintroducing the faulty branching alone, changing nothing else:

```
SABOTAGED:  FAIL same version, different build: the binary is REPLACED
SABOTAGED:  49 passed, 1 failed
FIXED:      50 passed, 0 failed
```

One test fails, and only that one.

## Checked and not changed

- **`install.ps1` already has the correct shape** — message branching inside, copy outside. Only the shell script diverged.
- **The service *is* restarted after an upgrade**, on both platforms: systemd runs an explicit `restart` after `enable --now` (which no-ops on a live unit), and launchd does `bootout` before `bootstrap`. So a replaced binary is actually the one running.