### PR TITLE
test(recipes): a recipe that does not parse must fail the build

### DIFF
--- a/crates/atlasctl-core/tests/golden.rs
+++ b/crates/atlasctl-core/tests/golden.rs
@@ -105,6 +105,40 @@ fn render(recipe: &Recipe) -> String {
     out
 }
 
+/// Every recipe in the corpus must parse.
+///
+/// Nothing asserted this, and three separate things conspire to hide a recipe
+/// that does not: the golden test below SKIPS it (`let Ok(recipe) = … else
+/// continue`), `atlasctl list` omits it, and `show` is the only command that
+/// says why. So a malformed recipe is invisible — CI green, the listing one
+/// short, and no message anywhere.
+///
+/// That is not hypothetical. An open pull request has sat for six weeks adding
+/// three recipes whose `defaults.env` is a map where the schema requires
+/// scalars. They render nothing, list nowhere, and every check passes.
+///
+/// Skipping an unparseable recipe is right for the golden test — it has nothing
+/// to render — but only because THIS test refuses to let one exist.
+#[test]
+fn every_recipe_in_the_corpus_parses() {
+    let mut bad = Vec::new();
+    for e in atlas_recipes_data::all() {
+        let prov = Provenance::Builtin {
+            path: e.path.to_string(),
+        };
+        if let Err(err) = Recipe::parse(e.name, e.yaml, prov) {
+            bad.push(format!("{}: {err:#}", e.path));
+        }
+    }
+    assert!(
+        bad.is_empty(),
+        "{} recipe(s) in the corpus do not parse, so they ship as files that \
+         nothing can load:\n  {}",
+        bad.len(),
+        bad.join("\n  ")
+    );
+}
+
 #[test]
 fn rendered_commands_match_their_goldens() {
     let dir = golden_dir();


### PR DESCRIPTION
Nothing asserted that the recipe corpus parses, and **three** things conspire to hide a recipe that does not:

- the golden test **skips** it — `let Ok(recipe) = … else { continue }` (`golden.rs:120`)
- `atlasctl list` omits it
- `show` is the only command that says why

So a malformed recipe is invisible: CI green, the listing one short, no message anywhere. It ships as a file nothing can load.

## How I found it

Assessing **#11**, open since July. It adds three recipes whose `defaults.env` is a map where the schema requires scalars. They parse as YAML and fail as *recipes* — so every check passes and the listing simply never mentions them.

```
qwen3.6-27b-nvfp4-dflash: could not parse recipe:
  defaults: data did not match any variant of untagged enum ScalarValue at line 60
```

Their header comment records the `env:` block as "VERIFIED 2026-07-13 vs sparkrun" — which is true of sparkrun, and not of this schema. That PR needs a fix regardless; this is about the *silence* around it.

## The fix

One test that parses every recipe in the corpus and names each failure with file, recipe and line.

Skipping an unparseable recipe stays correct in the golden test — it has nothing to render. It is only *safe* because this test now refuses to let one exist.

## Verified

**main's corpus passes today.** I checked that on a clean tree, after a dirty one told me otherwise — my first run failed because leftover files from the #11 merge experiment were still staged, which would have been a false alarm about main.

Sabotage: a probe recipe with `defaults.env` as a map fails the test and names the file, the recipe and the line.