### PR TITLE
fix(install): --grant-control was announced and then dropped

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -378,6 +378,28 @@ rc_file() {
     esac
 }
 
+# The advice itself, so the SENTINEL has a tested contract.
+#
+# `rc_file` returns the literal "fish" to mean "not a file at all, and not
+# `export` syntax either". That agreement lived across two places with nothing
+# holding them together: `rc_file` was tested in isolation and this branch was
+# inside `main`, which the test loader strips. Change the sentinel to a path
+# and the comparison here silently stops matching, handing a fish user an
+# `export PATH=...` line that fails when pasted -- exactly the defect the
+# sentinel was added to prevent, reintroduced without a failing test.
+path_advice() { # dir  -- writes the two warn lines
+    pa_rc=$(rc_file)
+    warn "$1 is not on your PATH. Add it, e.g.:"
+    if [ "$pa_rc" = "fish" ]; then
+        # Quoted, because $HOME can contain a space: an unquoted
+        # /Users/John Smith/.zshrc is a line that breaks when pasted, which is
+        # the one thing this message exists to avoid.
+        warn "    fish_add_path \"$1\""
+    else
+        warn "    echo 'export PATH=\"\$PATH:$1\"' >> \"$pa_rc\""
+    fi
+}
+
 # Put the downloaded binary in place and report which of the two things
 # happened: echoes "yes" when the installed copy was KEPT, and nothing when it
 # was replaced. All operator-facing text goes to stderr through `info`, so that
@@ -523,16 +545,7 @@ main() {
     case ":$PATH:" in
         *":$dir:"*) ;;
         *)
-            rc=$(rc_file)
-            warn "$dir is not on your PATH. Add it, e.g.:"
-            if [ "$rc" = "fish" ]; then
-                # Quoted, because $HOME can contain a space: an unquoted
-                # /Users/John Smith/.zshrc is a line that breaks when pasted,
-                # which is the one thing this message exists to avoid.
-                warn "    fish_add_path \"$dir\""
-            else
-                warn "    echo 'export PATH=\"\$PATH:$dir\"' >> \"$rc\""
-            fi
+            path_advice "$dir"
             ;;
     esac
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -57,8 +57,15 @@ detect_target() {
 }
 
 # Verify a downloaded archive against the release's SHA256SUMS.
