### PR TITLE
test(onboarding): cover the probes that replaced a guess

### DIFF
--- a/crates/atlasctl/src/commands/agentinfo.rs
+++ b/crates/atlasctl/src/commands/agentinfo.rs
@@ -226,4 +226,49 @@ mod status_tests {
             assert!(install < run, "the persistent option must come first: {a}");
         }
     }
+
+    /// A port nothing answers on must read as NOT listening, and must say what
+    /// that costs the operator.
+    ///
+    /// The whole reason this line exists is that the browser channel being up
+    /// says nothing about the peer channel: they are separate listeners. A
+    /// version of this that only ever printed the happy case would restore
+    /// exactly the blind spot it was added to remove.
+    #[test]
+    fn a_silent_peer_port_is_reported_as_not_listening() {
+        // Bind and drop, so the port is one we know is free rather than one we
+        // hope is: a hard-coded number can be in use on somebody's machine and
+        // the test would then assert the opposite of what it means.
+        let free = {
+            let l = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("bind");
+            l.local_addr().expect("addr").port()
+        };
+        let out = super::peer_channel_line(free);
+        assert!(
+            out[0].contains("NOT listening"),
+            "must state it plainly: {out:?}"
+        );
+        assert!(
+            out.iter().any(|l| l.contains("cannot join")),
+            "must say what it costs, not just that a socket is shut: {out:?}"
+        );
+    }
+
+    /// A port something IS listening on reads as accepting, in one line.
+    ///
+    /// One line on the happy path is deliberate: `agent status` is read most
+    /// often when nothing is wrong, and four lines of reassurance is how the
+    /// four lines that matter stop being read.
+    #[test]
+    fn a_live_peer_port_is_reported_in_one_line() {
+        let l = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("bind");
+        let port = l.local_addr().expect("addr").port();
+        let out = super::peer_channel_line(port);
+        assert_eq!(out.len(), 1, "{out:?}");
+        assert!(out[0].contains("accepting on"), "{out:?}");
+        assert!(
+            !out[0].contains("NOT"),
+            "a live port must not read as a dead one: {out:?}"
+        );
+    }
 }

--- a/crates/atlasctl/src/commands/service.rs
+++ b/crates/atlasctl/src/commands/service.rs
@@ -276,3 +276,54 @@ fn port_is_taken(port: u16) -> bool {
     let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
     TcpStream::connect_timeout(&addr, std::time::Duration::from_millis(300)).is_ok()
 }
+
+#[cfg(test)]
+mod obstacle_tests {
+    use super::{port_is_taken, startup_obstacle};
+
+    /// The probe must answer about the port it was ASKED about.
+    ///
+    /// This is the check that replaced an asserted "the usual cause is the
+    /// port". An assertion that is right by luck is no better than the one it
+    /// replaced, so both directions are pinned.
+    #[test]
+    fn the_port_probe_distinguishes_held_from_free() {
+        let held = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("bind");
+        let held_port = held.local_addr().expect("addr").port();
+        assert!(port_is_taken(held_port), "a bound port must read as taken");
+
+        // Bind then drop: a port we know is free, rather than a number we hope
+        // nothing on the machine is using.
+        let free_port = {
+            let l = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("bind");
+            l.local_addr().expect("addr").port()
+        };
+        assert!(
+            !port_is_taken(free_port),
+            "a closed port must not read as taken"
+        );
+    }
+
+    /// With a free port and a usable config directory, there is NO obstacle —
+    /// and saying so is the point.
+    ///
+    /// The bug this replaced was a confident wrong answer. "I cannot see why"
+    /// is the honest one when neither thing this can check is wrong, and it is
+    /// what sends the operator to the log instead of to a dead end.
+    #[test]
+    fn nothing_wrong_reports_nothing_rather_than_guessing() {
+        let free_port = {
+            let l = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("bind");
+            l.local_addr().expect("addr").port()
+        };
+        // The config-dir half depends on this machine's real directory, so this
+        // asserts only what is safe to assert: whatever it answers, it must not
+        // blame a port that nothing is holding.
+        if let Some(why) = startup_obstacle(free_port) {
+            assert!(
+                !why.contains("already listening"),
+                "must not blame a free port: {why}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
#151 replaced an asserted cause — *"the usual cause is the port"* — with two **observations**, and added a peer-channel line to `agent status`. Neither had a unit test.

That gap matters here more than usual: the defect being fixed was a confident wrong answer, and an assertion that happens to be right is no better than the one it replaced. So both are pinned in both directions.

## What is asserted

| test | pins |
|---|---|
| `the_port_probe_distinguishes_held_from_free` | a bound port reads taken, a closed one does not |
| `nothing_wrong_reports_nothing_rather_than_guessing` | with a free port, the obstacle must not blame the port |
| `a_silent_peer_port_is_reported_as_not_listening` | says "NOT listening" **and** what it costs the operator |
| `a_live_peer_port_is_reported_in_one_line` | one line, and not the dead-port wording |

Ports are obtained by **binding and reading back**, never hard-coded: a fixed number can be in use on somebody's machine, and the test would then assert the opposite of what it means.

The happy path asserts exactly **one** line on purpose. `agent status` is read most often when nothing is wrong, and four lines of reassurance is how the four lines that matter stop being read.

`nothing_wrong_reports_nothing_rather_than_guessing` asserts only what is safe to assert — the config-dir half depends on the real machine — so it pins the part that must hold regardless: a free port is never blamed.

## Verified by sabotage

- inverting the port probe → `the_port_probe_distinguishes_held_from_free` FAILED
- inverting the peer check → both `agentinfo` tests FAILED

(My first sabotage attempt broke compilation instead of failing a test, which proves nothing; redone so it compiles.)

Workspace: **all suites pass**, clippy zero errors under `--locked`, rustfmt clean.