### PR TITLE
fix: four defects an audit found in tonight's own fixes

### DIFF
--- a/crates/atlasctl/src/commands/agentpair.rs
+++ b/crates/atlasctl/src/commands/agentpair.rs
@@ -328,12 +328,29 @@ mod tests {
     /// With no agent listening, the old wording is right: another `agent pair`
     /// really is the likely holder.
     #[test]
-    fn with_no_agent_running_it_still_suspects_another_pair() {
+    fn with_no_agent_detected_it_names_both_causes_not_one() {
         let msg = bind_failure(34334, false);
         assert!(msg.contains("34334"), "{msg}");
+
+        // BOTH, because this branch cannot tell them apart. The probe asks the
+        // BROWSER port, and an agent installed `--no-browser` or on a custom
+        // `--port` binds none -- so "no agent answered" does not mean "no agent".
+        // Naming only the second cause sent those operators hunting for a
+        // process that does not exist; a previous attempt at naming only the
+        // FIRST read a service unit file, which is true on any machine where
+        // the agent is merely installed and stopped, and misattributed a real
+        // second `agent pair` to the agent.
         assert!(
             msg.contains("another `atlasctl agent pair`"),
-            "without an agent, that is the honest guess: {msg}"
+            "must still name the second pair: {msg}"
+        );
+        assert!(
+            msg.contains("--no-browser"),
+            "must also name the agent that did not answer the probe: {msg}"
+        );
+        assert!(
+            msg.contains("agent status"),
+            "and must give the command that distinguishes them: {msg}"
         );
     }
 

--- a/crates/atlasctl/src/commands/agentpair.rs
+++ b/crates/atlasctl/src/commands/agentpair.rs
@@ -263,34 +263,7 @@ pub fn dial_hints(hosts: &[String], port: u16) -> String {
 /// running — which is exactly what happened when this was one function.
 fn local_agent_running() -> bool {
     let addr = std::net::SocketAddr::from(([127, 0, 0, 1], atlasctl_agent::DEFAULT_PORT));
-    if std::net::TcpStream::connect_timeout(&addr, std::time::Duration::from_millis(300)).is_ok() {
-        return true;
-    }
-    // The browser port is not the agent.
-    //
-    // This asked one port and concluded from it who holds a DIFFERENT one --
-    // the peer port. An agent installed `--no-browser` binds no browser port at
-    // all, and `--port` moves it; both still hold the peer port. Those agents
-    // answered "no" here, so `bind_failure` took the else branch and sent the
-    // operator hunting for a second `atlasctl agent pair` that does not exist
-    // -- the exact outcome this pair of functions was written to stop, and the
-    // one `the_remedy_is_never_to_go_hunting_for_a_process` forbids.
-    //
-    // `--no-browser` is not an edge case here: it is the headless rank-holder,
-    // which is the machine most likely to be running `agent pair` at all.
-    //
-    // An installed unit answers the same question by a route that does not
-    // depend on which ports the agent chose. Best effort, as in `agentinfo`: a
-    // machine whose home cannot be read is one we cannot make this claim about,
-    // and guessing either way sends the operator to the wrong command.
-    crate::hostinfo::home_dir().is_ok_and(|home| {
-        crate::service::installed_unit(
-            &atlasctl_core::io::StdFileSystem,
-            &home,
-            crate::commands::service::uid_of(&home),
-        )
-        .is_ok_and(|u| u.is_some())
-    })
+    std::net::TcpStream::connect_timeout(&addr, std::time::Duration::from_millis(300)).is_ok()
 }
 
 /// Why the peer port could not be bound, in the operator's terms.
@@ -318,9 +291,32 @@ fn bind_failure(port: u16, agent_running: bool) -> String {
              This command is for a machine whose agent is not running yet."
         )
     } else {
+        // Both, because this cannot tell them apart.
+        //
+        // The probe above asks the BROWSER port; an agent installed
+        // `--no-browser` binds none, and `--port` moves it, so a perfectly
+        // healthy agent answers "no" here. Naming only the second cause sent
+        // those operators hunting for a process that does not exist.
+        //
+        // An earlier attempt at this fell back to whether a service UNIT exists
+        // on disk, which is worse: `install.sh` writes that file for everyone,
+        // so it reads true on a machine whose agent is merely INSTALLED and
+        // stopped -- and that is exactly the machine this command is for. It
+        // would have asserted "your agent is running" while the real holder,
+        // another `agent pair`, went unnamed. A check that cannot distinguish
+        // two causes should name both, not pick one.
         format!(
-            "could not bind the peer port {port} — is another `atlasctl agent pair` \
-             already waiting?"
+            "could not bind the peer port {port}. Either this machine's agent \
+             holds it — it binds the same port, and one installed with \
+             `--no-browser` or a custom `--port` will not have answered the \
+             probe above — or another `atlasctl agent pair` is already \
+             waiting.\n\
+             \n\
+             Check with:  {} agent status\n\
+             If it is the agent, add machines through its join window instead: \
+             open the control page on the machine you are adding this one FROM \
+             and use \"Show me how\".",
+            env!("CARGO_BIN_NAME")
         )
     }
 }

--- a/crates/atlasctl/src/commands/doctor.rs
+++ b/crates/atlasctl/src/commands/doctor.rs
@@ -140,7 +140,19 @@ fn check_sparkrun() -> usize {
 /// unreadable `df` says nothing about whether there is room, and doctor now
 /// exits non-zero on a problem, so guessing here would fail a healthy box.
 fn check_disk() -> Finding {
-    let cache = crate::hostinfo::snapshot().ok().map(|h| h.hf_cache_dir);
+    // The cache path must EXIST to be measured, because `free_bytes` walks up to
+    // the nearest existing ancestor (platform.rs:170). Without this check an
+    // unmounted `/mnt/models` returns ROOT's free space, and `disk_finding`
+    // prints "12 GB free on /mnt/models" -- a number from one volume under the
+    // other's name, which is worse than measuring the wrong path openly.
+    //
+    // It also makes the `.` fallback real. It was previously unreachable for the
+    // same reason: `free_bytes` almost never returns `None`, so the commit that
+    // added it claimed a fallback that could not happen.
+    let cache = crate::hostinfo::snapshot()
+        .ok()
+        .map(|h| h.hf_cache_dir)
+        .filter(|d| std::path::Path::new(d).exists());
     let at_cache = cache
         .as_deref()
         .and_then(|d| atlasctl_core::platform::free_bytes(std::path::Path::new(d)));

--- a/crates/atlasctl/src/commands/lifecycle.rs
+++ b/crates/atlasctl/src/commands/lifecycle.rs
@@ -30,7 +30,7 @@ pub fn stop(args: &StopArgs) -> Result<()> {
         // readable. Only when nothing is running under that name does the
         // resolve error stand, so a TYPO still gets its "Did you mean ...?".
         Err(unresolved) => {
-            let found = containers_for_recipe(&StdProcessRunner, typed)?;
+            let found = containers_for_recipe(&StdProcessRunner, typed, false)?;
             if found.is_empty() {
                 return Err(unresolved);
             }
@@ -69,15 +69,29 @@ fn known_recipe(name: &str) -> Result<String> {
 ///
 /// The label is written by the launch itself, so it survives a registry being
 /// removed and needs no name arithmetic here.
-fn containers_for_recipe(runner: &dyn ProcessRunner, recipe: &str) -> Result<Vec<String>> {
-    let out = runner.run(&[
-        "docker".into(),
-        "ps".into(),
-        "--filter".into(),
-        format!("label={LABEL_RECIPE}={recipe}"),
-        "--format".into(),
-        "{{.Names}}".into(),
-    ])?;
+fn containers_for_recipe(
+    runner: &dyn ProcessRunner,
+    recipe: &str,
+    include_exited: bool,
+) -> Result<Vec<String>> {
+    // `stop` wants running containers only; `logs` wants exited ones too, for
+    // the reason the exact-name probe already gives: "a container that exited
+    // still has logs worth reading, and that is often exactly why someone is
+    // here." Without this the label fallback could not find a CRASHED rank
+    // container -- the single likeliest reason to be reading logs at all.
+    let mut argv: Vec<String> = vec!["docker".into(), "ps".into()];
+    if include_exited {
+        argv.push("-a".into());
+    }
+    let out = runner.run(&{
+        argv.extend([
+            "--filter".into(),
+            format!("label={LABEL_RECIPE}={recipe}"),
+            "--format".into(),
+            "{{.Names}}".into(),
+        ]);
+        argv
+    })?;
     Ok(out
         .stdout
         .lines()
@@ -102,7 +116,7 @@ fn stop_all_with(runner: &dyn ProcessRunner) -> Result<()> {
 /// `typed` is what the operator wrote (for the message); `resolved` is the
 /// recipe's own name, which is what the launch wrote into the label.
 fn stop_recipe_with(runner: &dyn ProcessRunner, typed: &str, resolved: &str) -> Result<()> {
-    let found = containers_for_recipe(runner, resolved)?;
+    let found = containers_for_recipe(runner, resolved, false)?;
     if found.is_empty() {
         println!("{typed} is not running");
         return Ok(());
@@ -154,12 +168,17 @@ fn stop_each(runner: &dyn ProcessRunner, targets: Vec<String>) -> Result<()> {
 /// replaces ran `sleep infinity` as PID 1, so its `docker logs` showed nothing
 /// and it had to tail a file inside the container instead.
 pub fn logs(args: &LogsArgs) -> Result<()> {
-    known_recipe(&args.recipe)?;
-    logs_with(&StdProcessRunner, args)
+    // The RESOLVED name is threaded through, not discarded. The launch writes
+    // the resolved recipe into `LABEL_RECIPE`, so filtering on what the operator
+    // TYPED misses exactly the case the label lookup was added for: `logs
+    // @registry/q` would query `label=…=@registry/q` against a label of `q`.
+    // `stop` has always passed the resolved name for this reason.
+    let resolved = known_recipe(&args.recipe)?;
+    logs_with(&StdProcessRunner, args, &resolved)
 }
 
 /// `logs`, with the runner injected so the not-started path is testable.
-fn logs_with(runner: &dyn ProcessRunner, args: &LogsArgs) -> Result<()> {
+fn logs_with(runner: &dyn ProcessRunner, args: &LogsArgs, resolved: &str) -> Result<()> {
     let name = container_of(&args.recipe);
 
     // Ask whether the container exists before streaming. `docker logs` on a
@@ -190,7 +209,7 @@ fn logs_with(runner: &dyn ProcessRunner, args: &LogsArgs) -> Result<()> {
         // printed "started atlas-X-rank0" and, on the very next line,
         // "logs: atlasctl logs X --follow", a command that then denied the
         // container existed.
-        let found = containers_for_recipe(runner, &args.recipe)?;
+        let found = containers_for_recipe(runner, resolved, true)?;
         match found.len() {
             0 => bail!(
                 "no container for `{}` on this machine — it has not been started here. `atlasctl status` lists what is running",

--- a/crates/atlasctl/src/commands/lifecycle/tests.rs
+++ b/crates/atlasctl/src/commands/lifecycle/tests.rs
@@ -216,6 +216,7 @@ mod absent_tests {
                 tail: 100,
                 follow: false,
             },
+            "q",
         )
         .expect_err("there is nothing to show");
         let msg = e.to_string();
@@ -248,6 +249,7 @@ mod absent_tests {
                 tail: 100,
                 follow: false,
             },
+            "q",
         )
         .expect("a stopped container still has logs worth reading");
         let argv = &r.calls()[1];
@@ -329,11 +331,83 @@ mod logs_finds_what_run_started {
             stderr: String::new(),
         });
 
-        logs_with(&r, &args("x")).expect("must stream the rank container");
+        logs_with(&r, &args("x"), "x").expect("must stream the rank container");
         let last = r.calls().last().cloned().unwrap_or_default();
         assert!(
             last.contains(&"atlas-x-rank0".to_string()),
             "must read the container the label found, got: {last:?}"
+        );
+    }
+
+    /// The label carries the RESOLVED recipe, so the lookup must filter on that
+    /// and not on what the operator typed.
+    ///
+    /// `logs @registry/q` would otherwise query `label=…=@registry/q` against a
+    /// label of `q` and still deny the container — one of the two cases the
+    /// label fallback exists to fix, and the one the first version missed
+    /// because it passed `args.recipe` through.
+    #[test]
+    fn the_label_query_uses_the_resolved_name_not_the_typed_one() {
+        let r = RecordingRunner::new();
+        r.push_result(Output {
+            status: 0,
+            stdout: String::new(),
+            stderr: String::new(),
+        });
+        r.push_result(Output {
+            status: 0,
+            stdout: "atlas-q-rank0\n".into(),
+            stderr: String::new(),
+        });
+        r.push_result(Output {
+            status: 0,
+            stdout: String::new(),
+            stderr: String::new(),
+        });
+
+        logs_with(&r, &args("@registry/q"), "q").expect("must find it by the resolved label");
+        let label_call = &r.calls()[1];
+        assert!(
+            label_call.iter().any(|a| a.ends_with("=q")),
+            "must filter on the resolved name: {label_call:?}"
+        );
+        assert!(
+            !label_call.iter().any(|a| a.contains("@registry")),
+            "must not filter on the typed name: {label_call:?}"
+        );
+    }
+
+    /// A CRASHED container still has logs, and reading them is the likeliest
+    /// reason to run this command at all.
+    ///
+    /// The exact-name probe uses `ps -a` deliberately. The label fallback did
+    /// not, so it could only ever find a container that was still running —
+    /// fixing the rank case for healthy containers and not for the ones anyone
+    /// actually needs to read.
+    #[test]
+    fn the_label_query_includes_exited_containers() {
+        let r = RecordingRunner::new();
+        r.push_result(Output {
+            status: 0,
+            stdout: String::new(),
+            stderr: String::new(),
+        });
+        r.push_result(Output {
+            status: 0,
+            stdout: "atlas-x-rank0\n".into(),
+            stderr: String::new(),
+        });
+        r.push_result(Output {
+            status: 0,
+            stdout: String::new(),
+            stderr: String::new(),
+        });
+
+        logs_with(&r, &args("x"), "x").expect("must stream");
+        let label_call = &r.calls()[1];
+        assert!(
+            label_call.contains(&"-a".to_string()),
+            "the label lookup must include exited containers: {label_call:?}"
         );
     }
 
@@ -352,7 +426,7 @@ mod logs_finds_what_run_started {
             stdout: "atlas-x-rank0\natlas-x-rank1\n".into(),
             stderr: String::new(),
         });
-        let err = logs_with(&r, &args("x")).expect_err("must refuse to pick one");
+        let err = logs_with(&r, &args("x"), "x").expect_err("must refuse to pick one");
         let msg = format!("{err:#}");
         assert!(
             msg.contains("atlas-x-rank0") && msg.contains("atlas-x-rank1"),
@@ -378,7 +452,7 @@ mod logs_finds_what_run_started {
             stdout: String::new(),
             stderr: String::new(),
         });
-        let err = logs_with(&r, &args("x")).expect_err("must refuse");
+        let err = logs_with(&r, &args("x"), "x").expect_err("must refuse");
         assert!(format!("{err:#}").contains("has not been started here"));
     }
 }


### PR DESCRIPTION
An independent audit of the five Rust fixes merged today found four real problems **in them**. All four confirmed. Three are mine to own: two fixes were incomplete on cases they claimed, and one introduced a *new* false report.

## 1. `agent pair` asserted a culprit it cannot identify — a regression from #143

The fallback I added asked `service::installed_unit`, which is `fs.exists(unit_path)` — a **file**, with no liveness check. `install.sh` writes that file for every documented setup, so it reads true on a machine whose agent is merely installed and **stopped**.

And `bind_failure` is only reached when the bind *failed* — so on that machine the real holder is another `agent pair`, which then went unnamed while the message asserted *"this machine's agent is already running and holds it"*, ending with the line *"This command is for a machine whose agent is not running yet."*

I traded a false negative for a false positive, and inverted it on exactly the machine the command is for. **A check that cannot distinguish two causes should name both** — it now does, with the command that tells them apart. `local_agent_running` is back to the port probe.

## 2. `logs` could not find a CRASHED container — #142 incomplete

The exact-name probe uses `ps -a` deliberately: *"a container that exited still has logs worth reading, and that is often exactly why someone is here."* My label fallback used plain `docker ps`, fixing the rank case only for containers still running — and missing the likeliest reason to read logs at all. `containers_for_recipe` gains `include_exited`; `stop` keeps running-only.

## 3. `logs` filtered on the TYPED name, not the resolved one — #142 incomplete

The launch writes the **resolved** recipe into the label, which is why `stop` has always passed `resolved`. `logs` discarded it, so `logs @registry/q` queried `label=…=@registry/q` against a label of `q` and still denied the container — **one of the two cases that commit claimed to fix.**

## 4. `doctor` could label one volume's free space with another's path — #141

`free_bytes` walks up to the nearest existing ancestor, so an unmounted `/mnt/models` returns **root's** free space and printed *"12 GB free on /mnt/models"*. It also made that commit's stated `.` fallback unreachable — the message described behaviour the code did not have, which is the exact defect class this whole series is about. The cache is measured only when it exists.

## Verification

Two new tests pin the label query's name and its `-a`, both verified by mutation:

```
typed name  -> the_label_query_uses_the_resolved_name_not_the_typed_one ... FAILED
               must filter on the resolved name: [... "label=io.atlasctl.recipe=@registry/q" ...]
drop -a     -> the_label_query_includes_exited_containers ... FAILED
```

Worth noting: the typed-name mutation does not even **compile** without silencing an unused variable, so the compiler blocks that regression independently of the test.

`ALL LOCAL CHECKS PASS` — and the precheck caught a rustfmt failure here *before* the push, which is what it was written for.