-# The SHA256 of a file, or "" when it cannot be read. One implementation, used
-# both by the download check and by `binary_differs` below.
+# The SHA256 of a file, or "" when it cannot be read -- used by
+# `binary_differs` to decide whether an upgrade is needed.
+#
+# `verify_checksum` deliberately does NOT share this: it must DIE when no
+# hasher exists, because installing an unverified binary is worse than not
+# installing, whereas this returns "" and lets the caller treat "cannot hash"
+# as "assume it differs" and reinstall -- the safe direction there. Two
+# failure semantics, so two implementations. (The comment here previously
+# claimed one shared implementation, which was simply untrue.)
 sha256_of() {
     [ -r "$1" ] || return 0
     if command -v sha256sum >/dev/null 2>&1; then
@@ -456,7 +463,22 @@ main() {
         shift
     done
     [ -z "$join" ] || info "will join the fleet at ${join#*@} once installed"
-    [ -z "$grant_control" ] || info "and will let that fleet run models on this machine"
+    # Announced only WITH a join, because it only happens with a join.
+    # `--grant-control` is meaningful solely alongside `--join`: the grant is
+    # written into this machine's pin of the inviter, so with no inviter there
+    # is nothing to write it into, and `install_agent` correspondingly forwards
+    # the flag on the join path alone. Printing the promise unconditionally told
+    # an operator who passed the flag without a join that their machine was now
+    # remotely drivable when nothing of the sort had been arranged -- a consent
+    # decision reported as made when it was silently dropped.
+    if [ -n "$grant_control" ]; then
+        if [ -n "$join" ]; then
+            info "and will let that fleet run models on this machine"
+        else
+            warn "--grant-control does nothing without --join, so it is being ignored."
+            warn "It grants control to the fleet you are JOINING; there is none here."
+        fi
+    fi
 
     need uname
     need tar
@@ -504,9 +526,12 @@ main() {
             rc=$(rc_file)
             warn "$dir is not on your PATH. Add it, e.g.:"
             if [ "$rc" = "fish" ]; then
-                warn "    fish_add_path $dir"
+                # Quoted, because $HOME can contain a space: an unquoted
+                # /Users/John Smith/.zshrc is a line that breaks when pasted,
+                # which is the one thing this message exists to avoid.
+                warn "    fish_add_path \"$dir\""
             else
-                warn "    echo 'export PATH=\"\$PATH:$dir\"' >> $rc"
+                warn "    echo 'export PATH=\"\$PATH:$dir\"' >> \"$rc\""
             fi
             ;;
     esac

--- a/scripts/tests/install-sh.test.sh
+++ b/scripts/tests/install-sh.test.sh
@@ -236,6 +236,36 @@ check "fish is identified, not guessed" "fish"             "$(rc /usr/bin/fish L
 check "unknown shell falls back"        "/h/.profile"      "$(rc /bin/dash Linux)"
 check "empty SHELL falls back"          "/h/.profile"      "$(rc '' Linux)"
 
+# --- path_advice --------------------------------------------------------------
+# rc_file is tested in isolation above; this pins its CONTRACT with the only
+# caller. The "fish" return is a sentinel, not a path, and the caller has to
+# recognise it -- an agreement that previously lived in two places with nothing
+# checking they still agreed.
+
+adv() {
+    ( . "$WORK/lib.sh"; _os="$2"; SHELL="$1" HOME="${3:-/h}"
+      # shellcheck disable=SC2317  # called indirectly, by rc_file
+      uname() { echo "$_os"; }
+      path_advice "${4:-/opt/bin}" ) 2>&1 | tail -1
+}
+
+# fish gets fish syntax. `export PATH=...` is not valid fish, so emitting it
+# would hand the operator a line that fails when pasted.
+contains "fish is given fish syntax" \
+    "$(adv /usr/bin/fish Linux)" "fish_add_path"
+check "fish is NOT given an export line" "" \
+    "$(adv /usr/bin/fish Linux | grep -o 'export PATH')"
+
+# Everyone else gets the export line, aimed at the file their shell reads.
+contains "zsh is given .zshrc"        "$(adv /bin/zsh Darwin)"  ".zshrc"
+contains "bash on macos gets .bash_profile" "$(adv /bin/bash Darwin)" ".bash_profile"
+
+# A $HOME with a space must still paste. This is why both are quoted.
+contains "a spaced HOME stays quoted" \
+    "$(adv /bin/zsh Darwin '/Users/John Smith')" '>> "/Users/John Smith/.zshrc"'
+contains "a spaced dir stays quoted too" \
+    "$(adv /usr/bin/fish Linux /h '/opt/my bin')" 'fish_add_path "/opt/my bin"'
+
 # --- place_binary -------------------------------------------------------------
 # The point of these is that the FILE moved, not that a message was printed.
 # The bug they exist for printed exactly the right sentence and left the old

--- a/scripts/tests/install-sh.test.sh
+++ b/scripts/tests/install-sh.test.sh
@@ -283,18 +283,38 @@ case "$1" in
   --version) echo "atlasctl 9.9.9" ;;
   agent) case "$2" in
       status)  [ -n "${RUNNING:-}" ] && exit 0 || exit 1 ;;
-      install) echo "[fake] agent install ran" ;;
+      # The whole argv, not a fixed string. Echoing a constant made the
+    # forwarding of --join and --grant-control invisible: a mutation deleting
+    # both still passed every test here.
+    install) echo "[fake] agent install ran: $*" ;;
     esac ;;
 esac
 EOF
 chmod +x "$WORK/fake-atlasctl"
 
-agent_run() { # same_version join running supervised
+agent_run() { # same_version join running supervised [grant]
     ( . "$WORK/lib.sh"
       # shellcheck disable=SC2317  # both stubs are called by install_agent
       if [ "$4" = yes ]; then service_installed() { return 0; }; else service_installed() { return 1; }; fi
-      RUNNING="$3" install_agent "$WORK/fake-atlasctl" "$2" "" "$1" ) 2>&1
+      # $5 reaches install_agent as its $3. Nothing passed one before, so
+      # `${3:+"$3"}` -- the grant-control forwarding -- was never executed by
+      # any test, which is how a dropped flag shipped.
+      RUNNING="$3" install_agent "$WORK/fake-atlasctl" "$2" "${5:-}" "$1" ) 2>&1
 }
