### PR TITLE
fix(join): stop blaming the code when nothing answered

### DIFF
--- a/crates/atlasctl-agent/src/peer/reach.rs
+++ b/crates/atlasctl-agent/src/peer/reach.rs
@@ -26,6 +26,33 @@ use std::io::ErrorKind;
 /// Errs toward `false`: an unrecognised failure stops the walk. Giving up one
 /// address early is a worse message; giving up an attempt is a lockout.
 #[must_use]
+/// Attached to a [`walk`] failure when NO address was ever reached.
+///
+/// The distinction is not cosmetic. A caller that never reached the far machine
+/// never presented its credentials either — so a pairing code is untouched, and
+/// telling the operator to mint a fresh one sends them to redo the one step
+/// that was not the problem. That is exactly the dead end a real onboarding
+/// transcript ended in.
+///
+/// Carried as an error source rather than sniffed out of a message, so the rule
+/// stays in [`never_reached`] and cannot drift into a second copy.
+#[derive(Debug)]
+pub struct NeverReached;
+
+impl std::fmt::Display for NeverReached {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("no address answered")
+    }
+}
+
+impl std::error::Error for NeverReached {}
+
+/// Whether this error carries [`NeverReached`].
+#[must_use]
+pub fn was_never_reached(err: &anyhow::Error) -> bool {
+    err.chain().any(|c| c.is::<NeverReached>())
+}
+
 pub fn never_reached(err: &anyhow::Error) -> bool {
     err.chain().any(|cause| {
         cause.downcast_ref::<std::io::Error>().is_some_and(|io| {
@@ -61,17 +88,23 @@ where
     F: FnMut(std::net::SocketAddr) -> anyhow::Result<T>,
 {
     let mut why: Vec<String> = Vec::new();
+    // Every failure so far was a failure to REACH, not a refusal by the far end.
+    let mut all_unreachable = true;
     for addr in addrs {
         match dial(*addr) {
             Ok(v) => return Ok((*addr, v)),
             Err(e) => {
                 let keep_going = never_reached(&e);
+                all_unreachable &= keep_going;
                 why.push(format!("{addr}: {e:#}"));
                 if !keep_going {
                     break;
                 }
             }
         }
+    }
+    if all_unreachable {
+        return Err(anyhow::Error::new(NeverReached).context(why.join("; ")));
     }
     anyhow::bail!("{}", why.join("; "))
 }
@@ -95,17 +128,23 @@ where
     Fut: std::future::Future<Output = anyhow::Result<T>>,
 {
     let mut why: Vec<String> = Vec::new();
+    // Every failure so far was a failure to REACH, not a refusal by the far end.
+    let mut all_unreachable = true;
     for addr in addrs {
         match dial(*addr).await {
             Ok(v) => return Ok((*addr, v)),
             Err(e) => {
                 let keep_going = never_reached(&e);
+                all_unreachable &= keep_going;
                 why.push(format!("{addr}: {e:#}"));
                 if !keep_going {
                     break;
                 }
             }
         }
+    }
+    if all_unreachable {
+        return Err(anyhow::Error::new(NeverReached).context(why.join("; ")));
     }
     anyhow::bail!("{}", why.join("; "))
 }
@@ -166,6 +205,43 @@ mod tests {
         // every failure as a refusal and stop after one address.
         let e = io(ErrorKind::ConnectionRefused).context("dialling 10.10.10.9:34334");
         assert!(never_reached(&e));
+    }
+
+    /// A walk where nothing ever answered is tagged, so the caller can say the
+    /// code is untouched instead of telling the operator to mint a new one.
+    ///
+    /// This is the distinction a real onboarding transcript died on: a
+    /// `Connection refused` was reported as "the code expires, and is good for
+    /// one machine only", so the next thing tried was a fresh code — the one
+    /// step that was not the problem.
+    #[test]
+    fn a_walk_that_reached_nothing_is_tagged_as_such() {
+        let out = super::walk(&[a(9), a(13)], |addr| -> anyhow::Result<()> {
+            Err(anyhow::Error::new(std::io::Error::new(
+                std::io::ErrorKind::ConnectionRefused,
+                format!("nothing at {addr}"),
+            )))
+        });
+        let e = out.expect_err("nothing answered");
+        assert!(
+            super::was_never_reached(&e),
+            "an all-refused walk must be tagged: {e:#}"
+        );
+    }
+
+    /// A walk that DID reach a machine which then refused is not tagged: there
+    /// the credentials were presented, so the code really may be spent.
+    #[test]
+    fn a_walk_that_was_answered_is_not_tagged() {
+        let out = super::walk(&[a(9)], |_| -> anyhow::Result<()> {
+            // No io::Error in the chain: the far end answered and said no.
+            Err(anyhow::anyhow!("that code has already been used"))
+        });
+        let e = out.expect_err("refused");
+        assert!(
+            !super::was_never_reached(&e),
+            "a refusal by the far end must not read as unreachable: {e:#}"
+        );
     }
 
     #[test]

--- a/crates/atlasctl/src/commands/service.rs
+++ b/crates/atlasctl/src/commands/service.rs
@@ -169,9 +169,35 @@ fn join_fleet(join: &crate::joinarg::Join, grant_control: bool) -> Result<()> {
         ))
     })
     .map_err(|e| {
-        anyhow::anyhow!(
-            "could not join the fleet. The code expires, and is good for one machine only — mint a fresh one if this is not the first try.\n  {e:#}"
-        )
+        // Blaming the code when nothing ever answered sends the operator to
+        // redo the one step that was not the problem. A refused or timed-out
+        // dial means this machine never presented the code at all, so it is
+        // still good — what is wrong is on the OTHER machine, and that is
+        // where the next command has to be run.
+        if atlasctl_agent::peer::reach::was_never_reached(&e) {
+            anyhow::anyhow!(
+                concat!(
+                    "could not reach that machine — nothing answered on its peer port.\n",
+                    "  {e:#}\n",
+                    "The code was never presented, so it is still good: do not mint a new one.\n",
+                    "On THAT machine, check the `peers:` line of:\n",
+                    "    atlasctl doctor\n",
+                    "A peer channel that is not listening is the usual cause. It retries, so ",
+                    "something else may still be holding the port.",
+                ),
+                e = e
+            )
+        } else {
+            anyhow::anyhow!(
+                concat!(
+                    "could not join the fleet. It answered, so the code is the likely ",
+                    "problem — it expires, and is good for one machine only. Mint a fresh ",
+                    "one if this is not the first try.\n",
+                    "  {e:#}",
+                ),
+                e = e
+            )
+        }
     })?;
 
     atlasctl_agent::fleet::record_pairing(

--- a/crates/atlasctl/src/commands/service.rs
+++ b/crates/atlasctl/src/commands/service.rs
@@ -168,37 +168,7 @@ fn join_fleet(join: &crate::joinarg::Join, grant_control: bool) -> Result<()> {
             &join.code,
         ))
     })
