### PR TITLE
feat(doctor): report the listener other machines actually dial

### DIFF
--- a/crates/atlasctl/src/commands/doctor.rs
+++ b/crates/atlasctl/src/commands/doctor.rs
@@ -20,6 +20,7 @@ pub fn run() -> Result<()> {
     for f in [
         check_config_dir(),
         check_agent(),
+        check_peer_channel(),
         check_reachable(),
         check_disk(),
     ] {
@@ -220,6 +221,19 @@ fn check_agent() -> Finding {
     let up =
         std::net::TcpStream::connect_timeout(&addr, std::time::Duration::from_millis(300)).is_ok();
     doctor_checks::agent(up, port)
+}
+
+/// Whether the peer listener — the one other machines dial — is open.
+///
+/// Probed the same way as the browser port, and reported separately, because
+/// the two are separate listeners: the agent can be perfectly healthy for its
+/// own browser while accepting no peers at all.
+fn check_peer_channel() -> Finding {
+    let port = atlasctl_agent::peer::DEFAULT_PEER_PORT;
+    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
+    let up =
+        std::net::TcpStream::connect_timeout(&addr, std::time::Duration::from_millis(300)).is_ok();
+    doctor_checks::peer_channel(up, port)
 }
 
 /// Whether another machine could reach this one.

--- a/crates/atlasctl/src/commands/doctor_checks.rs
+++ b/crates/atlasctl/src/commands/doctor_checks.rs
@@ -164,6 +164,36 @@ pub fn agent(listening: bool, port: u16) -> Finding {
     }
 }
 
+/// Is the listener other machines actually connect to open?
+///
+/// Distinct from [`agent`], which probes the BROWSER port. They are separate
+/// listeners with separate failure modes, and only one of them was ever
+/// checked here — so doctor could report a healthy agent and a dialable
+/// address for a machine that could not accept a single peer.
+///
+/// That combination is worse than either alone: [`reachable`] answers "you
+/// have an address", and an operator reasonably reads the pair as "other
+/// machines can reach me". The address is useless if nothing is listening at
+/// the other end of it.
+///
+/// Not marked a problem when shut. A single-machine install never needs the
+/// peer channel, and doctor turning red for an unused feature is how its red
+/// stops meaning anything.
+#[must_use]
+pub fn peer_channel(listening: bool, port: u16) -> Finding {
+    if listening {
+        Finding::ok("peers", &format!("accepting on {port}"))
+    } else {
+        Finding {
+            line: format!(
+                "{:<9} not listening on {port} — other machines cannot join this one",
+                "peers:"
+            ),
+            problem: false,
+        }
+    }
+}
+
 /// Could another machine dial this one?
 ///
 /// The failure this catches: a laptop on Wi-Fi advertised no address at all,
@@ -264,6 +294,39 @@ mod tests {
         assert!(f.problem);
         assert!(f.line.contains("owned by root"), "{}", f.line);
         assert!(f.line.contains("--config-dir"), "{}", f.line);
+    }
+
+    /// A shut peer channel is REPORTED but is not a problem.
+    ///
+    /// A single-machine install never needs it, and doctor turning red for an
+    /// unused feature is how its red stops meaning anything. It still has to
+    /// appear: the whole reason this check exists is that `agent: ok` plus
+    /// `network: ok` reads as "other machines can reach me", and neither of
+    /// those looks at the port they would actually dial.
+    #[test]
+    fn a_shut_peer_channel_is_reported_without_being_called_a_problem() {
+        let f = peer_channel(false, 34334);
+        assert!(!f.problem, "an unused peer channel is not a fault");
+        assert!(f.line.contains("34334"), "must name the port: {}", f.line);
+        assert!(
+            f.line.contains("cannot join"),
+            "must say what it costs, not just that a socket is shut: {}",
+            f.line
+        );
+    }
+
+    /// An open one says so, and names the port, so the two findings can be told
+    /// apart in a transcript pasted into an issue.
+    #[test]
+    fn an_open_peer_channel_names_its_port() {
+        let f = peer_channel(true, 34334);
+        assert!(!f.problem);
+        assert!(f.line.contains("34334"), "{}", f.line);
+        assert!(
+            !f.line.contains("cannot"),
+            "an open channel must not read as a shut one: {}",
+            f.line
+        );
     }
 
     /// An operator running `doctor` before installing anything has no fault.


### PR DESCRIPTION
## The blind spot

`doctor` checked the **browser** port and the machine's **addresses**, and nothing in between.

Those two together read as "other machines can reach me":

```
agent:    ok (listening on 127.0.0.1:34333)
network:  ok (10.10.10.9 on enp1s0f0np0, and 2 more)
```

...for a machine that cannot accept a single peer, because the port those addresses point at is a **separate listener** that neither check looks at. `reachable`'s own doc says it answers "could another machine dial this one?" — but an address is useless if nothing is listening at the other end of it.

That is exactly the state behind a `Connection refused` for somebody following a join command this machine printed — and `doctor` is what an operator runs when onboarding fails.

## After

```
agent:    ok (listening on 127.0.0.1:34333)
peers:    ok (accepting on 34334)
network:  ok (10.10.10.9 on enp1s0f0np0, and 2 more)
```

Placed next to the agent check rather than beside `network`, so the two listeners read as a pair.

## Reported, not red

A shut peer channel is **not** marked a problem. A single-machine install never needs it, and doctor turning red for an unused feature is how its red stops meaning anything. The line still has to appear — the absence of any line is what let the blind spot exist in the first place.

## Verified

Run against this machine (output above), and by sabotage: inverting the condition fails both new tests.

Workspace: 376 + 212 + 161 tests, clippy zero errors under `--locked`, rustfmt clean.

Follows #151, which gave `agent status` the same fact.