### PR TITLE
fix(cache): a directory is not a downloaded model

### DIFF
--- a/crates/atlasctl-agent/src/launcher/docker.rs
+++ b/crates/atlasctl-agent/src/launcher/docker.rs
@@ -102,6 +102,44 @@ impl Launcher for DockerLauncher {
         let plan = self.plan(recipe, overrides)?;
         let name = plan.docker.name.clone();
 
+        // The same guard `atlasctl run` applies, because this path has an
+        // operator too — they are just in a browser instead of a terminal, and
+        // they get LESS to work with, not more: the launch runs offline, so a
+        // missing model fails inside a container that has already exited, and
+        // all the browser can show is that it stopped.
+        //
+        // Skipped when the recipe brings its own weights (`--model-from-path`),
+        // since then the Hub cache is never consulted.
+        if !plan.docker.command.iter().any(|a| a == "--model-from-path")
+            && let Some(dir) = atlasctl_core::hfcache::hub_dir(
+                std::path::Path::new(&self.host.hf_cache_dir),
+                &recipe.model,
+            )
+        {
+            use atlasctl_core::hfcache::CacheState;
+            let detail = match atlasctl_core::hfcache::cache_state(&dir) {
+                CacheState::Weights => None,
+                CacheState::Absent => Some(format!(
+                    "the model `{}` is not in this machine's HuggingFace cache ({}). \
+                     The launch runs offline, so it cannot download it — fetch it \
+                     first with `hf download {}`.",
+                    recipe.model, self.host.hf_cache_dir, recipe.model
+                )),
+                // Named separately: telling someone it is "not there" when they
+                // can see the directory reads as a broken tool, and they stop
+                // trusting the instruction that follows.
+                CacheState::MetadataOnly => Some(format!(
+                    "the model `{}` has a cache directory in {} but no weight \
+                     files — what an interrupted or metadata-only download \
+                     leaves behind. Complete it with `hf download {}`.",
+                    recipe.model, self.host.hf_cache_dir, recipe.model
+                )),
+            };
+            if let Some(detail) = detail {
+                return Err(AgentError::LaunchFailed { detail });
+            }
+        }
+
         // Clear a previous container of the same name. Failure is expected when
         // nothing is there; the launch below is what has to succeed.
         let _ = self

--- a/crates/atlasctl-agent/src/launcher/docker/tests.rs
+++ b/crates/atlasctl-agent/src/launcher/docker/tests.rs
@@ -7,6 +7,27 @@ use atlasctl_core::io::RecordingRunner;
 use atlasctl_core::io::process::Output;
 use atlasctl_core::recipe::Provenance;
 
+/// A cache root that really holds `org/m`'s weights.
+///
+/// The launcher refuses to start a recipe whose model is missing from the cache,
+/// because the launch runs offline and the container would otherwise fail after
+/// the image pull with nothing useful on screen. These tests are about the
+/// docker command rather than the cache, so they need one that satisfies that
+/// guard — and building it here, rather than weakening the guard for tests,
+/// keeps the production path honest.
+fn cache_with_model() -> &'static std::path::Path {
+    static ROOT: std::sync::OnceLock<std::path::PathBuf> = std::sync::OnceLock::new();
+    ROOT.get_or_init(|| {
+        let root =
+            std::env::temp_dir().join(format!("atlasctl-launch-cache-{}", std::process::id()));
+        let snap = root.join("hub/models--org--m/snapshots/deadbeef");
+        std::fs::create_dir_all(&snap).expect("mkdir cache");
+        std::fs::write(snap.join("config.json"), b"{}").expect("write config");
+        std::fs::write(snap.join("model.safetensors"), b"weights").expect("write weights");
+        root
+    })
+}
+
 fn host() -> HostSnapshot {
     HostSnapshot {
         posix_user: Some(PosixUser {
@@ -14,7 +35,7 @@ fn host() -> HostSnapshot {
             gid: 1000,
         }),
         home: "/home/spark".into(),
-        hf_cache_dir: "/home/spark/.cache/huggingface".into(),
+        hf_cache_dir: cache_with_model().display().to_string(),
         env: BTreeMap::new(),
     }
 }
@@ -227,4 +248,73 @@ fn docker_being_unavailable_is_reported_as_such() {
         matches!(err, AgentError::DockerUnavailable { .. }),
         "{err:?}"
     );
+}
+
+/// A model that is not in the cache is refused BEFORE docker is invoked.
+///
+/// The launch runs offline, so an absent model cannot be fetched; without this
+/// the container starts, fails inside on the Hub library's own cache-miss, and
+/// exits — and a browser operator sees only that it stopped. The assertion that
+/// the runner recorded nothing is the point: refusing late would still "fail",
+/// just uselessly.
+#[test]
+fn a_model_missing_from_the_cache_is_refused_without_running_docker() {
+    let runner = Arc::new(RecordingRunner::new());
+    let mut h = host();
+    h.hf_cache_dir = std::env::temp_dir()
+        .join(format!("atlasctl-empty-cache-{}", std::process::id()))
+        .display()
+        .to_string();
+    let l = DockerLauncher::new(runner.clone(), h, &ROOTLESS_V1, Box::new(NvidiaDevices));
+
+    let err = l
+        .launch(&recipe(), &BTreeMap::new())
+        .expect_err("an absent model must be refused");
+    let AgentError::LaunchFailed { detail } = err else {
+        panic!("expected LaunchFailed, got {err:?}");
+    };
+    assert!(detail.contains("org/m"), "must name the model: {detail}");
+    assert!(
+        detail.contains("hf download"),
+        "must say how to fix it: {detail}"
+    );
+    assert!(
+        runner.calls().is_empty(),
+        "docker must not be invoked at all, got {:?}",
+        runner.calls()
+    );
+}
+
+/// A cache directory that exists but holds no weights is refused, and says so.
+///
+/// `Path::exists` on the model directory is not enough: an interrupted or
+/// metadata-only download leaves `refs/`, `snapshots/` and a `config.json`
+/// behind. Telling that operator the model is "not there" when they can see the
+/// directory reads as a broken tool, so the message names the real state.
+#[test]
+fn a_metadata_only_cache_entry_is_refused_and_named_as_such() {
+    let runner = Arc::new(RecordingRunner::new());
+    let root = std::env::temp_dir().join(format!("atlasctl-meta-cache-{}", std::process::id()));
+    let snap = root.join("hub/models--org--m/snapshots/deadbeef");
+    std::fs::create_dir_all(&snap).expect("mkdir");
+    std::fs::write(snap.join("config.json"), b"{}").expect("write config");
+    // Deliberately no weight file.
+
+    let mut h = host();
+    h.hf_cache_dir = root.display().to_string();
+    let l = DockerLauncher::new(runner.clone(), h, &ROOTLESS_V1, Box::new(NvidiaDevices));
+
+    let err = l
+        .launch(&recipe(), &BTreeMap::new())
+        .expect_err("a weightless cache entry must be refused");
+    let AgentError::LaunchFailed { detail } = err else {
+        panic!("expected LaunchFailed, got {err:?}");
+    };
+    assert!(
+        detail.contains("no weight files"),
+        "must name the real state rather than claiming absence: {detail}"
+    );
+    assert!(runner.calls().is_empty(), "docker must not be invoked");
+
+    std::fs::remove_dir_all(&root).ok();
 }