-    .map_err(|e| {
-        // Blaming the code when nothing ever answered sends the operator to
-        // redo the one step that was not the problem. A refused or timed-out
-        // dial means this machine never presented the code at all, so it is
-        // still good — what is wrong is on the OTHER machine, and that is
-        // where the next command has to be run.
-        if atlasctl_agent::peer::reach::was_never_reached(&e) {
-            anyhow::anyhow!(
-                concat!(
-                    "could not reach that machine — nothing answered on its peer port.\n",
-                    "  {e:#}\n",
-                    "The code was never presented, so it is still good: do not mint a new one.\n",
-                    "On THAT machine, check the `peers:` line of:\n",
-                    "    atlasctl doctor\n",
-                    "A peer channel that is not listening is the usual cause. It retries, so ",
-                    "something else may still be holding the port.",
-                ),
-                e = e
-            )
-        } else {
-            anyhow::anyhow!(
-                concat!(
-                    "could not join the fleet. It answered, so the code is the likely ",
-                    "problem — it expires, and is good for one machine only. Mint a fresh ",
-                    "one if this is not the first try.\n",
-                    "  {e:#}",
-                ),
-                e = e
-            )
-        }
-    })?;
+    .map_err(|e| join_failure(&e))?;
 
     atlasctl_agent::fleet::record_pairing(
         &pins,
@@ -301,4 +271,103 @@ fn port_is_taken(port: u16) -> bool {
     use std::net::{Ipv4Addr, SocketAddr, TcpStream};
     let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
     TcpStream::connect_timeout(&addr, std::time::Duration::from_millis(300)).is_ok()
+}
+
+/// Turn a failed join into words the operator can act on.
+///
+/// Extracted so the WORDING is testable. The defect this replaced was entirely
+/// a wording defect — the code was blamed for a failure that never presented
+/// it — and a fix to wording that no test can see is one refactor away from
+/// coming back.
+fn join_failure(e: &anyhow::Error) -> anyhow::Error {
+    // Blaming the code when nothing ever answered sends the operator to redo
+    // the one step that was not the problem. A refused or timed-out dial means
+    // this machine never presented the code at all, so it is still good — what
+    // is wrong is on the OTHER machine, and that is where the next command has
+    // to be run.
+    if atlasctl_agent::peer::reach::was_never_reached(e) {
+        anyhow::anyhow!(
+            concat!(
+                "could not reach that machine — nothing answered on its peer port.\n",
+                "  {e:#}\n",
+                "The code was never presented, so it is still good: do not mint a new one.\n",
+                "On THAT machine, check the `peers:` line of:\n",
+                "    atlasctl doctor\n",
+                "A peer channel that is not listening is the usual cause. It retries, so ",
+                "something else may still be holding the port.",
+            ),
+            e = e
+        )
+    } else {
+        anyhow::anyhow!(
+            concat!(
+                "could not join the fleet. It answered, so the code is the likely ",
+                "problem — it expires, and is good for one machine only. Mint a fresh ",
+                "one if this is not the first try.\n",
+                "  {e:#}",
+            ),
+            e = e
+        )
+    }
+}
+
+#[cfg(test)]
+mod join_failure_tests {
+    use super::join_failure;
+
+    fn unreachable() -> anyhow::Error {
+        anyhow::Error::new(atlasctl_agent::peer::reach::NeverReached)
+            .context("192.168.68.67:34334: Connection refused (os error 111)")
+    }
+
+    /// Nothing answered: the code is exonerated, and the next command is aimed
+    /// at the machine that is actually broken.
+    #[test]
+    fn an_unreachable_target_does_not_blame_the_code() {
+        let msg = format!("{:#}", join_failure(&unreachable()));
+        assert!(msg.contains("still good"), "must exonerate the code: {msg}");
+        assert!(
+            !msg.contains("Mint a fresh"),
+            "must NOT send them to mint a new code — that is the dead end: {msg}"
+        );
+        assert!(
+            msg.contains("doctor"),
+            "must aim the next command at the other machine: {msg}"
+        );
+        assert!(
+            msg.contains("Connection refused"),
+            "must keep the underlying cause: {msg}"
+        );
+    }
+
+    /// Answered and refused: the code IS the likely problem, and saying so is
+    /// correct here. The two branches must not converge on one vague message.
+    #[test]
+    fn a_refusal_by_the_far_end_still_points_at_the_code() {
+        let e = anyhow::anyhow!("that code has already been used");
+        let msg = format!("{:#}", join_failure(&e));
+        assert!(msg.contains("Mint a fresh"), "{msg}");
+        assert!(
+            !msg.contains("still good"),
+            "a spent code must not be called good: {msg}"
+        );
+    }
+
+    /// No run of spaces inside either message.
+    ///
+    /// Written as ordinary string continuations, rustfmt reflows these into the
+    /// message body. That happened to the first draft of this change and to a
+    /// test fixture the same day, and it is invisible in review.
+    #[test]
+    fn neither_message_carries_reflowed_whitespace() {
+        for msg in [
+            format!("{:#}", join_failure(&unreachable())),
+            format!("{:#}", join_failure(&anyhow::anyhow!("refused"))),
+        ] {
+            assert!(
+                !msg.contains("  ") || msg.contains("\n  "),
+                "reflowed whitespace leaked into the message: {msg:?}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
From a real onboarding transcript. The join failed with two things on screen at once that disagree:

```
error: could not join the fleet. The code expires, and is good for one machine
only — mint a fresh one if this is not the first try.
  192.168.68.67:34334: Connection refused (os error 111)
```

A **refused dial means the code was never presented**, so it is untouched. Minting a fresh one redoes the one step that was not the problem — and the next attempt fails identically. That is where the transcript ended.

## The fix

`walk` already classifies "never reached" — `never_reached()` is what decides whether another address is worth trying — but it flattened the `io::Error` into a message, so the caller could not tell the two apart.

It now attaches a `NeverReached` marker to the aggregate, carried as an **error source** rather than sniffed out of text, so the rule stays in one place and cannot drift into a second copy.

The join then says which failure actually happened:

| outcome | what it says |
|---|---|
| nothing answered | the code is still good, **do not** mint a new one; check the `peers:` line of `atlasctl doctor` on the **other** machine |
| answered, then refused | the code is the likely problem, as before |

## A formatting trap worth naming

Both messages are built with `concat!` of explicit lines. Written as ordinary string continuations, rustfmt reflows them into runs of spaces *inside the message* — which it did to the first draft of this change, and to a test fixture earlier today.

## Verified by sabotage

Disabling the tagging fails `a_walk_that_reached_nothing_is_tagged_as_such`. A companion test pins the other direction, so a far-end refusal cannot start reading as unreachable.

Workspace: 379 + 212 + 159 tests, clippy zero errors under `--locked`, rustfmt clean.

Pairs with #155 (`doctor` now reports the `peers:` line this message sends people to).