### PR TITLE
fix(release): don't publish a release before its assets exist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,9 @@ jobs:
     outputs:
       tag: ${{ steps.pick.outputs.tag }}
       release: ${{ steps.pick.outputs.release }}
+      cut: ${{ steps.pick.outputs.cut }}
+    permissions:
+      contents: write
     steps:
       - id: pick
         env:
@@ -76,14 +79,42 @@ jobs:
             echo "manual dispatch for $INPUT_TAG"
             echo "tag=$INPUT_TAG" >> "$GITHUB_OUTPUT"
             echo "release=true" >> "$GITHUB_OUTPUT"
+            echo "cut=false" >> "$GITHUB_OUTPUT"
           elif [ "$RP_RESULT" = "success" ] && [ "$RP_CREATED" = "true" ]; then
             echo "release-please cut $RP_TAG"
             echo "tag=$RP_TAG" >> "$GITHUB_OUTPUT"
             echo "release=true" >> "$GITHUB_OUTPUT"
+            echo "cut=true" >> "$GITHUB_OUTPUT"
           else
             echo "nothing to release on this run"
             echo "release=false" >> "$GITHUB_OUTPUT"
           fi
+
+      # release-please publishes the release the instant the release PR merges,
+      # but the archives are uploaded ~30 minutes later, by `github-release` at
+      # the very end of this run. In between, `releases/latest` resolves to a
+      # release with zero assets and every
+      # `curl https://atlasinference.io/install.sh | sh` on earth dies on a 404
+      # for the tarball it just tried to fetch. Not theoretical: v0.5.0 did
+      # exactly that to real installs.
+      #
+      # Marking it a prerelease removes it from `releases/latest` (which skips
+      # prereleases), so installs keep resolving to the previous, fully
+      # populated release. `github-release` promotes it once the assets are up.
+      #
+      # Deliberately NOT a draft: GitHub does not create the tag for a draft
+      # release, and `preflight at the tag` and `publish-crates` both check that
+      # tag out.
+      - name: hide the release until its assets exist
+        if: ${{ steps.pick.outputs.cut == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.pick.outputs.tag }}
+        run: |
+          set -eu
+          id=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$TAG" --jq .id)
+          gh api -X PATCH "repos/$GITHUB_REPOSITORY/releases/$id" -F prerelease=true >/dev/null
+          echo "$TAG hidden from releases/latest until its assets land"
 
   # release-please rewrites the version in every workspace manifest but updates
   # Cargo.lock only for the members its own discovery finds — its log reports