--- a/crates/atlasctl-core/src/hfcache.rs
+++ b/crates/atlasctl-core/src/hfcache.rs
@@ -36,6 +36,63 @@ pub fn hub_dir(cache_root: &Path, model: &str) -> Option<PathBuf> {
     )
 }
 
+/// What a Hub cache holds for a model.
+///
+/// A launch runs offline, so "the directory is there" is not the question the
+/// launcher needs answered — "are the weights there" is. These are genuinely
+/// different states, and the difference is common: a cache entry left by a
+/// metadata-only fetch, an aborted download, or a cleanup that reclaimed blobs
+/// keeps `refs/`, `snapshots/` and a resolvable `config.json` while every weight
+/// file is gone. Nine such directories, 32-68 KB each, were sitting in the cache
+/// of the machine this was written on — each one of which `Path::exists`
+/// reported as a present model, sending the launch on to fail inside a container
+/// with the Hub library's own cache-miss message.
+#[derive(Debug, PartialEq, Eq)]
+pub enum CacheState {
+    /// No directory for this model at all.
+    Absent,
+    /// The directory exists but carries no usable weight file.
+    MetadataOnly,
+    /// At least one weight file is present and its blob resolves.
+    Weights,
+}
+
+/// File extensions that constitute model weights.
+///
+/// Deliberately short: an extension listed here that is NOT weights would make a
+/// metadata-only cache read as complete, which is the exact bug this exists to
+/// prevent.
+const WEIGHT_EXTENSIONS: [&str; 3] = ["safetensors", "bin", "gguf"];
+
+/// Classify what `dir` (from [`hub_dir`]) actually holds.
+pub fn cache_state(dir: &Path) -> CacheState {
+    if !dir.exists() {
+        return CacheState::Absent;
+    }
+    let Ok(snapshots) = std::fs::read_dir(dir.join("snapshots")) else {
+        return CacheState::MetadataOnly;
+    };
+    for snap in snapshots.flatten() {
+        let Ok(entries) = std::fs::read_dir(snap.path()) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let is_weight = path
+                .extension()
+                .and_then(|e| e.to_str())
+                .is_some_and(|e| WEIGHT_EXTENSIONS.contains(&e));
+            // `metadata` follows the symlink into `blobs/`, so an entry whose
+            // blob was reclaimed reads as absent rather than as a weight file.
+            // A dangling link is exactly what a partially cleaned cache leaves.
+            if is_weight && std::fs::metadata(&path).is_ok() {
+                return CacheState::Weights;
+            }
+        }
+    }
+    CacheState::MetadataOnly
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -76,5 +133,71 @@ mod tests {
                 "must not guess a cache path for {not_an_id:?}"
             );
         }
