### PR TITLE
fix(nearest): suggest the name the operator half-typed

### DIFF
--- a/crates/atlasctl-core/src/nearest.rs
+++ b/crates/atlasctl-core/src/nearest.rs
@@ -14,6 +14,12 @@
 /// A quarter of the longer of the two names: floored at 2 so a short name still
 /// catches a near miss, and capped at 5 so an unrelated string prints nothing
 /// rather than three wrong guesses.
+/// How much of a name must be typed before a prefix counts as "meant".
+///
+/// Four is enough that `qwen` does not offer three arbitrary recipes while
+/// `qwen3.8-flash-next` finds the one it is the front of.
+const PREFIX_MIN: usize = 4;
+
 const fn max_edits(len: usize) -> usize {
     match len / 4 {
         0 | 1 => 2,
@@ -63,6 +69,18 @@ where
         .into_iter()
         .filter_map(|c| {
             let name = c.as_ref();
+            // An incomplete name is not a typo, and edit distance rejects the
+            // case that happens most: the family without the quant suffix.
+            // `qwen3.8-flash-next` is six edits from `qwen3.8-flash-next-nvfp4`
+            // — past any sane typo threshold — and is the obvious thing to type,
+            // because it is what the model is called. Rank those first: the
+            // operator knows the name, they just did not finish it.
+            //
+            // Length-gated so a stray couple of characters cannot list three
+            // arbitrary recipes with confidence.
+            if typed_len >= PREFIX_MIN && name.len() > typed.len() && name.starts_with(typed) {
+                return Some((0, name.to_string()));
+            }
             let d = edit_distance(typed, name);
             (d <= max_edits(typed_len.max(name.chars().count()))).then(|| (d, name.to_string()))
         })

--- a/crates/atlasctl-core/src/nearest/tests.rs
+++ b/crates/atlasctl-core/src/nearest/tests.rs
@@ -91,3 +91,54 @@ fn the_message_tail_is_empty_when_there_is_nothing_to_suggest() {
         ". Did you mean a, b?"
     );
 }
+
+/// A name the operator did not finish typing must be offered.
+///
+/// This is the case edit distance cannot reach: `qwen3.8-flash-next` is SIX
+/// edits from `qwen3.8-flash-next-nvfp4`, past any threshold that is not also
+/// offering nonsense — and it is the obvious thing to type, because it is what
+/// the model is called. Before this, that typed exactly right returned nothing
+/// at all.
+#[test]
+fn an_unfinished_name_finds_the_recipe_it_is_the_front_of() {
+    let got = super::nearest(
+        "qwen3.8-flash-next",
+        ["qwen3.8-flash-next-nvfp4", "qwen3.6-27b-fp8"],
+    );
+    assert_eq!(got, vec!["qwen3.8-flash-next-nvfp4".to_string()]);
+}
+
+/// Prefix matches come FIRST, because a name half-typed is a stronger signal
+/// than a name mistyped.
+#[test]
+fn a_prefix_outranks_a_mere_typo() {
+    let got = super::nearest("qwen3.6-27b", ["qwen3.6-27b-fp8", "qwen3.6-27c"]);
+    assert_eq!(
+        got.first().map(String::as_str),
+        Some("qwen3.6-27b-fp8"),
+        "{got:?}"
+    );
+}
+
+/// Two characters must not confidently offer three recipes.
+///
+/// The guard is the whole reason this is length-gated: without it every short
+/// string becomes a prefix of something, and the suggestion stops meaning
+/// anything.
+#[test]
+fn a_couple_of_characters_is_not_treated_as_a_name() {
+    let got = super::nearest("qw", ["qwen3.8-flash-next-nvfp4", "qwen3.6-27b-fp8"]);
+    assert!(
+        !got.contains(&"qwen3.8-flash-next-nvfp4".to_string()),
+        "a two-character stub must not claim a 24-character name: {got:?}"
+    );
+}
+
+/// An exact name is not "a prefix of itself" — it resolves, and never reaches
+/// this path. Pinned so the `name.len() > typed.len()` guard cannot be dropped
+/// as redundant.
+#[test]
+fn an_exact_name_is_not_suggested_against_itself() {
+    let got = super::nearest("qwen3.6-27b-fp8", ["qwen3.6-27b-fp8"]);
+    assert_eq!(got, vec!["qwen3.6-27b-fp8".to_string()], "{got:?}");
+}


### PR DESCRIPTION
Found by typing what a user would actually type. After tonight's Flash-Next work, the obvious command is:

```
atlasctl run qwen3.8-flash-next
```

The answer was `no recipe named 'qwen3.8-flash-next'` — full stop. Meanwhile `qwen3.8-flash-next-nvfp4` is in the corpus, and the typed name is an **exact prefix** of it.

## Why edit distance could not reach it

`-nvfp4` is **six edits**, past any threshold that is not also offering nonsense. But this is not a typo — it is an **incomplete name**, and it is the commonest one to type, because the prefix is what the model is *called*. The suffix is a quantisation the operator has no reason to remember.

## The change

Prefix matches rank **first**, ahead of typos: a name half-typed is a stronger signal than a name mistyped.

Length-gated at four characters, which is what keeps it meaningful — without the gate every short string is a prefix of something and the suggestion stops carrying information. Pinned by a test: `qw` must not claim a 24-character name.

## Verified by sabotage

Making the gate unreachable fails `an_unfinished_name_finds_the_recipe_it_is_the_front_of` and `a_prefix_outranks_a_mere_typo`.

(My first sabotage attempt deleted the block instead, which broke the build rather than failing a test — that proves nothing, so I redid it.)

## Now

```
error: no recipe named `qwen3.8-flash-next`. Did you mean qwen3.8-flash-next-nvfp4?
```

Workspace: 380 + 218 + 168 tests, clippy zero errors under `--locked`, rustfmt clean.