@@ -345,6 +376,21 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.resolve.outputs.tag }}
         run: gh release upload "$TAG" dist/* --clobber
+
+      # The assets are attached, so the release can stop hiding. Gated on `cut`
+      # so a recovery dispatch re-uploading an OLD tag cannot drag
+      # `releases/latest` backwards onto it.
+      - name: promote the release now that it is complete
+        if: ${{ needs.resolve.outputs.cut == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+        run: |
+          set -eu
+          id=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$TAG" --jq .id)
+          gh api -X PATCH "repos/$GITHUB_REPOSITORY/releases/$id" \
+            -F prerelease=false -f make_latest=true >/dev/null
+          echo "$TAG is now the latest release"
 
   publish-crates:
     name: crates.io

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -304,7 +304,26 @@ try {
     try {
         Invoke-WebRequest -UseBasicParsing -Uri "$base/$archiveName" -OutFile $archive
     } catch {
-        Die "could not download $base/$archiveName - is there a release for $target yet?"
+        # Three very different causes; the old message named only the least
+        # likely one and read as "atlasctl does not support your machine". The
+        # usual cause is that the release was published minutes ago and its
+        # archives are still uploading, so releases/latest briefly resolves to a
+        # release with no assets. SHA256SUMS is written by the same step that
+        # uploads the archives, so its presence separates the cases.
+        $probe = Join-Path $tmp 'SHA256SUMS.probe'
+        $haveSums = $true
+        try {
+            Invoke-WebRequest -UseBasicParsing -Uri "$base/SHA256SUMS" -OutFile $probe
+        } catch {
+            $haveSums = $false
+        }
+        if (-not $haveSums) {
+            Die "this release has not finished publishing its binaries yet - they are uploaded a few minutes after the release itself appears. Retry shortly, or pin a known-good version by setting `$env:ATLASCTL_VERSION` to a tag (see https://github.com/$Repo/releases)."
+        }
+        if (Select-String -Path $probe -SimpleMatch $archiveName -Quiet) {
+            Die "downloading $archiveName failed, but this release does list it. That points at a network problem on the way to GitHub rather than a missing build - please retry."
+        }
+        Die "this release has no build for $target. The targets it does ship are listed at https://github.com/$Repo/releases"
     }
     $sums = Join-Path $tmp 'SHA256SUMS'
     try {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -516,8 +516,10 @@ main() {
     version="${ATLASCTL_VERSION:-latest}"
     if [ "$version" = "latest" ]; then
         base="https://github.com/$REPO/releases/latest/download"
+        release_page="https://github.com/$REPO/releases/latest"
     else
         base="https://github.com/$REPO/releases/download/$version"
+        release_page="https://github.com/$REPO/releases/tag/$version"
     fi
 
     tmp=$(mktemp -d)
@@ -526,8 +528,32 @@ main() {
 
     archive_name="${BIN_NAME}-${target}.tar.xz"
     info "downloading $archive_name"
-    fetch "$base/$archive_name" "$tmp/$archive_name" \
-        || die "could not download $base/$archive_name — is there a release for $target yet?"
+    if ! fetch "$base/$archive_name" "$tmp/$archive_name"; then
+        # A failed asset download has three very different causes, and the old
+        # message named only the least likely one: it asked whether this
+        # platform has a release at all, which reads as "atlasctl does not
+        # support your machine". The usual cause is far more boring -- the
+        # release was published a few minutes ago and its archives are still
+        # uploading, so `releases/latest` briefly resolves to a release with no
+        # assets. A user who is told their platform is unsupported gives up; a
+        # user who is told to retry in a few minutes succeeds.
+        #
+        # SHA256SUMS is written by the same step that uploads the archives, so
+        # its presence separates the cases with no API call and no jq.
+        # A tag that does not exist at all must not be reported as "still
+        # publishing" -- that would send someone who mistyped a version off to
+        # wait for an upload that is never coming.
+        if ! fetch "$release_page" "$tmp/release.probe" 2>/dev/null; then
+            die "there is no release named '$version' in $REPO. Available releases are listed at https://github.com/$REPO/releases"
+        fi
+        if fetch "$base/SHA256SUMS" "$tmp/SHA256SUMS.probe" 2>/dev/null; then
+            if grep -q "$archive_name" "$tmp/SHA256SUMS.probe" 2>/dev/null; then
+                die "downloading $archive_name failed, but this release does list it. That points at a network problem on the way to GitHub rather than a missing build — please retry."
+            fi
+            die "this release has no build for $target. The targets it does ship are listed at https://github.com/$REPO/releases"
+        fi
+        die "this release has not finished publishing its binaries yet — they are uploaded a few minutes after the release itself appears. Retry shortly, or pin a known-good version with ATLASCTL_VERSION=<tag> (see https://github.com/$REPO/releases)."
+    fi
     fetch "$base/SHA256SUMS" "$tmp/SHA256SUMS" \
         || die "could not download SHA256SUMS; refusing to install unverified binaries."
 


### PR DESCRIPTION
## The bug, observed live

`v0.5.0` was cut at **12:47:53Z**. At **12:55Z** — eight minutes later, with the build matrix still queued — a real install attempt failed:

```
[atlas] downloading atlasctl-aarch64-unknown-linux-musl.tar.xz
curl: (22) The requested URL returned error: 404
[atlas] could not download .../releases/latest/download/atlasctl-aarch64-unknown-linux-musl.tar.xz
        — is there a release for aarch64-unknown-linux-musl yet?
```

release-please publishes the release as soon as the release PR merges, but the archives are uploaded ~30 minutes later by `github-release` at the end of that same run. In between, `releases/latest` points at a release with **zero assets**, and every `curl https://atlasinference.io/install.sh | sh` on the internet 404s. `install.ps1` fails the same way.

This has happened on every release; it is only invisible because nobody happened to install during the window.

## The fix

* `resolve` marks a freshly cut release **prerelease**, which removes it from `releases/latest` (that endpoint skips prereleases). Installs keep resolving to the previous, fully populated release.
* `github-release` **promotes** it (`prerelease=false`, `make_latest=true`) once the assets are attached.

Verified by hand on `v0.5.0` while it was empty: marking it prerelease moved `releases/latest` back to `v0.4.1`, and an install immediately succeeded again with `checksum verified`.

## Two things deliberately decided

**Prerelease, not draft.** A draft would hide the release completely, but GitHub does not create the tag for a draft release — and `preflight at the tag` and `publish-crates` both check that tag out. Draft would break the pipeline.

**The promote step is gated on a new `cut` output.** The `workflow_dispatch` recovery path re-uploads an *existing, older* tag; setting `make_latest=true` there would drag `releases/latest` backwards onto it. `cut` is true only on the release-please path.

## Honest limitation

This narrows the window from ~30 minutes to the few seconds between release-please creating the release and `resolve` starting. Closing it entirely would require release-please to create the release hidden in the first place.

## Risk

If the matrix fails, the release stays a prerelease rather than becoming a public release with no assets — which is the safer of the two failures, and visible.