+    }
+
+    /// Build a cache entry: `files` are created under a snapshot directory,
+    /// each as a real file unless its name is prefixed `dangling:`.
+    fn entry(root: &Path, model: &str, files: &[&str]) -> PathBuf {
+        let dir = hub_dir(root, model).expect("hub id");
+        let snap = dir.join("snapshots").join("deadbeef");
+        std::fs::create_dir_all(&snap).expect("mkdir");
+        std::fs::create_dir_all(dir.join("blobs")).expect("mkdir blobs");
+        for f in files {
+            match f.strip_prefix("dangling:") {
+                Some(name) => {
+                    // A weight whose blob was reclaimed — the state a partial
+                    // cache cleanup leaves behind.
+                    #[cfg(unix)]
+                    std::os::unix::fs::symlink(dir.join("blobs/gone"), snap.join(name))
+                        .expect("symlink");
+                }
+                None => std::fs::write(snap.join(f), b"x").expect("write"),
+            }
+        }
+        dir
+    }
+
+    #[test]
+    fn a_directory_that_exists_but_holds_no_weights_is_not_a_present_model() {
+        let tmp = std::env::temp_dir().join(format!("atlasctl-hf-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        // Exactly the shape observed on a real box: refs, a snapshot, and a
+        // config.json — and not one weight file.
+        let meta = entry(&tmp, "org/metadata-only", &["config.json"]);
+        assert_eq!(cache_state(&meta), CacheState::MetadataOnly);
+        assert!(
+            meta.exists(),
+            "the bug this guards: the directory IS there, which is why \
+             `Path::exists` passed it through as a usable model"
+        );
+
+        let full = entry(&tmp, "org/complete", &["config.json", "model.safetensors"]);
+        assert_eq!(cache_state(&full), CacheState::Weights);
+
+        assert_eq!(
+            cache_state(&hub_dir(&tmp, "org/never-fetched").unwrap()),
+            CacheState::Absent
+        );
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    /// A reclaimed blob leaves the symlink behind. Counting the link rather than
+    /// its target would report weights that cannot be read.
+    #[cfg(unix)]
+    #[test]
+    fn a_weight_whose_blob_was_reclaimed_does_not_count() {
+        let tmp = std::env::temp_dir().join(format!("atlasctl-hf-dangle-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        let d = entry(
+            &tmp,
+            "org/reclaimed",
+            &["config.json", "dangling:model.safetensors"],
+        );
+        assert_eq!(cache_state(&d), CacheState::MetadataOnly);
+
+        std::fs::remove_dir_all(&tmp).ok();
     }
 }

--- a/crates/atlasctl-core/src/hfcache.rs
+++ b/crates/atlasctl-core/src/hfcache.rs
@@ -137,24 +137,29 @@ mod tests {
 
     /// Build a cache entry: `files` are created under a snapshot directory,
     /// each as a real file unless its name is prefixed `dangling:`.
+    /// Build a cache entry holding `files` as real files under one snapshot.
     fn entry(root: &Path, model: &str, files: &[&str]) -> PathBuf {
         let dir = hub_dir(root, model).expect("hub id");
         let snap = dir.join("snapshots").join("deadbeef");
         std::fs::create_dir_all(&snap).expect("mkdir");
         std::fs::create_dir_all(dir.join("blobs")).expect("mkdir blobs");
         for f in files {
-            match f.strip_prefix("dangling:") {
-                Some(name) => {
-                    // A weight whose blob was reclaimed — the state a partial
-                    // cache cleanup leaves behind.
-                    #[cfg(unix)]
-                    std::os::unix::fs::symlink(dir.join("blobs/gone"), snap.join(name))
-                        .expect("symlink");
-                }
-                None => std::fs::write(snap.join(f), b"x").expect("write"),
-            }
+            std::fs::write(snap.join(f), b"x").expect("write");
         }
         dir
+    }
+
+    /// Add a weight whose blob is missing — the state a partial cache cleanup
+    /// leaves behind.
+    ///
+    /// Unix-only, and kept OUT of `entry` on purpose: expressing it as a
+    /// magic filename prefix meant the Windows build had a bound name it could
+    /// not use, which `#![deny(warnings)]` rejects. A separate function is
+    /// gated as a whole, so there is nothing left over to be unused.
+    #[cfg(unix)]
+    fn add_dangling_weight(dir: &Path, name: &str) {
+        let snap = dir.join("snapshots").join("deadbeef");
+        std::os::unix::fs::symlink(dir.join("blobs/gone"), snap.join(name)).expect("symlink");
     }
 
     #[test]
@@ -191,11 +196,8 @@ mod tests {
         let tmp = std::env::temp_dir().join(format!("atlasctl-hf-dangle-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&tmp);
 
-        let d = entry(
-            &tmp,
-            "org/reclaimed",
-            &["config.json", "dangling:model.safetensors"],
-        );
+        let d = entry(&tmp, "org/reclaimed", &["config.json"]);
+        add_dangling_weight(&d, "model.safetensors");
         assert_eq!(cache_state(&d), CacheState::MetadataOnly);
 
         std::fs::remove_dir_all(&tmp).ok();

--- a/crates/atlasctl/src/commands/run.rs
+++ b/crates/atlasctl/src/commands/run.rs
@@ -127,17 +127,36 @@ pub fn run(args: &RunArgs) -> Result<()> {
     let brings_own_weights = plan.docker.command.iter().any(|a| a == "--model-from-path");
     if !brings_own_weights
         && let Some(dir) = hfcache::hub_dir(Path::new(&host.hf_cache_dir), &recipe.model)
-        && !dir.exists()
     {
-        bail!(
-            "`{}` needs the model `{}`, which is not in {}.\n\
-                 The launch runs offline, so it cannot download it. Fetch it first:\n\
-                   hf download {}",
-            args.recipe,
-            recipe.model,
-            host.hf_cache_dir,
-            recipe.model
-        );
+        match hfcache::cache_state(&dir) {
+            hfcache::CacheState::Weights => {}
+            hfcache::CacheState::Absent => bail!(
+                "`{}` needs the model `{}`, which is not in {}.\n\
+                     The launch runs offline, so it cannot download it. Fetch it first:\n\
+                       hf download {}",
+                args.recipe,
+                recipe.model,
+                host.hf_cache_dir,
+                recipe.model
+            ),
+            // Distinct from Absent on purpose. `hf download` is the same fix,
+            // but "it is not there" is the wrong thing to tell someone who can
+            // SEE the directory: they check, find it, and conclude the tool is
+            // broken. Naming the state — present, but no weights — is what makes
+            // the instruction believable.
+            hfcache::CacheState::MetadataOnly => bail!(
+                "`{}` needs the model `{}`. Its cache directory exists in {}, but \
+                 holds no weight files — only metadata, which is what an \
+                 interrupted or metadata-only download leaves behind.\n\
+                     The launch runs offline, so it cannot fetch the rest. \
+                 Complete it with:\n\
+                       hf download {}",
+                args.recipe,
+                recipe.model,
+                host.hf_cache_dir,
+                recipe.model
+            ),
+        }
     }
 
     let runner = StdProcessRunner;


### PR DESCRIPTION
## The bug

`atlasctl run` refuses to launch a recipe whose model is missing from the HuggingFace cache — the launch runs offline, so it cannot fetch it. The guard asked `Path::exists` on the model's cache directory, which is not the question that matters.

A cache entry left by a metadata-only fetch, an interrupted download, or a cleanup that reclaimed blobs keeps `refs/`, `snapshots/` and a resolvable `config.json` while **every weight file is gone**.

This is not hypothetical. Nine such directories are in the cache of the machine I wrote this on:

```
models--Kbenkhaled--Qwen3.5-27B-NVFP4              48K
models--Sehyo--Qwen3.5-35B-A3B-NVFP4               68K
models--ig1--Qwen3-VL-30B-A3B-Instruct-NVFP4       44K
models--nvidia--Gemma-4-31B-IT-NVFP4               40K
...
```

Each contains exactly `refs/main`, one blob, and `snapshots/<hash>/config.json`. `Path::exists` reports every one as a present model, so the guard passes it through and the launch fails *inside* a container that has already exited — reachable only via `atlasctl logs`.

## The fix

`hfcache::cache_state` answers the real question with three states: `Absent`, `MetadataOnly`, `Weights`.

`MetadataOnly` is a separate state on purpose. Telling someone the model is "not there" when they can **see** the directory reads as a broken tool, and they stop believing the `hf download` that follows. The message names the real state instead.

A weight file whose blob was reclaimed does not count: the check follows the symlink into `blobs/`, because a dangling link is exactly what a partial cleanup leaves behind.

## The agent gets the guard it never had

`atlasctl run` had a check; the agent — the path the **browser** drives — had none. That operator sees strictly less: a container that exits, and a UI that can only report it stopped.

Both new agent tests assert the runner recorded **nothing**, which is the real point. Refusing after the docker call would still fail, just uselessly.

## Verification

Sabotaged (guard disabled), both new tests fail:

```
a_model_missing_from_the_cache_is_refused_without_running_docker --- FAILED
a_metadata_only_cache_entry_is_refused_and_named_as_such --- FAILED
```

The launcher test fixture now builds a real cache containing its model, rather than the guard being weakened for tests — the production path stays honest.

Workspace: **820 tests passed**, clippy zero errors under `--locked`, rustfmt clean, no file over the 500-line cap.