### PR TITLE
fix(cache): a nested weight file is still a weight file

### DIFF
--- a/crates/atlasctl-agent/src/launcher/docker/tests.rs
+++ b/crates/atlasctl-agent/src/launcher/docker/tests.rs
@@ -318,3 +318,50 @@ fn a_metadata_only_cache_entry_is_refused_and_named_as_such() {
 
     std::fs::remove_dir_all(&root).ok();
 }
+
+/// A recipe that brings its own weights is NOT refused for a cache miss.
+///
+/// `--model-from-path` points the engine at a directory, so the Hub cache is
+/// never consulted and a "missing model" refusal would block a launch that was
+/// going to work. That escape hatch is the whole reason the guard reads the
+/// rendered argv rather than the model field, and nothing tested it: the guard
+/// could have been tightened later — or the flag renamed — and the only symptom
+/// would be a refusal nobody could explain.
+#[test]
+fn a_recipe_that_brings_its_own_weights_is_not_refused() {
+    let runner = Arc::new(RecordingRunner::new());
+    // A cache with nothing in it at all, so the guard would certainly fire.
+    let mut h = host();
+    h.hf_cache_dir = std::env::temp_dir()
+        .join(format!("atlasctl-byo-weights-{}", std::process::id()))
+        .display()
+        .to_string();
+    let l = DockerLauncher::new(runner.clone(), h, &ROOTLESS_V1, Box::new(NvidiaDevices));
+
+    let r = Recipe::parse(
+        "r",
+        concat!(
+            "model: org/m\n",
+            "container: img:tag\n",
+            "runtime: atlas\n",
+            "defaults:\n",
+            "  port: 8888\n",
+            "  model_from_path: /models/local\n",
+        ),
+        Provenance::Builtin {
+            path: "r.yaml".into(),
+        },
+    )
+    .expect("fixture parses");
+
+    let started = l.launch(&r, &BTreeMap::new()).expect("must not be refused");
+    assert_eq!(started.container, "atlas-r");
+    // The guard is skipped by reading the RENDERED command, so prove the flag
+    // actually reached it — a recipe whose setting was silently dropped would
+    // pass this test for the wrong reason.
+    let ran = runner.calls().concat().join(" ");
+    assert!(
+        ran.contains("--model-from-path"),
+        "the flag must reach the command: {ran}"
+    );
+}

--- a/crates/atlasctl-core/src/hfcache.rs
+++ b/crates/atlasctl-core/src/hfcache.rs
@@ -62,7 +62,20 @@ pub enum CacheState {
 /// Deliberately short: an extension listed here that is NOT weights would make a
 /// metadata-only cache read as complete, which is the exact bug this exists to
 /// prevent.
-const WEIGHT_EXTENSIONS: [&str; 3] = ["safetensors", "bin", "gguf"];
+const WEIGHT_EXTENSIONS: [&str; 5] = ["safetensors", "bin", "gguf", "pt", "pth"];
+
+/// How deep to look inside a snapshot for weights.
+///
+/// Every checkpoint in the cache this was written against is flat — weights sit
+/// directly in the snapshot — but a Hub repo may nest them, and the two possible
+/// mistakes here are not symmetric. Missing a weight file REFUSES a launch that
+/// would have worked, which is the failure the operator cannot argue with.
+/// Finding one the engine then cannot use costs nothing new: that is exactly
+/// what happened before this check existed.
+///
+/// Bounded rather than unbounded so a cache with something enormous mounted
+/// under it cannot turn a preflight check into a directory walk.
+const MAX_SNAPSHOT_DEPTH: usize = 3;
 
 /// Classify what `dir` (from [`hub_dir`]) actually holds.
 pub fn cache_state(dir: &Path) -> CacheState {
@@ -72,25 +85,47 @@ pub fn cache_state(dir: &Path) -> CacheState {
     let Ok(snapshots) = std::fs::read_dir(dir.join("snapshots")) else {
         return CacheState::MetadataOnly;
     };
+    // Any snapshot with weights is enough: a cache holding one complete
+    // revision and one interrupted revision can serve the complete one.
     for snap in snapshots.flatten() {
-        let Ok(entries) = std::fs::read_dir(snap.path()) else {
-            continue;
-        };
-        for entry in entries.flatten() {
-            let path = entry.path();
-            let is_weight = path
-                .extension()
-                .and_then(|e| e.to_str())
-                .is_some_and(|e| WEIGHT_EXTENSIONS.contains(&e));
-            // `metadata` follows the symlink into `blobs/`, so an entry whose
-            // blob was reclaimed reads as absent rather than as a weight file.
-            // A dangling link is exactly what a partially cleaned cache leaves.
-            if is_weight && std::fs::metadata(&path).is_ok() {
-                return CacheState::Weights;
-            }
+        if has_weight_below(&snap.path(), MAX_SNAPSHOT_DEPTH) {
+            return CacheState::Weights;
         }
     }
     CacheState::MetadataOnly
+}
+
+/// Whether a weight file that can actually be read exists at or below `dir`.
+fn has_weight_below(dir: &Path, depth: usize) -> bool {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return false;
+    };
+    let mut dirs = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        // `file_type` does NOT follow symlinks, so a link is examined as a file
+        // below rather than being descended into — which also means a cache
+        // containing a symlink loop cannot spin here.
+        let Ok(ft) = entry.file_type() else { continue };
+        if ft.is_dir() {
+            dirs.push(path);
+            continue;
+        }
+        let is_weight = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|e| WEIGHT_EXTENSIONS.contains(&e));
+        // `metadata` DOES follow the link into `blobs/`, so an entry whose blob
+        // was reclaimed reads as absent rather than as a weight file. A dangling
+        // link is exactly what a partially cleaned cache leaves behind.
+        if is_weight && std::fs::metadata(&path).is_ok() {
+            return true;
+        }
+    }
+    if depth == 0 {
+        return false;
+    }
+    dirs.iter().any(|d| has_weight_below(d, depth - 1))
 }
 
 #[cfg(test)]
