### PR TITLE
fix(release): assert the release is one a user can actually install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -648,3 +648,33 @@ jobs:
             exit 1
           fi
           echo "release $TAG shipped on every channel"
+
+      # Job results are not the outcome. The release is cut HIDDEN and promoted
+      # once its assets are attached, so every job above can succeed and still
+      # leave a release nobody can install: a prerelease is skipped by
+      # `releases/latest`, which is exactly what `install.sh` resolves. Assert
+      # the state a user actually meets, not the states we passed through.
+      - name: and it must be the release a user gets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+        run: |
+          set -eu
+          rel="repos/$GITHUB_REPOSITORY/releases/tags/$TAG"
+          pre=$(gh api "$rel" --jq .prerelease)
+          n=$(gh api "$rel" --jq '.assets|length')
+          latest=$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq .tag_name)
+          echo "prerelease=$pre assets=$n latest=$latest"
+          if [ "$pre" != false ]; then
+            echo "::error::$TAG is still a prerelease, so releases/latest skips it and install.sh cannot see it"
+            exit 1
+          fi
+          if [ "$n" -eq 0 ]; then
+            echo "::error::$TAG has no assets"
+            exit 1
+          fi
+          if [ "$latest" != "$TAG" ]; then
+            echo "::error::releases/latest is $latest, not $TAG — an install now would fetch the wrong version"
+            exit 1
+          fi
+          echo "$TAG is the release a user gets"


### PR DESCRIPTION
`verify-published` asserted that every publish job **succeeded**. Since #148 that is no longer the same question as whether anything shipped.

A release is now cut **hidden** — marked prerelease — and promoted once its assets are attached. `releases/latest` skips prereleases, and `releases/latest` is exactly what `install.sh` resolves.

So every job in the run can succeed while leaving a release nobody can install, if the promote step is ever removed, skipped, or reordered. The job whose stated purpose is:

> Twice now a release run reported success while every publish job was skipped. A green run that shipped nothing is the failure...

would report success again, for a new reason.

## What it asserts now

The state a user meets, rather than the states we passed through:

- not a prerelease
- has assets
- **is** `releases/latest`

## Verified against the live release, not by inspection

```
v0.6.0 -> prerelease=false assets=15 latest=v0.6.0   exit 0
v0.5.0 -> releases/latest is v0.6.0, not v0.5.0      exit 1
```

It passes for the release users actually get, and fails for one they do not.

Context: #148 introduced the hide/promote pair, and both halves executed correctly on tonight's v0.6.0 — this closes the loop so a future regression in that pair cannot pass unnoticed.