### PR TITLE
fix(join): say so when minting a code nothing can accept

### DIFF
--- a/crates/atlasctl-agent/src/peer.rs
+++ b/crates/atlasctl-agent/src/peer.rs
@@ -45,10 +45,10 @@ pub const DEFAULT_PEER_PORT: u16 = 34334;
 
 /// Whether this process's peer listener has ever come up, and on which port.
 ///
-/// `0` means "not yet". Written once the listener binds, read by
-/// `atlasctl agent status` through the agent's own status reply, so an operator
-/// can see the one thing that otherwise only shows up as a "Connection refused"
-/// on a DIFFERENT machine: this agent is running, but cannot accept peers.
+/// `0` means "not yet". Written once the listener binds, and read when this
+/// agent is about to promise something that depends on it — minting a join code
+/// being the case that matters, since an unhonourable invitation is discovered
+/// on a DIFFERENT machine as a bare "Connection refused".
 static LISTENING_ON: std::sync::atomic::AtomicU16 = std::sync::atomic::AtomicU16::new(0);
 
 /// Record that the peer listener is accepting on `port`.
@@ -56,11 +56,12 @@ pub fn mark_listener_up(port: u16) {
     LISTENING_ON.store(port, std::sync::atomic::Ordering::Relaxed);
 }
 
-/// The port the peer listener is accepting on, or `None` if it is not up.
+/// The port THIS process's peer listener is accepting on, or `None`.
 ///
-/// Not a probe: a probe from inside this process would also succeed against
-/// somebody ELSE's listener on the same port, which is precisely the case this
-/// is meant to distinguish.
+/// Not a probe, and that is the whole value of it. `atlasctl doctor` and
+/// `agent status` probe the port from outside the agent, which cannot tell our
+/// listener from somebody else's on the same port — useful to an operator, but
+/// not something the agent may rely on when deciding what it can promise.
 #[must_use]
 pub fn listening_on() -> Option<u16> {
     match LISTENING_ON.load(std::sync::atomic::Ordering::Relaxed) {

--- a/crates/atlasctl-agent/src/session/fleet.rs
+++ b/crates/atlasctl-agent/src/session/fleet.rs
@@ -38,6 +38,29 @@ impl Session<'_> {
         let Some(joining) = self.deps.joining else {
             return vec![err(Some(id), AgentError::NotReady)];
         };
+        // A code is an invitation to DIAL this machine's peer port. If our
+        // listener is not up, nobody can accept it — and the operator finds out
+        // on the OTHER machine, after installing there, as a bare "Connection
+        // refused" against an address this agent told them to use.
+        //
+        // Said here rather than refused: the window is a human decision and the
+        // listener retries, so a code minted a moment before the port frees is
+        // still worth having. What was missing is any word of it on the machine
+        // that can actually fix it.
+        //
+        // `listening_on`, not a probe: a probe would also succeed against
+        // whatever else is holding that port, which is the very situation being
+        // warned about.
+        if crate::peer::listening_on().is_none() {
+            eprintln!(
+                concat!(
+                    "warning: minting a join code while this machine's peer channel is ",
+                    "not accepting on {}. Until it is, nothing can complete this join ",
+                    "— the far machine will see \"Connection refused\".",
+                ),
+                crate::peer::DEFAULT_PEER_PORT
+            );
+        }
         match joining.mint(allow_control) {
             Ok(code) => vec![ServerMsg::JoinInvitation {
                 id,


### PR DESCRIPTION
## Two things, one cause

`peer::listening_on()` was added in #151 and **never read** — dead code. Worse, its doc claimed `agent status` consumed it, which is not true: that probes the port from outside the agent. Both corrected here, and the state wired to the consumer that actually needs it.

## The gap it fills

A join code is an invitation to **dial this machine's peer port**. If our listener is not up, nobody can accept it — and the operator finds out on the *other* machine, after installing there, as a bare `Connection refused` against an address this agent told them to use. That is the transcript this whole series came from.

Now the machine that can fix it says so, at the moment it hands out the invitation.

## Said, not refused

The join window is a human decision, and the listener retries (#151), so a code minted a moment before the port frees is still worth having. Refusing would trade one dead end for another. What was missing was any word of it on the machine that can act.

## Why `listening_on` and not a probe

A probe would also succeed against whatever **else** is holding that port — which is the exact situation being warned about. Whether *our* listener is up is the one question only the agent can answer about itself. `doctor` and `agent status` probe from outside on purpose; that is useful to an operator and unsafe for the agent to rely on.

## Formatting

Built with `concat!`. Rust's `\`-continuation does strip the next line's indentation, so the previous form rendered correctly — but rustfmt collapsing a continuation into one physical line is how two strings were mangled earlier today, and `concat!` cannot be reflowed.

Workspace: 377 + 212 + 159 tests, clippy zero errors under `--locked`, rustfmt clean.

Completes the set with #151 (retry + `agent status`), #155 (`doctor`), #156 (stop blaming the code).