@@ -184,6 +219,48 @@ mod tests {
             cache_state(&hub_dir(&tmp, "org/never-fetched").unwrap()),
             CacheState::Absent
         );
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    /// Weights nested inside a snapshot still count.
+    ///
+    /// Every checkpoint in the cache this was written against is flat, so a
+    /// top-level-only scan passed every test and every real model on that
+    /// machine — and would have REFUSED a launch for the first Hub repo that
+    /// nests them. That direction is the one an operator cannot argue with:
+    /// the model is right there and the tool says it is not.
+    #[test]
+    fn a_weight_in_a_subdirectory_still_counts() {
+        let tmp = std::env::temp_dir().join(format!("atlasctl-hf-nested-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        let dir = entry(&tmp, "org/nested", &["config.json"]);
+        let inner = dir.join("snapshots/deadbeef/weights");
+        std::fs::create_dir_all(&inner).expect("mkdir inner");
+        std::fs::write(inner.join("model.safetensors"), b"w").expect("write");
+        assert_eq!(cache_state(&dir), CacheState::Weights);
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    /// ...but not past the depth bound, so this stays a preflight check and
+    /// cannot become a walk of whatever is mounted under the cache.
+    #[test]
+    fn the_search_stops_at_the_depth_bound() {
+        let tmp = std::env::temp_dir().join(format!("atlasctl-hf-deep-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        let dir = entry(&tmp, "org/deep", &["config.json"]);
+        let deep = dir
+            .join("snapshots/deadbeef")
+            .join("a")
+            .join("b")
+            .join("c")
+            .join("d");
+        std::fs::create_dir_all(&deep).expect("mkdir deep");
+        std::fs::write(deep.join("model.safetensors"), b"w").expect("write");
+        assert_eq!(cache_state(&dir), CacheState::MetadataOnly);
 
         std::fs::remove_dir_all(&tmp).ok();
     }


### PR DESCRIPTION
Found auditing #150, in the direction that matters.

## The defect

`cache_state` scanned only the **top level** of a snapshot. A Hub repo that nests its weights would be classified `MetadataOnly`, and the launch **refused** — the model right there on disk, and the tool insisting it is not.

Every checkpoint in the cache this was written against is flat, so the top-level scan passed every test and every real model on that machine. That is exactly how this class of bug survives review.

## Why the fix leans the way it does

The two possible mistakes are not symmetric:

| mistake | cost |
|---|---|
| miss a weight file | **refuses a launch that would have worked** — the operator cannot argue with it and cannot see why |
| find one the engine cannot use | nothing new — precisely what happened before this check existed |

So the search is recursive now, and the extension list is wider (`pt`, `pth` alongside `safetensors`, `bin`, `gguf`). Both changes only ever move a model from *refused* to *attempted*.

## Bounds

- Depth 3, so a preflight check cannot become a walk of whatever is mounted under the cache.
- `file_type()` (which does **not** follow symlinks) decides whether to descend, so a link is examined as a file and a symlink loop cannot spin. `metadata()` still follows links when testing readability, which is what makes a reclaimed blob read as absent.

## Verified by sabotage

With the depth bound at `0` — the old behaviour — `a_weight_in_a_subdirectory_still_counts` FAILS and the flat cases pass.

Workspace: 214 core tests, clippy zero errors under `--locked`, rustfmt clean, and `cargo check --target x86_64-pc-windows-msvc` clean for this crate.