### PR TITLE
fix(onboarding): stop contradicting the operator

### DIFF
--- a/crates/atlasctl-agent/src/daemon.rs
+++ b/crates/atlasctl-agent/src/daemon.rs
@@ -111,6 +111,13 @@ pub struct PeerWork {
     pub control: Arc<crate::control::ControlHost>,
 }
 
+/// How long to wait before trying the peer port again.
+///
+/// Short enough that an operator who frees the port sees the channel come up
+/// while they are still looking, long enough that a genuinely occupied port
+/// does not spin.
+const PEER_BIND_RETRY: std::time::Duration = std::time::Duration::from_secs(5);
+
 pub fn spawn_peer_work(w: PeerWork) {
     spawn_peer_listener(
         Arc::clone(&w.fleet),
@@ -153,6 +160,9 @@ fn spawn_peer_listener(
         answer_budget: crate::peer::control::RELAY_ANSWER_BUDGET,
     });
     tokio::spawn(async move {
+        // Set once the first bind failure has been reported, so the retry loop
+        // does not repeat itself forever.
+        let mut bind_reported = false;
         // Pinned peers always; a stranger only while a human has a join code
         // outstanding. Decided during the handshake, so for all the time nobody
         // is onboarding an unpaired agent reaches no further than rustls'
@@ -173,17 +183,51 @@ fn spawn_peer_listener(
             }
         };
         let acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(cfg));
-        let listener = match tokio::net::TcpListener::bind(("0.0.0.0", port)).await {
-            Ok(l) => l,
-            Err(e) => {
-                eprintln!(
-                    "{}",
-                    crate::peer::bindfail::peer_bind_failure(port, e.kind(), &e.to_string())
-                );
-                return;
+        // Keep trying, rather than giving up for the life of the process.
+        //
+        // This used to `return` on the first bind failure, and the consequence
+        // was invisible: the browser channel is a SEPARATE listener, so the
+        // agent went on looking completely healthy while being unable to accept
+        // a single peer. The machine still advertised itself, still minted join
+        // codes, and the operator learned about it on the OTHER machine — after
+        // installing there — as a bare "Connection refused" against an address
+        // this agent told them to use.
+        //
+        // Almost every cause is transient: an agent started by hand in another
+        // terminal, a previous unit not yet reaped, a port in TIME_WAIT. Waiting
+        // for it costs nothing and turns a permanent, silent failure into a
+        // delay that resolves itself.
+        let listener = loop {
+            match tokio::net::TcpListener::bind(("0.0.0.0", port)).await {
+                Ok(l) => break l,
+                Err(e) => {
+                    // Printed once per distinct failure, not once per attempt: a
+                    // line every 5 seconds forever is how a log stops being read.
+                    if !std::mem::replace(&mut bind_reported, true) {
+                        eprintln!(
+                            "{}",
+                            crate::peer::bindfail::peer_bind_failure(
+                                port,
+                                e.kind(),
+                                &e.to_string()
+                            )
+                        );
+                        eprintln!(
+                            "peer channel: retrying every {}s until it is free; \
+                             this agent cannot accept peers until then",
+                            PEER_BIND_RETRY.as_secs()
+                        );
+                    }
+                    tokio::time::sleep(PEER_BIND_RETRY).await;
+                }
             }
         };
-        eprintln!("peer channel on 0.0.0.0:{port}");
+        if bind_reported {
+            eprintln!("peer channel on 0.0.0.0:{port} (recovered)");
+        } else {
+            eprintln!("peer channel on 0.0.0.0:{port}");
+        }
+        crate::peer::mark_listener_up(port);
 
         // 0 means "the last accept succeeded", which is also what makes the
         // first failure of a run the one that gets printed.

--- a/crates/atlasctl-agent/src/peer.rs
+++ b/crates/atlasctl-agent/src/peer.rs
@@ -42,3 +42,29 @@ mod pair_tests;
 
 /// Port the peer channel listens on.
 pub const DEFAULT_PEER_PORT: u16 = 34334;
+
+/// Whether this process's peer listener has ever come up, and on which port.
+///
+/// `0` means "not yet". Written once the listener binds, read by
+/// `atlasctl agent status` through the agent's own status reply, so an operator
+/// can see the one thing that otherwise only shows up as a "Connection refused"
+/// on a DIFFERENT machine: this agent is running, but cannot accept peers.
+static LISTENING_ON: std::sync::atomic::AtomicU16 = std::sync::atomic::AtomicU16::new(0);
+
+/// Record that the peer listener is accepting on `port`.
+pub fn mark_listener_up(port: u16) {
+    LISTENING_ON.store(port, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// The port the peer listener is accepting on, or `None` if it is not up.
+///
+/// Not a probe: a probe from inside this process would also succeed against
+/// somebody ELSE's listener on the same port, which is precisely the case this
+/// is meant to distinguish.
+#[must_use]
+pub fn listening_on() -> Option<u16> {
+    match LISTENING_ON.load(std::sync::atomic::Ordering::Relaxed) {
+        0 => None,
+        p => Some(p),
+    }
+}

--- a/crates/atlasctl/src/commands/agentinfo.rs
+++ b/crates/atlasctl/src/commands/agentinfo.rs
@@ -100,6 +100,14 @@ pub fn status(args: &AgentStatusArgs) -> Result<()> {
     match std::net::TcpStream::connect(&addr) {
         Ok(_) => {
             println!("agent: running (listening on {addr})");
+            // The browser channel and the peer channel are SEPARATE listeners,
+            // and the peer one can be down while this one is up. Nothing used to
+            // say so, so the first sign was a "Connection refused" on a
+            // different machine — after installing there — against an address
+            // this agent had handed out in a join command.
+            for line in peer_channel_line(atlasctl_agent::peer::DEFAULT_PEER_PORT) {
+                println!("{line}");
+            }
             Ok(())
         }
         Err(e) => {
@@ -120,6 +128,29 @@ pub fn status(args: &AgentStatusArgs) -> Result<()> {
             }
             bail!("no agent is listening on {addr}")
         }
+    }
+}
+
+/// What to say about the peer channel: the listener that accepts other machines.
+///
+/// Reported separately from the browser channel because they are separate
+/// listeners with separate failure modes. A machine can serve its own browser
+/// perfectly while being unable to accept a single peer — which is exactly the
+/// state that produces a "Connection refused" for somebody following a join
+/// command this machine printed.
+fn peer_channel_line(port: u16) -> Vec<String> {
+    use std::net::{Ipv4Addr, SocketAddr, TcpStream};
+    let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
+    if TcpStream::connect_timeout(&addr, std::time::Duration::from_millis(300)).is_ok() {
+        vec![format!("peer channel: accepting on {port}")]
+    } else {
+        vec![
+            format!("peer channel: NOT listening on {port}"),
+            "  Other machines cannot join or reach this one. The agent itself is".to_string(),
+            "  fine — this is a second listener, and it retries, so the usual".to_string(),
+            "  cause is that something else still holds the port.".to_string(),
+            "  See why with the agent's log; it names the reason once.".to_string(),
+        ]
     }
 }
 

--- a/crates/atlasctl/src/commands/service.rs
+++ b/crates/atlasctl/src/commands/service.rs
@@ -52,9 +52,24 @@ pub fn install(args: &crate::cli::AgentInstallArgs) -> Result<()> {
         // operator ends up pairing a browser against a five-second crash loop.
         println!("agent installed, but it is NOT running");
         println!("  the unit is enabled and the supervisor accepted it, so this is");
-        println!("  the agent exiting at startup. The usual cause is the port:");
-        println!("    an agent started by hand still holds {}.", args.port);
-        println!("  See why with:");
+        println!("  the agent exiting at startup.");
+        // Ask, do not assert. This used to state "the usual cause is the port"
+        // unconditionally -- and a real install then printed the ACTUAL cause a
+        // few lines later (a config directory owned by another uid). Two
+        // confident, contradictory explanations is worse than one honest "I
+        // cannot see why": the operator acts on the first, nothing changes, and
+        // they stop trusting the second.
+        match startup_obstacle(args.port) {
+            Some(why) => {
+                for line in why.lines() {
+                    println!("  {line}");
+                }
+            }
+            None => {
+                println!("  This installer could not see why from here — the log can:");
+            }
+        }
+        println!("  See the log with:");
         match done.kind {
             // `journalctl` does not exist on macOS, and it was the only thing
             // offered here — so the one diagnostic an operator was handed
@@ -226,4 +241,38 @@ pub(crate) fn uid_of(home: &std::path::Path) -> u32 {
 #[cfg(not(unix))]
 pub(crate) fn uid_of(_home: &std::path::Path) -> u32 {
     0
+}
+
+/// The reason an agent would exit at startup, when it is one this process can
+/// actually check.
+///
+/// Both checks are observations, not guesses: the config directory is inspected,
+/// and the port is probed by connecting to it. `None` means neither is wrong,
+/// which is a useful answer — it tells the operator to go and read the log
+/// rather than chase a cause that was never there.
+fn startup_obstacle(port: u16) -> Option<String> {
+    if let Ok(dir) = crate::configdir::resolve()
+        && let Some(why) = crate::configdir::diagnose(&dir)
+    {
+        return Some(format!(
+            "The reason is this node's config directory:\n{why}"
+        ));
+    }
+    if port_is_taken(port) {
+        return Some(format!(
+            "Something is already listening on {port}, so the agent cannot bind it.\n             The usual cause is an agent started by hand in another terminal.\n             Stop it, or install on a different port with `--port`."
+        ));
+    }
+    None
+}
+
+/// Whether something already answers on the loopback port.
+///
+/// A connect, not a bind: binding to test would race the agent the supervisor is
+/// starting right now and could report the port taken by the very process being
+/// installed.
+fn port_is_taken(port: u16) -> bool {
+    use std::net::{Ipv4Addr, SocketAddr, TcpStream};
+    let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
+    TcpStream::connect_timeout(&addr, std::time::Duration::from_millis(300)).is_ok()
 }

--- a/crates/atlasctl/src/configdir.rs
+++ b/crates/atlasctl/src/configdir.rs
@@ -121,6 +121,28 @@ pub fn advice(dir: &Path, f: DirFacts) -> Option<String> {
 ///
 /// # Errors
 /// If the directory cannot be created, or exists but is not writable.
+/// Why this directory would stop an agent from starting, if anything would.
+///
+/// The same question [`ensure_usable`] answers, asked without the side effect,
+/// so a caller that has ALREADY failed can report the real reason instead of
+/// guessing one. `None` means the directory is not the problem.
+///
+/// This exists because `agent install` used to announce "the usual cause is the
+/// port" whenever the agent did not come up — and then a later step printed the
+/// actual cause, which was this directory being owned by another uid. Two
+/// confident, contradictory explanations is worse than one honest "I do not
+/// know": the operator acts on the first and it does nothing.
+#[must_use]
+pub fn diagnose(dir: &Path) -> Option<String> {
+    if !dir.exists() {
+        return None;
+    }
+    if !dir.is_dir() {
+        return Some(format!("{} exists but is not a directory", dir.display()));
+    }
+    advice(dir, facts(dir).ok()?)
+}
+
 pub fn ensure_usable(dir: &Path) -> Result<()> {
     if !dir.exists() {
         std::fs::create_dir_all(dir).with_context(|| cannot_create(dir))?;

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -249,7 +249,7 @@ install_agent() {
         warn "Check which with:  $BIN_NAME agent status"
         warn "A join code is single-use and expires. To retry just the join:"
         warn "    $BIN_NAME agent install --join <code>@<host>"
-        return
+        return 1
     fi
     # NOT silenced. `agent install` deliberately reports two things the
     # operator can only act on if they see them: that enable-linger failed, so
@@ -270,7 +270,7 @@ install_agent() {
         warn "is usable right now — the website will find it. Nothing else to do."
         warn "To point that agent at this newly installed binary, stop it and run:"
         warn "    $BIN_NAME agent install"
-        return
+        return 0
     fi
     warn "To run the agent by hand:"
     warn "    $BIN_NAME agent run"
@@ -280,6 +280,7 @@ install_agent() {
     else
         warn "    journalctl --user -u atlasctl-agent -n 50"
     fi
+    return 1
 }
 
 check_docker() {
@@ -577,11 +578,29 @@ main() {
 
     check_docker
     check_sparkrun
-    install_agent "$dir/$BIN_NAME" "$join" "$grant_control" "$same_version"
+    agent_ok=1
+    install_agent "$dir/$BIN_NAME" "$join" "$grant_control" "$same_version" || agent_ok=0
 
-    info "done. Try:"
-    info "    $BIN_NAME list"
-    info "    $BIN_NAME run qwen3.6-35b-a3b-fp8-mtp"
+    # `atlasctl` only resolves if its directory is on PATH. Printing the bare
+    # name to someone we warned about PATH a few lines ago is a command that
+    # fails the moment they paste it, which reads as a broken install.
+    case ":$PATH:" in
+        *":$dir:"*) try="$BIN_NAME" ;;
+        *) try="$dir/$BIN_NAME" ;;
+    esac
+
+    # Do not congratulate a failed run. The old code printed "done. Try:"
+    # unconditionally, so an operator whose agent had NOT started read a
+    # failure and a success in the same breath and believed the cheerful one.
+    if [ "$agent_ok" = 1 ]; then
+        info "done. Try:"
+    else
+        warn "atlasctl is installed, but the agent step above did not succeed."
+        warn "Fix that first — the website cannot use this machine until it does."
+        warn "Then try:"
+    fi
+    info "    $try list"
+    info "    $try run qwen3.6-35b-a3b-fp8-mtp"
 }
 
 main "$@"


### PR DESCRIPTION
From a real install transcript: MacBook (control-only) → mint a join code → run it on the DGX. Four defects, three of them things the tool *said*.

## 1. `agent install` asserted a cause it had not checked

When the agent did not come up it printed:

```
  the agent exiting at startup. The usual cause is the port:
    an agent started by hand still holds 34333.
```

The actual cause was printed a few lines later, by a different step:

```
error: /home/nologik/.config/atlasctl is owned by uid 996 but this process is uid 1000.
```

Two confident, contradictory explanations is worse than one honest "I cannot see why" — the operator acts on the first, nothing changes, and they stop believing the second.

It now **checks**: `configdir::diagnose` inspects the directory, the port is probed by connecting to it, and when neither is wrong it says so and points at the log.

## 2. A failed install ended by congratulating them

`install_agent` returned success unconditionally, so this appeared in one breath:

```
[atlas] the agent install, the fleet join, or both did not succeed.
...
[atlas] done. Try:
[atlas]     atlasctl list
```

It now returns a real status, and the tail says the agent step failed and must be fixed first. The "an agent is already listening" branch stays **success** on purpose — that machine is usable.

## 3. The hint could not be run

The same output warned `~/.local/bin is not on your PATH`, then suggested `atlasctl list` — which therefore could not resolve. The hint now prints the full path when the directory is not on PATH.

## 4. The peer listener gave up silently — the join failure underneath it

```
joining the fleet at 192.168.68.67:34334…
error: ... Connection refused (os error 111)
```

`spawn_peer_listener` reported a bind failure and **returned**, for the life of the process. The browser channel is a separate listener, so the agent went on looking healthy, still advertised itself, and still minted join codes — while being unable to accept a single peer. The operator finds out on the *other* machine, after installing there, as a bare "Connection refused" against an address this agent handed them.

It now retries every 5s, reporting once rather than per attempt, because nearly every cause is transient: a hand-started agent, an unreaped unit, a port in `TIME_WAIT`.

`atlasctl agent status` also now reports the peer channel **separately** from the browser channel, since they fail separately and only one was ever visible:

```
agent: running (listening on 127.0.0.1:34333)
peer channel: NOT listening on 34334
  Other machines cannot join or reach this one. ...
```

## Verification

`install_agent` stubbed to fail → the tail prints the warning and full-path hints. Stubbed to succeed → `done. Try:`. Both confirmed by running the script.

Workspace: **817 tests passed**, clippy zero errors under `--locked`, rustfmt clean.

## Not fixed here

I could not establish *why* that MacBook's port 34334 refused — port already held, or the macOS firewall. The retry makes the first self-healing and `agent status` makes either visible, but if it recurs, `peer channel:` in `agent status` plus the agent log will now name it.