### PR TITLE
fix(cluster): the endpoint fallback named a port the engine never uses

### DIFF
--- a/crates/atlasctl-agent/src/clusterdriver/plan.rs
+++ b/crates/atlasctl-agent/src/clusterdriver/plan.rs
@@ -175,4 +175,12 @@ impl ClusterDriver {
 /// Not a silent fallback: it is the serving runtime's own default, it is only
 /// reached once both layers above have been asked, and it only ever decorates
 /// a URL shown to a human — nothing is launched from it.
-const DEFAULT_SERVE_PORT: u16 = 8000;
+///
+/// It was 8000, and the engine has never defaulted to 8000. `serve_port`'s own
+/// doc above describes the resulting symptom precisely -- "the endpoint told
+/// them `:8000` while the model served on `:8888`" -- and fixed it for layer 2
+/// while this layer went on reproducing it whenever the recipe pins no port.
+/// A comment asserting a value is the runtime's default is not a check, so
+/// `the_fallback_port_is_the_engines_own_default` now asserts it against
+/// `vendor/serve-options.v1.json`, which is reflected out of the engine's clap.
+pub(super) const DEFAULT_SERVE_PORT: u16 = 8888;

--- a/crates/atlasctl-agent/src/clusterdriver/tests.rs
+++ b/crates/atlasctl-agent/src/clusterdriver/tests.rs
@@ -296,3 +296,42 @@ pub(super) fn all_three() -> Vec<NodeId> {
 pub(super) fn calls(log: &Log) -> Vec<String> {
     log.lock().expect("log lock").clone()
 }
+
+/// The fallback endpoint port must be the engine's own default, not a number
+/// that once looked like it.
+///
+/// It was 8000 for as long as this constant existed, and the engine has never
+/// defaulted to 8000. Nothing caught it because the only thing asserting the
+/// value was a doc comment claiming it was "the serving runtime's own default"
+/// -- and a comment cannot fail. The symptom is the one `serve_port`'s doc
+/// already describes for the layer above: an endpoint printed as `:8000` while
+/// rank 0 serves on `:8888`.
+///
+/// Asserted against the vendored snapshot, which is reflected out of the
+/// engine's clap, so the engine changing its default fails here rather than
+/// quietly making this wrong again.
+#[test]
+fn the_fallback_port_is_the_engines_own_default() {
+    use super::plan::DEFAULT_SERVE_PORT;
+    const SNAPSHOT: &str = include_str!("../../../../vendor/serve-options.v1.json");
+
+    // Deliberately a string scan rather than a JSON parse: this file has no
+    // serde dependency, and the shape being matched is the one the generator
+    // emits verbatim.
+    let port_entry = SNAPSHOT
+        .split('{')
+        .find(|chunk| chunk.contains("\"key\": \"port\""))
+        .expect("the snapshot has a `port` flag");
+    let default = port_entry
+        .split("\"default\":")
+        .nth(1)
+        .and_then(|rest| rest.split('"').nth(1))
+        .expect("the `port` flag declares a default");
+
+    assert_eq!(
+        default,
+        DEFAULT_SERVE_PORT.to_string(),
+        "DEFAULT_SERVE_PORT is {DEFAULT_SERVE_PORT}, but the engine defaults --port to {default}. \
+         The endpoint this decorates would tell an operator the wrong port."
+    );
+}


### PR DESCRIPTION
Found by an audit for messages that assert something the code does not do — the same class as [#135](https://github.com/Avarok-Cybersecurity/atlas-recipes/pull/135), [#136](https://github.com/Avarok-Cybersecurity/atlas-recipes/pull/136) and [#137](https://github.com/Avarok-Cybersecurity/atlas-recipes/pull/137) tonight.

## The defect

```rust
/// Not a silent fallback: it is the serving runtime's own default …
const DEFAULT_SERVE_PORT: u16 = 8000;
```

The engine defaults `--port` to **8888**. From the binary itself:

```
--port <PORT>
    HTTP port
    [default: 8888]
```

and from `vendor/serve-options.v1.json`, which is reflected out of the engine's clap:

```json
{"key": "port", …, "default": "8888", "help": "HTTP port"}
```

It has never defaulted to 8000.

## Why this is worse than an off-by-one constant

`serve_port`'s own doc, ten lines above the constant, **already describes this exact symptom**:

> Layer 2 was missing, and its absence was invisible in exactly the case that matters: a recipe pinning `port: 8888` and an operator who did not override it produced an empty settings map, so the endpoint told them `:8000` while the model served on `:8888`.

That was diagnosed and fixed for layer 2 (the recipe lookup). Layer 3 — this fallback — was left reproducing it. A cluster launch whose recipe pins no port still hands the operator a URL pointing at a port nothing serves.

## The guard

The value was only ever asserted by a comment claiming it was correct, and **a comment cannot fail**. `the_fallback_port_is_the_engines_own_default` now asserts it against the vendored snapshot, so the engine changing its default breaks a test instead of quietly making this wrong again.

Verified by reverting the constant to 8000:

```
assertion `left == right` failed: DEFAULT_SERVE_PORT is 8000, but the engine
defaults --port to 8888. The endpoint this decorates would tell an operator
the wrong port.
test result: FAILED. 0 passed; 1 failed
```

and with the fix: `374 passed; 0 failed` across the whole `atlasctl-agent` suite.

## Note on the audit

The audit that surfaced this cited `flags/table.rs` as the source of 8888; that file carries no defaults, so the citation was wrong even though the claim was right. I verified 8888 against the engine binary and the vendored snapshot instead. Four further findings from the same audit are being checked before any are acted on.