### PR TITLE
fix(install): the PATH advice named a file macOS never reads

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -347,6 +347,30 @@ do_uninstall() {
     exit 0
 }
 
+# Which file actually gets read when the operator opens a new terminal.
+#
+# This used to say `~/.profile` to everybody. macOS has defaulted to zsh since
+# Catalina and **zsh never reads ~/.profile** -- so the one instruction printed
+# to a Mac user, on the platform we ship a binary for and tell people to curl
+# from, silently did nothing. They reopen the terminal, `atlasctl` is still not
+# found, and the installer said it succeeded.
+#
+# Keyed off $SHELL (the login shell), not the shell running this script: the
+# installer is piped into `sh`, so $0 says nothing about what the operator uses.
+# fish is named rather than guessed at, because `export PATH=...` is not fish
+# syntax and would fail if pasted.
+rc_file() {
+    case "${SHELL:-}" in
+        */zsh)  echo "$HOME/.zshrc" ;;
+        # Bash reads ~/.bashrc for interactive non-login shells (the Linux
+        # terminal case) but ~/.bash_profile for login shells, which is what
+        # Terminal.app opens on macOS.
+        */bash) [ "$(uname -s)" = "Darwin" ] && echo "$HOME/.bash_profile" || echo "$HOME/.bashrc" ;;
+        */fish) echo "fish" ;;
+        *)      echo "$HOME/.profile" ;;
+    esac
+}
+
 # Put the downloaded binary in place and report which of the two things
 # happened: echoes "yes" when the installed copy was KEPT, and nothing when it
 # was replaced. All operator-facing text goes to stderr through `info`, so that
@@ -477,8 +501,13 @@ main() {
     case ":$PATH:" in
         *":$dir:"*) ;;
         *)
+            rc=$(rc_file)
             warn "$dir is not on your PATH. Add it, e.g.:"
-            warn "    echo 'export PATH=\"\$PATH:$dir\"' >> ~/.profile"
+            if [ "$rc" = "fish" ]; then
+                warn "    fish_add_path $dir"
+            else
+                warn "    echo 'export PATH=\"\$PATH:$dir\"' >> $rc"
+            fi
             ;;
     esac
 

--- a/scripts/tests/install-sh.test.sh
+++ b/scripts/tests/install-sh.test.sh
@@ -210,6 +210,32 @@ case "$out" in *"was not found"*) bad "a stopped docker must not be called missi
 contains "no nvidia runtime: named separately" "$(docker_state nogpu)" "NVIDIA container runtime"
 check "a healthy docker says nothing" "" "$(docker_state fine)"
 
+# --- rc_file ------------------------------------------------------------------
+# The bug: everyone was told `~/.profile`. zsh -- the macOS default since
+# Catalina -- does not read it, so the only instruction a Mac user got did
+# nothing, on the platform the front page tells them to curl from.
+
+# The OS is captured BEFORE the stub is defined: inside `uname()`, `$2` is the
+# stub's own argument list (`-s`), not this helper's -- which silently returned
+# an empty OS and sent the macOS case down the Linux branch.
+rc() { ( . "$WORK/lib.sh"; _os="$2"; SHELL="$1" HOME=/h
+         # shellcheck disable=SC2317  # called indirectly, by rc_file
+         uname() { echo "$_os"; }
+         rc_file ) }
+
+check "zsh gets .zshrc, not .profile"   "/h/.zshrc"        "$(rc /bin/zsh Darwin)"
+check "zsh on linux too"                "/h/.zshrc"        "$(rc /usr/bin/zsh Linux)"
+# bash splits by OS: Terminal.app opens a LOGIN shell, which reads
+# .bash_profile; a Linux terminal is interactive non-login and reads .bashrc.
+check "bash on macos -> .bash_profile"  "/h/.bash_profile" "$(rc /bin/bash Darwin)"
+check "bash on linux -> .bashrc"        "/h/.bashrc"       "$(rc /bin/bash Linux)"
+# fish is NAMED, not guessed: `export PATH=...` is not fish syntax, so emitting
+# it would hand the operator a line that fails when pasted.
+check "fish is identified, not guessed" "fish"             "$(rc /usr/bin/fish Linux)"
+# An unset or unrecognised SHELL keeps the old advice, which is right for sh/ksh.
+check "unknown shell falls back"        "/h/.profile"      "$(rc /bin/dash Linux)"
+check "empty SHELL falls back"          "/h/.profile"      "$(rc '' Linux)"
+
 # --- place_binary -------------------------------------------------------------
 # The point of these is that the FILE moved, not that a message was printed.
 # The bug they exist for printed exactly the right sentence and left the old


### PR DESCRIPTION
## The bug

When the install directory is not on `PATH`, the installer prints exactly one instruction — and it said `~/.profile` to everybody:

```sh
warn "$dir is not on your PATH. Add it, e.g.:"
warn "    echo 'export PATH=\"\$PATH:$dir\"' >> ~/.profile"
```

**macOS has defaulted to zsh since Catalina, and zsh does not read `~/.profile`.** So on the platform we ship a signed `aarch64-apple-darwin` binary for — the one the front page tells people to curl — the only remedy printed does nothing. The operator opens a new terminal, `atlasctl` is still not found, and the installer reported success.

## The fix

`rc_file()` names the file the operator's shell actually reads:

| `$SHELL` | file | why |
|---|---|---|
| zsh | `~/.zshrc` | sourced for interactive shells, login or not |
| bash on macOS | `~/.bash_profile` | Terminal.app opens a **login** shell |
| bash on Linux | `~/.bashrc` | interactive non-login |
| fish | `fish_add_path` | `export PATH=…` is **not fish syntax** — the old line failed when pasted |
| anything else | `~/.profile` | where that advice was right all along |

Keyed off `$SHELL` rather than the running shell: this script is piped into `sh`, so `$0` says nothing about what the operator uses.

`install.ps1` needed no change — it already writes the user `PATH` through the registry and tells the operator to open a new terminal.

## Tests

Seven cases covering all six branches. Verified they catch the original defect by restoring the old unconditional `~/.profile`:

```
OLD-BEHAVIOUR:  FAIL zsh gets .zshrc, not .profile
OLD-BEHAVIOUR:  FAIL zsh on linux too
OLD-BEHAVIOUR:  FAIL bash on macos -> .bash_profile
OLD-BEHAVIOUR:  FAIL bash on linux -> .bashrc
OLD-BEHAVIOUR:  FAIL fish is identified, not guessed
OLD-BEHAVIOUR:  52 passed, 5 failed
FIXED:          57 passed, 0 failed
```

Five fail, and only those five.

One test was wrong on the first attempt and the suite caught it: the `uname` stub read `$2` from its **own** argument list (`-s`) rather than the helper's, so the macOS case silently took the Linux branch and passed for the wrong reason. The stub now captures the OS before defining itself, and that reasoning is recorded in the test.