### PR TITLE
fix(logs): find the container `run` actually started

### DIFF
--- a/crates/atlasctl/src/commands/lifecycle.rs
+++ b/crates/atlasctl/src/commands/lifecycle.rs
@@ -180,11 +180,34 @@ fn logs_with(runner: &dyn ProcessRunner, args: &LogsArgs) -> Result<()> {
         "--format".into(),
         "{{.Names}}".into(),
     ])?;
+    let mut name = name;
     if probe.success() && probe.stdout.trim().is_empty() {
-        bail!(
-            "no container for `{}` on this machine — it has not been started here. `atlasctl status` lists what is running",
-            args.recipe
-        );
+        // The exact name missed. Ask the LABEL before concluding nothing is
+        // running, for the reason `containers_for_recipe` documents: a cluster
+        // launch appends `-rank{n}`, and a registry-qualified name produces
+        // `atlas-@registry/X`, which docker cannot even hold. `stop` was fixed
+        // for exactly these two cases and `logs` was not -- so `run X --rank 0`
+        // printed "started atlas-X-rank0" and, on the very next line,
+        // "logs: atlasctl logs X --follow", a command that then denied the
+        // container existed.
+        let found = containers_for_recipe(runner, &args.recipe)?;
+        match found.len() {
+            0 => bail!(
+                "no container for `{}` on this machine — it has not been started here. `atlasctl status` lists what is running",
+                args.recipe
+            ),
+            1 => name = found.into_iter().next().unwrap_or_default(),
+            // Several ranks on this box. Naming one for the operator would be a
+            // guess about which one they meant, and the ranks do not log the
+            // same thing; say what is there instead.
+            _ => bail!(
+                "`{}` is running as {} containers on this machine: {}. \
+                 Read one with:  docker logs --tail 200 -f <name>",
+                args.recipe,
+                found.len(),
+                found.join(", ")
+            ),
+        }
     }
 
     let mut argv = vec![

--- a/crates/atlasctl/src/commands/lifecycle/tests.rs
+++ b/crates/atlasctl/src/commands/lifecycle/tests.rs
@@ -311,11 +311,23 @@ mod logs_finds_what_run_started {
     fn a_rank_container_is_found_by_label_after_the_name_guess_misses() {
         let r = RecordingRunner::new();
         // exact-name probe: nothing
-        r.push_result(Output { status: 0, stdout: String::new(), stderr: String::new() });
+        r.push_result(Output {
+            status: 0,
+            stdout: String::new(),
+            stderr: String::new(),
+        });
         // label lookup: the rank container run actually created
-        r.push_result(Output { status: 0, stdout: "atlas-x-rank0\n".into(), stderr: String::new() });
+        r.push_result(Output {
+            status: 0,
+            stdout: "atlas-x-rank0\n".into(),
+            stderr: String::new(),
+        });
         // `docker logs` itself
-        r.push_result(Output { status: 0, stdout: String::new(), stderr: String::new() });
+        r.push_result(Output {
+            status: 0,
+            stdout: String::new(),
+            stderr: String::new(),
+        });
 
         logs_with(&r, &args("x")).expect("must stream the rank container");
         let last = r.calls().last().cloned().unwrap_or_default();
@@ -330,7 +342,11 @@ mod logs_finds_what_run_started {
     #[test]
     fn several_ranks_are_listed_rather_than_chosen_between() {
         let r = RecordingRunner::new();
-        r.push_result(Output { status: 0, stdout: String::new(), stderr: String::new() });
+        r.push_result(Output {
+            status: 0,
+            stdout: String::new(),
+            stderr: String::new(),
+        });
         r.push_result(Output {
             status: 0,
             stdout: "atlas-x-rank0\natlas-x-rank1\n".into(),
@@ -338,16 +354,30 @@ mod logs_finds_what_run_started {
         });
         let err = logs_with(&r, &args("x")).expect_err("must refuse to pick one");
         let msg = format!("{err:#}");
-        assert!(msg.contains("atlas-x-rank0") && msg.contains("atlas-x-rank1"), "got: {msg}");
-        assert!(msg.contains("docker logs"), "must say how to read one: {msg}");
+        assert!(
+            msg.contains("atlas-x-rank0") && msg.contains("atlas-x-rank1"),
+            "got: {msg}"
+        );
+        assert!(
+            msg.contains("docker logs"),
+            "must say how to read one: {msg}"
+        );
     }
 
     /// Nothing running under that name at all keeps the original message.
     #[test]
     fn genuinely_absent_still_says_it_was_never_started_here() {
         let r = RecordingRunner::new();
-        r.push_result(Output { status: 0, stdout: String::new(), stderr: String::new() });
-        r.push_result(Output { status: 0, stdout: String::new(), stderr: String::new() });
+        r.push_result(Output {
+            status: 0,
+            stdout: String::new(),
+            stderr: String::new(),
+        });
+        r.push_result(Output {
+            status: 0,
+            stdout: String::new(),
+            stderr: String::new(),
+        });
         let err = logs_with(&r, &args("x")).expect_err("must refuse");
         assert!(format!("{err:#}").contains("has not been started here"));
     }

--- a/crates/atlasctl/src/commands/lifecycle/tests.rs
+++ b/crates/atlasctl/src/commands/lifecycle/tests.rs
@@ -208,6 +208,7 @@ mod absent_tests {
     fn logs_for_a_recipe_never_started_here_says_so_and_never_streams() {
         let r = RecordingRunner::new();
         r.push_result(out(0, "\n", "")); // ps -a matched nothing
+        r.push_result(out(0, "\n", "")); // ...and neither did the label lookup
         let e = logs_with(
             &r,
             &LogsArgs {
@@ -223,7 +224,16 @@ mod absent_tests {
             msg.contains("atlasctl status"),
             "points somewhere useful: {msg}"
         );
-        assert_eq!(r.calls().len(), 1, "must not have run `docker logs` at all");
+        // Asserted directly rather than by counting calls. The count was 1 when
+        // this only guessed a name; it now also asks the LABEL before concluding
+        // nothing is running, because a rank launch is `atlas-q-rank0` and the
+        // guess never finds it. "Did not stream" is the actual claim, and saying
+        // it outright survives that lookup being added.
+        assert!(
+            !r.calls().iter().any(|c| c.contains(&"logs".to_string())),
+            "must not have run `docker logs` at all: {:?}",
+            r.calls()
+        );
     }
 
     #[test]
@@ -275,5 +285,70 @@ mod daemon_down {
             stderr: String::new(),
         });
         stop_all_with(&r).expect("an answered-but-empty listing is genuinely idle");
+    }
+}
+
+/// `logs` used to guess the container name, so it could not find the two
+/// launches whose names it does not spell.
+mod logs_finds_what_run_started {
+    use super::super::*;
+    use atlasctl_core::io::RecordingRunner;
+    use atlasctl_core::io::process::Output;
+
+    fn args(recipe: &str) -> LogsArgs {
+        LogsArgs {
+            recipe: recipe.to_owned(),
+            follow: false,
+            tail: 10,
+        }
+    }
+
+    /// The case the CLI itself creates. `run X --rank 0` prints
+    /// "started atlas-X-rank0" and then "logs: atlasctl logs X --follow"
+    /// (run.rs:195) -- a command that guessed `atlas-X` and denied the
+    /// container existed, one line after saying it had started.
+    #[test]
+    fn a_rank_container_is_found_by_label_after_the_name_guess_misses() {
+        let r = RecordingRunner::new();
+        // exact-name probe: nothing
+        r.push_result(Output { status: 0, stdout: String::new(), stderr: String::new() });
+        // label lookup: the rank container run actually created
+        r.push_result(Output { status: 0, stdout: "atlas-x-rank0\n".into(), stderr: String::new() });
+        // `docker logs` itself
+        r.push_result(Output { status: 0, stdout: String::new(), stderr: String::new() });
+
+        logs_with(&r, &args("x")).expect("must stream the rank container");
+        let last = r.calls().last().cloned().unwrap_or_default();
+        assert!(
+            last.contains(&"atlas-x-rank0".to_string()),
+            "must read the container the label found, got: {last:?}"
+        );
+    }
+
+    /// Several ranks on one box: naming one would be a guess about which the
+    /// operator meant, and the ranks do not log the same thing.
+    #[test]
+    fn several_ranks_are_listed_rather_than_chosen_between() {
+        let r = RecordingRunner::new();
+        r.push_result(Output { status: 0, stdout: String::new(), stderr: String::new() });
+        r.push_result(Output {
+            status: 0,
+            stdout: "atlas-x-rank0\natlas-x-rank1\n".into(),
+            stderr: String::new(),
+        });
+        let err = logs_with(&r, &args("x")).expect_err("must refuse to pick one");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("atlas-x-rank0") && msg.contains("atlas-x-rank1"), "got: {msg}");
+        assert!(msg.contains("docker logs"), "must say how to read one: {msg}");
+    }
+
+    /// Nothing running under that name at all keeps the original message.
+    #[test]
+    fn genuinely_absent_still_says_it_was_never_started_here() {
+        let r = RecordingRunner::new();
+        r.push_result(Output { status: 0, stdout: String::new(), stderr: String::new() });
+        r.push_result(Output { status: 0, stdout: String::new(), stderr: String::new() });
+        let err = logs_with(&r, &args("x")).expect_err("must refuse");
+        assert!(format!("{err:#}").contains("has not been started here"));
     }
 }


### PR DESCRIPTION
Fourth confirmed finding from the CLI audit (after #139, #140, #141).

## The CLI creates this failure itself

`run X --rank 0` prints, two lines apart:

```
started atlas-x-rank0
logs:     atlasctl logs x --follow
```

and that command answers:

> no container for `x` on this machine — it has not been started here

`logs` guessed `atlas-{typed}`. `containers_for_recipe`'s own doc already lists the two launches that name does not spell:

> * `run X --rank 0` makes `atlas-X-rank0` …
> * `stop @registry/X` guessed `atlas-@registry/X`

**`stop` was fixed for both. `logs` was not.**

## The change

Ask the label when the name guess misses — the same lookup `stop` uses, which needs no name arithmetic and survives a registry being removed.

Several ranks on one box are **listed rather than chosen between**:

```
`x` is running as 2 containers on this machine: atlas-x-rank0, atlas-x-rank1.
Read one with:  docker logs --tail 200 -f <name>
```

Naming one would be a guess about which the operator meant, and the ranks do not log the same thing. A genuinely absent recipe keeps the original message.

## An updated pre-existing assertion

`logs_for_a_recipe_never_started_here_says_so_and_never_streams` asserted `calls().len() == 1` as a proxy for "never streamed". The label lookup makes that 2, legitimately.

It now asserts the claim **directly** — no call is `docker logs` — which is what the test was always about, is stronger than a count, and does not depend on how many probes precede the answer. The weaker option would have been bumping 1 to 2, which pins an implementation detail rather than the behaviour.

## Verification

Reverting to name-guessing fails 2 of the 3 new tests:

```
several_ranks_are_listed_rather_than_chosen_between ... FAILED
a_rank_container_is_found_by_label_after_the_name_guess_misses ... FAILED
```

With the fix: **152 passed, 0 failed**; clippy clean.