+
+# The flags actually reach the binary. Asserted on the fake's full argv,
+# because a constant string cannot distinguish "forwarded" from "dropped".
+contains "a join forwards --join to the agent" \
+    "$(agent_run yes '12345678@10.0.0.1' 1 yes)" "agent install --join 12345678@10.0.0.1"
+
+contains "a join forwards --grant-control too" \
+    "$(agent_run yes '12345678@10.0.0.1' 1 yes --grant-control)" \
+    "--join 12345678@10.0.0.1 --grant-control"
+
+# ...and does NOT invent one on the path that has no inviter. `--grant-control`
+# is meaningful only with `--join`, so the no-join path must not forward it.
+check "no join means no --grant-control on the command line" "" \
+    "$(agent_run '' '' '' no --grant-control | grep -o '\-\-grant-control' | head -1)"
 
 contains "a fresh install installs the service" \
     "$(agent_run '' '' '' no)" "[fake] agent install ran"


### PR DESCRIPTION
Found by an independent audit of tonight's three installer changes (#122 / #135 / #136).

## The defect

`--grant-control` is meaningful **only alongside `--join`** — its own help says so: the grant is written into this machine's pin of *the inviter*, so with no inviter there is nothing to write it into. `install_agent` reflects that correctly and forwards the flag on the join path only (`install.sh:233`); the no-join path is a bare `agent install` (`:251`).

The message did not. `install.sh:459` printed **"and will let that fleet run models on this machine"** whenever the flag was passed. So an operator who passed `--grant-control` without a join was told their machine had been made remotely drivable when nothing of the sort was arranged — **a consent decision reported as made while it was silently dropped.**

That is the same defect class as the `"replacing it"` branch that replaced nothing, surviving in a different function.

The fix is not to forward the flag — that would be wrong, since there is no inviter. It is to say only what happens: announce the grant with a join, and warn that the flag is ignored without one.

## Also from the audit

- **Unquoted PATH advice.** `$dir` and `$rc` were interpolated bare, so a `$HOME` containing a space emitted `>> /Users/John Smith/.zshrc` — a line that breaks when pasted, which is the one thing that message exists to prevent.
- **A comment that was untrue.** `sha256_of` claimed to be "one implementation, used both by the download check and by `binary_differs`". It is not — `verify_checksum` has its own ladder, and *deliberately*: it must **die** where `sha256_of` returns `""`, because installing an unverified binary is worse than not installing. Two failure semantics, two implementations. The comment now says that. I did not unify them; rewriting checksum verification to satisfy a comment is the wrong trade.

## The tests were decorative, and are no longer

The fake binary echoed a constant string, so flag forwarding was **invisible**. The audit proved it by deleting the `--join` and `--grant-control` forwarding outright:

> replacing line 233 with a bare `"$exe" agent install` … still gives **57 passed, 0 failed**

Root cause of the blind spot: no test ever passed a non-empty `$3`, so `${3:+"$3"}` — the grant-control forwarding — was **never executed by any test**. That is how a dropped flag shipped.

Now the fake echoes its full argv, `agent_run` accepts a grant argument, and three tests assert what actually reaches the command line, including that the no-join path does **not** invent one. Re-running the audit's exact mutation:

```
MUTATED:   FAIL a join forwards --join to the agent
MUTATED:   FAIL a join forwards --grant-control too
MUTATED:   58 passed, 2 failed
RESTORED:  60 passed, 0 failed
```

## Second commit: pin the fish sentinel's contract

The audit also noted that `rc_file` is tested in isolation while the branch that **consumes** its result lived inside `main`, which the test loader strips. So the agreement between them — that `"fish"` is a *sentinel* meaning "not a file, and not `export` syntax either" — was held in two places with nothing checking they still agreed.

Change the sentinel to a path and the comparison in `main` silently stops matching, handing a fish user an `export PATH=…` line that fails when pasted: **exactly the defect the sentinel exists to prevent, reintroduced with no failing test.** Extracting `path_advice()` is what makes that testable — the same reasoning that made `place_binary` testable in #135.

Six tests: fish gets fish syntax and specifically **not** an export line; zsh and macOS-bash get their own files; and both a spaced `$HOME` and a spaced install dir stay quoted, which is the only coverage the quoting fix has.

Verified by mutation — returning `$HOME/.config/fish/config.fish` instead of the sentinel:

```
MUTATED:   FAIL fish is identified, not guessed
MUTATED:   FAIL fish is given fish syntax
MUTATED:   FAIL fish is NOT given an export line
MUTATED:   FAIL a spaced dir stays quoted too
MUTATED:   62 passed, 4 failed
RESTORED:  66 passed, 0 failed
```
