### PR TITLE
docs(releasing): how to un-hide a release the pipeline left hidden

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -86,6 +86,34 @@ attached to it — and is kept afterwards only as a recovery path. Delete it, an
 revoke `CARGO_REGISTRY_TOKEN`, once `release.yml` has published cleanly at least
 once.
 
+### A release left hidden
+
+A release is created as a **prerelease** and promoted once its assets are
+attached, so that `releases/latest` — which `install.sh` resolves — keeps
+serving the previous, complete release while the matrix builds. If the run dies
+between those two points, the new release stays hidden.
+
+That is the safer of the two failures: installs go on working. It is also loud,
+because `verify-published` asserts the end state and fails the run.
+
+**The recovery dispatch does not un-hide it, deliberately.** Re-running
+`release.yml` with a `tag` input uploads assets but leaves `cut=false`, so it
+neither hides nor promotes — that guard is what stops a recovery of an OLD tag
+dragging `releases/latest` backwards onto it. The trade is that a stuck release
+needs one manual step:
+
+```sh
+id=$(gh api repos/:owner/:repo/releases/tags/vX.Y.Z --jq .id)
+gh api -X PATCH repos/:owner/:repo/releases/$id -F prerelease=false -f make_latest=true
+```
+
+Do that only when the release genuinely has its assets — check first, because
+un-hiding an empty one recreates the 404 the hiding exists to prevent:
+
+```sh
+gh api repos/:owner/:repo/releases/tags/vX.Y.Z --jq '.assets|length'
+```
+
 ## Version history baseline
 
 `v0.1.0` is tagged at the commit the bootstrap workflow published from


### PR DESCRIPTION
Found tracing the release path for ordering faults.

## The dangerous case is guarded

`cut=true` is set **only** on the release-please path, and both the hide and the promote are gated on it. So a `workflow_dispatch` recovery — which re-publishes an *old* tag — can never drag `releases/latest` backwards onto it. Concurrency (`group: release-${{ github.ref }}`, no cancel) serialises runs, so two releases cannot interleave either.

That is all correct. But it has a consequence nothing wrote down.

## The gap

If a run dies **between** hiding a release and promoting it, the release stays hidden. And the recovery dispatch will not un-hide it, because it deliberately runs with `cut=false` — the same guard that protects `latest`.

Someone hitting that would re-dispatch, watch it upload assets, and still find the release invisible, with nothing explaining why.

The state itself is fine: it is the safer of the two failures (installs keep resolving to the previous complete release), and it is loud (`verify-published` fails the run, since #163). What was missing is the one manual step out of it — and the check that must come **first**, because un-hiding a release with no assets recreates the exact 404 the hiding exists to prevent.

Commands verified against the live `v0.6.1` rather than written from memory.