### PR TITLE
fix(atlasctl): name the Docker problem, stop latching it, and match PATH properly

### DIFF
--- a/crates/atlasctl-agent/src/fleet.rs
+++ b/crates/atlasctl-agent/src/fleet.rs
@@ -155,7 +155,25 @@ pub struct LocalFleet {
     /// This machine's own addresses, from the fabric provider.
     local_addresses: Vec<NodeAddress>,
     /// Whether this machine can run a model, and why not if it cannot.
+    ///
+    /// The value the agent computed at startup. It is the answer only until
+    /// `relaunch_probe` supplies a fresher one — see `launchability()`.
     launchability: Launchability,
+    /// Re-runs the capability probe, when the agent gave us one.
+    ///
+    /// Without this the startup answer is permanent, and the commonest reason
+    /// a machine reports "cannot launch" — its owner not being in the `docker`
+    /// group — is also the easiest to fix, and was surviving the fix. An
+    /// operator who ran `usermod -aG docker`, logged back in and reloaded the
+    /// page still saw a machine that could not run models, with no indication
+    /// that the agent needed restarting.
+    relaunch_probe: Option<Box<dyn Fn() -> Launchability + Send + Sync>>,
+    /// Last re-probe and its answer, so a fleet listing does not spawn a
+    /// process per node description.
+    launch_cache: Mutex<Option<(Instant, Launchability)>>,
+    /// How long a re-probe answer is reused. Settable so the refresh interval
+    /// is a property of the deployment rather than a constant nobody can reach.
+    launch_ttl: Duration,
     /// Coarse accelerator tag for display.
     accelerator: String,
     /// Display name for this machine.
@@ -225,6 +243,9 @@ impl LocalFleet {
             pins,
             local_addresses,
             launchability,
+            relaunch_probe: None,
+            launch_cache: Mutex::new(None),
+            launch_ttl: Self::DEFAULT_LAUNCH_TTL,
             accelerator,
             name,
             vitals: None,
@@ -287,10 +308,57 @@ impl LocalFleet {
         self
     }
 
+    /// Supply a probe that can re-answer "can this machine launch?".
+    ///
+    /// Optional so every existing construction — and every test — keeps the
+    /// startup value and stays free of processes.
+    #[must_use]
+    pub fn with_relaunch_probe(
+        mut self,
+        probe: Box<dyn Fn() -> Launchability + Send + Sync>,
+    ) -> Self {
+        self.relaunch_probe = Some(probe);
+        self
+    }
+
+    /// How long a re-probe answer is reused before asking again.
+    ///
+    /// Short enough that fixing Docker heals the page within one refresh;
+    /// long enough that listing a fleet does not run `docker info` per node.
+    pub const DEFAULT_LAUNCH_TTL: Duration = Duration::from_secs(5);
+
+    /// Override how long a re-probe answer is reused.
+    #[must_use]
+    pub const fn with_launch_ttl(mut self, ttl: Duration) -> Self {
+        self.launch_ttl = ttl;
+        self
+    }
+
+    /// This machine's launchability, re-probed if it has gone stale.
+    #[must_use]
+    pub fn launchability(&self) -> Launchability {
+        let Some(probe) = self.relaunch_probe.as_ref() else {
+            return self.launchability.clone();
+        };
+        // A poisoned lock must not make the machine look incapable, so every
+        // failure here falls back to the last good answer rather than to "no".
+        let Ok(mut cache) = self.launch_cache.lock() else {
+            return self.launchability.clone();
+        };
+        if let Some((at, ref cached)) = *cache
+            && at.elapsed() < self.launch_ttl
+        {
+            return cached.clone();
+        }
+        let fresh = probe();
+        *cache = Some((Instant::now(), fresh.clone()));
+        fresh
+    }
+
     /// Whether this machine can run a model.
     #[must_use]
     pub fn can_launch(&self) -> bool {
-        self.launchability.can_launch
+        self.launchability().can_launch
     }
 
     /// This agent's identity.
@@ -449,7 +517,7 @@ impl LocalFleet {
             is_local: true,
             pairing: PairingState::Paired,
             addresses: self.local_addresses.clone(),
-            launchability: self.launchability.clone(),
+            launchability: self.launchability(),
             agent_version: env!("CARGO_PKG_VERSION").to_owned(),
             accelerator: self.accelerator.clone(),
             os: crate::discovery::local_os(),

--- a/crates/atlasctl-agent/src/fleet/tests.rs
+++ b/crates/atlasctl-agent/src/fleet/tests.rs
@@ -465,3 +465,85 @@ fn an_unverified_link_is_usable_but_never_preferred_and_never_warns() {
     assert!(LinkClass::Unverified.rank() < LinkClass::Ethernet.rank());
     assert!(LinkClass::Unverified.rank() > LinkClass::Virtual.rank());
 }
+
+/// A machine that starts unable to launch must not stay that way.
+///
+/// The DGX Spark report this covers: the owner was not in the `docker` group,
+/// the agent probed once at startup, and the browser showed "this machine
+/// cannot run models" as though it were a fact about the hardware. Adding
+/// themselves to the group changed nothing until the agent was restarted, and
+/// nothing told them to restart it.
+mod relaunch_probe {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn a_machine_that_becomes_able_to_launch_is_reported_as_able() {
+        let dir = Tmp::new("relaunch-heals");
+        let calls = Arc::new(AtomicUsize::new(0));
+        let c = Arc::clone(&calls);
+        // First answer is the startup one: refused. Every answer after it is
+        // the operator having fixed their group membership.
+        let fleet = LocalFleet::new(
+            Identity::generate(),
+            PinStore::new(&dir.0),
+            DisplayName::new("spark-256a"),
+            vec![roce("10.10.10.9")],
+            Launchability::no("Docker refused this user".to_owned()),
+            "GB10".to_owned(),
+        )
+        .with_relaunch_probe(Box::new(move || {
+            if c.fetch_add(1, Ordering::SeqCst) == 0 {
+                Launchability::no("Docker refused this user".to_owned())
+            } else {
+                Launchability::yes()
+            }
+        }))
+        // Zero, so the test measures the re-probe rather than the clock. The
+        // caching behaviour has its own test below.
+        .with_launch_ttl(Duration::ZERO);
+
+        assert!(!fleet.can_launch(), "first probe still refuses");
+        assert!(
+            fleet.can_launch(),
+            "after the operator fixed Docker the agent must say so without a restart"
+        );
+    }
+
+    #[test]
+    fn the_answer_is_cached_so_a_listing_does_not_probe_per_node() {
+        let dir = Tmp::new("relaunch-cached");
+        let calls = Arc::new(AtomicUsize::new(0));
+        let c = Arc::clone(&calls);
+        let fleet = fleet_at(&dir.0).with_relaunch_probe(Box::new(move || {
+            c.fetch_add(1, Ordering::SeqCst);
+            Launchability::yes()
+        }));
+        for _ in 0..25 {
+            let _ = fleet.can_launch();
+        }
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "25 reads inside the TTL must cost one probe, not 25 `docker info` spawns"
+        );
+    }
+
+    #[test]
+    fn without_a_probe_the_startup_answer_is_kept_verbatim() {
+        // Every existing construction, and every test, takes this path: no
+        // probe, no processes, no behaviour change.
+        let dir = Tmp::new("relaunch-none");
+        let fleet = LocalFleet::new(
+            Identity::generate(),
+            PinStore::new(&dir.0),
+            DisplayName::new("laptop"),
+            vec![roce("10.10.10.9")],
+            Launchability::no("control-only".to_owned()),
+            "none".to_owned(),
+        );
+        assert!(!fleet.can_launch());
+        assert_eq!(fleet.launchability().reason, "control-only");
+    }
+}

--- a/crates/atlasctl-core/src/docker/diagnose.rs
+++ b/crates/atlasctl-core/src/docker/diagnose.rs
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Telling apart the ways `docker` refuses.
+//!
+//! atlasctl never speaks to the daemon socket directly — it shells out to the
+//! `docker` CLI and reads what comes back. That leaves exactly one signal for
+//! "why did this not work": the CLI's own stderr. Passing that through verbatim
+//! is what produced the report this module exists to answer, where a user on a
+//! working DGX Spark was shown
+//!
+//! ```text
+//! permission denied while trying to connect to the Docker daemon socket
+//! at unix:///var/run/docker.sock
+//! ```
+//!
+//! and left to work out on their own that the fix is a one-time group change.
+//! Worse, the agent's own probe called that case "the docker daemon did not
+//! answer", which is the opposite of what happened: the daemon answered and
+//! refused. That wrong diagnosis then travelled to the browser and was rendered
+//! as a hardware verdict about the machine.
+//!
+//! This is deliberately a pure function over `(status, stderr)`. Classifying is
+//! the part that is easy to get wrong and easy to test; running the process is
+//! neither.
+
+use std::fmt;
+
+/// The canonical place to send someone whose Docker cannot be reached.
+///
+/// Ours rather than Docker's, so the page can carry the DGX Spark specifics and
+/// the "do not use sudo" warning, and link onward for the canonical steps.
+pub const DOCKER_SETUP_DOCS: &str =
+    "https://docs.atlasinference.io/getting-started/troubleshooting.html";
+
+/// Why a `docker` invocation did not succeed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DockerFault {
+    /// No `docker` on PATH at all.
+    NotInstalled,
+    /// The daemon answered and refused this user. Almost always group membership.
+    PermissionDenied,
+    /// Nothing is listening: the daemon is not running, or DOCKER_HOST is wrong.
+    DaemonDown,
+    /// Something else. The raw stderr is carried so it is never swallowed.
+    Other(String),
+}
+
+impl DockerFault {
+    /// Classify a failed `docker` invocation from its exit status and stderr.
+    ///
+    /// Order matters, though not for the reason it first appears to. Docker's
+    /// usual group-denial message says "trying to connect to the Docker daemon
+    /// socket", which the daemon-down patterns below do NOT match, so for that
+    /// one string either order works.
+    ///
+    /// It matters for the clients that print both facts. Several — older
+    /// engines, Docker Desktop's shim, some podman-docker wrappers — emit the
+    /// "Cannot connect to the Docker daemon ... Is the docker daemon running?"
+    /// line and a "permission denied" cause together. Classified daemon-first,
+    /// those users are told to start a daemon that is already running. The
+    /// permission check therefore comes first, and `both_phrases_present_...`
+    /// below pins it with exactly such a string.
+    pub fn classify(stderr: &str) -> Self {
+        let s = stderr.to_ascii_lowercase();
+
+        if s.contains("permission denied") || s.contains("permissiondenied") {
+            return Self::PermissionDenied;
+        }
+        // The shell's phrasing and the OS's, since atlasctl may be invoked
+        // where `docker` is genuinely absent rather than merely unreachable.
+        if s.contains("command not found")
+            || s.contains("no such file or directory")
+            || s.contains("executable file not found")
+            || s.contains("is not recognized as an internal or external command")
+        {
+            return Self::NotInstalled;
+        }
+        if s.contains("cannot connect to the docker daemon")
+            || s.contains("is the docker daemon running")
+            || s.contains("connection refused")
+            || s.contains("docker_host")
+        {
+            return Self::DaemonDown;
+        }
+        Self::Other(stderr.trim().to_owned())
+    }
+
+    /// A one-line statement of what is wrong. No remedy, no URL.
+    ///
+    /// This is what travels over the wire to the browser as the launchability
+    /// reason, so it has to read well inside a sentence someone else wrote.
+    pub fn summary(&self) -> String {
+        match self {
+            Self::NotInstalled => "Docker is not installed, or not on PATH".to_owned(),
+            Self::PermissionDenied => {
+                "Docker refused this user: you are not in the `docker` group".to_owned()
+            }
+            Self::DaemonDown => "the Docker daemon is not running".to_owned(),
+            Self::Other(raw) => format!("Docker failed: {raw}"),
+        }
+    }
+
+    /// The full terminal message: what is wrong, how to fix it, where to read more.
+    ///
+    /// The `sudo` warning is not decoration. The reported user's next move after
+    /// the permission error was `sudo atlasctl`, which appears to work and then
+    /// runs the model as root and leaves root-owned files in `~/.atlas` that the
+    /// unprivileged run afterwards cannot read.
+    pub fn advice(&self) -> String {
+        match self {
+            Self::PermissionDenied => format!(
+                "Docker is installed but this user cannot reach it.\n\
+                 \n\
+                 You are not in the `docker` group. Fix it once:\n\
+                 \n    sudo usermod -aG docker $USER\
+                 \n    newgrp docker          # or log out and back in\n\
+                 \n\
+                 Then re-run. Do NOT use `sudo atlasctl` — it runs the model as\n\
+                 root and leaves root-owned files in ~/.atlas that your normal\n\
+                 user cannot read afterwards.\n\
+                 \n\
+                 {DOCKER_SETUP_DOCS}"
+            ),
+            Self::NotInstalled => format!(
+                "Docker is not installed, or not on PATH.\n\
+                 \n\
+                 `atlasctl run` needs a container engine. `atlasctl list` and\n\
+                 `atlasctl run --print` work without one.\n\
+                 \n\
+                 {DOCKER_SETUP_DOCS}"
+            ),
+            Self::DaemonDown => format!(
+                "Docker is installed but its daemon is not running.\n\
+                 \n\
+                 Start it, then re-run:\n\
+                 \n    sudo systemctl start docker\n\
+                 \n\
+                 {DOCKER_SETUP_DOCS}"
+            ),
+            Self::Other(raw) => format!(
+                "Docker failed and atlasctl does not recognise the error:\n\
+                 \n{raw}\n\
+                 \n{DOCKER_SETUP_DOCS}"
+            ),
+        }
+    }
+}
+
+impl fmt::Display for DockerFault {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.summary())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The exact string Docker emits for the group case, from the user report.
+    const REAL_PERMISSION_DENIED: &str = "Got permission denied while trying to connect to the \
+         Docker daemon socket at unix:///var/run/docker.sock: Get \
+         \"http://%2Fvar%2Frun%2Fdocker.sock/v1.47/info\": dial unix \
+         /var/run/docker.sock: connect: permission denied";
+
+    /// The exact string Docker emits when nothing is listening.
+    const REAL_DAEMON_DOWN: &str = "Cannot connect to the Docker daemon at \
+         unix:///var/run/docker.sock. Is the docker daemon running?";
+
+    #[test]
+    fn the_reported_permission_error_is_classified_as_a_permission_problem() {
+        assert_eq!(
+            DockerFault::classify(REAL_PERMISSION_DENIED),
+            DockerFault::PermissionDenied
+        );
+    }
+
+    #[test]
+    fn both_phrases_present_still_means_permission_not_a_dead_daemon() {
+        // This is the case the check ORDER exists for, and the reason the
+        // ordering is testable at all: a client that reports both facts in one
+        // stderr. Classified daemon-first, the operator is told to start a
+        // daemon that is already running.
+        //
+        // Written as a test after the first attempt at this file asserted the
+        // ordering against REAL_PERMISSION_DENIED — which does not contain the
+        // daemon-down phrasing, so reversing the checks left it passing and the
+        // "control" proved nothing.
+        let both = "Cannot connect to the Docker daemon at unix:///var/run/docker.sock. \
+                    Is the docker daemon running?: dial unix /var/run/docker.sock: \
+                    connect: permission denied";
+        assert_eq!(DockerFault::classify(both), DockerFault::PermissionDenied);
+    }
+
+    #[test]
+    fn a_genuinely_dead_daemon_is_still_reported_as_one() {
+        assert_eq!(
+            DockerFault::classify(REAL_DAEMON_DOWN),
+            DockerFault::DaemonDown
+        );
+    }
+
+    #[test]
+    fn a_missing_binary_is_told_apart_from_an_unreachable_one() {
+        for s in [
+            "docker: command not found",
+            "exec: \"docker\": executable file not found in $PATH",
+            "'docker' is not recognized as an internal or external command",
+        ] {
+            assert_eq!(DockerFault::classify(s), DockerFault::NotInstalled, "{s}");
+        }
+    }
+
+    #[test]
+    fn an_unrecognised_error_keeps_its_text_rather_than_being_swallowed() {
+        let f = DockerFault::classify("  toomanyrequests: rate limit exceeded  ");
+        assert_eq!(
+            f,
+            DockerFault::Other("toomanyrequests: rate limit exceeded".to_owned())
+        );
+        // And it still reaches the operator.
+        assert!(f.advice().contains("rate limit exceeded"));
+    }
+
+    #[test]
+    fn classification_is_case_insensitive() {
+        assert_eq!(
+            DockerFault::classify("PERMISSION DENIED"),
+            DockerFault::PermissionDenied
+        );
+    }
+
+    #[test]
+    fn the_permission_advice_carries_the_fix_the_warning_and_the_link() {
+        let a = DockerFault::PermissionDenied.advice();
+        assert!(
+            a.contains("usermod -aG docker"),
+            "must name the one-time fix"
+        );
+        assert!(a.contains("newgrp docker"), "must say how to apply it now");
+        assert!(
+            a.contains("sudo atlasctl"),
+            "must warn against the obvious wrong move"
+        );
+        assert!(a.contains(DOCKER_SETUP_DOCS), "must link the docs");
+    }
+
+    #[test]
+    fn no_summary_claims_the_daemon_was_silent_when_it_answered() {
+        // The original defect, as an assertion: the permission case must never
+        // be described as the daemon failing to answer.
+        let s = DockerFault::PermissionDenied.summary().to_ascii_lowercase();
+        assert!(!s.contains("did not answer"));
+        assert!(!s.contains("not running"));
+        assert!(s.contains("group"));
+    }
+
+    #[test]
+    fn every_variant_has_a_nonempty_summary_and_advice() {
+        // Guards against a new variant landing with an empty arm.
+        for f in [
+            DockerFault::NotInstalled,
+            DockerFault::PermissionDenied,
+            DockerFault::DaemonDown,
+            DockerFault::Other("x".into()),
+        ] {
+            assert!(!f.summary().is_empty(), "{f:?}");
+            assert!(
+                f.advice().len() > f.summary().len(),
+                "{f:?} advice adds nothing"
+            );
+        }
+    }
+}

--- a/crates/atlasctl-core/src/docker/mod.rs
+++ b/crates/atlasctl-core/src/docker/mod.rs
@@ -4,11 +4,13 @@
 
 pub mod collective;
 pub mod command;
+pub mod diagnose;
 pub mod profile;
 pub mod quote;
 pub mod translate;
 
 pub use collective::{CollectiveEnv, NcclRoce, NoCollectiveEnv};
 pub use command::{DockerCommand, UserSpec};
+pub use diagnose::{DOCKER_SETUP_DOCS, DockerFault};
 pub use profile::{AmdDevices, DeviceProfile, LaunchProfile, NvidiaDevices, ROOTLESS_V1};
 pub use translate::{LaunchContext, LaunchPlan, Placement, TranslateError, translate};

--- a/crates/atlasctl/src/commands/agent.rs
+++ b/crates/atlasctl/src/commands/agent.rs
@@ -8,6 +8,7 @@ use anyhow::{Context, Result};
 use atlasctl_agent::launcher::DockerLauncher;
 use atlasctl_agent::server::AgentState;
 use atlasctl_agent::token;
+use atlasctl_core::docker::DockerFault;
 use atlasctl_core::docker::profile::{NvidiaDevices, ROOTLESS_V1};
 use atlasctl_core::io::{ProcessRunner, StdProcessRunner};
 use std::sync::Arc;
@@ -73,11 +74,17 @@ impl atlasctl_agent::fleet::FleetView for FleetHandle {
 fn probe_can_launch(runner: &dyn ProcessRunner) -> Result<(), String> {
     match runner.run(&atlasctl_agent::fleet::docker_probe_argv()) {
         Ok(out) if out.success() => Ok(()),
-        Ok(out) => Err(format!(
-            "the docker daemon did not answer: {}",
-            out.stderr.trim()
-        )),
-        Err(e) => Err(format!("docker is not available: {e}")),
+        // Classified rather than passed through. This string is what the
+        // browser renders when it says a machine cannot run models, and the
+        // previous wording — "the docker daemon did not answer" — was wrong for
+        // the commonest case by far: a user not in the `docker` group, where
+        // the daemon answers and refuses. Being told the daemon is down sends
+        // them to restart a service that is running, and the site turned it
+        // into a verdict about the hardware.
+        Ok(out) => Err(DockerFault::classify(&out.stderr).summary()),
+        // The runner itself could not spawn the process, so there is no stderr
+        // to classify: `docker` is not there.
+        Err(e) => Err(format!("{}: {e}", DockerFault::NotInstalled.summary())),
     }
 }
 
@@ -149,6 +156,10 @@ pub fn run(args: &AgentRunArgs) -> Result<()> {
         Ok(()) => atlasctl_protocol::fleet::Launchability::yes(),
         Err(why) => atlasctl_protocol::fleet::Launchability::no(why.clone()),
     };
+    // The closure below needs the startup answer for --client mode, where
+    // there is nothing to re-probe; `launchability` itself is moved into the
+    // fleet.
+    let launchability_seed = launchability.clone();
     eprintln!("node identity: {}", identity.id().short());
     eprintln!(
         "{}",
@@ -228,6 +239,26 @@ pub fn run(args: &AgentRunArgs) -> Result<()> {
         accelerator.clone(),
     )
     .with_vitals(Box::new(vitals))
+    // Re-answer "can this machine launch?" instead of trusting the value
+    // probed at startup. The commonest reason a Spark reports that it cannot —
+    // its owner not being in the `docker` group — is a one-line fix, and
+    // before this the fix did not take effect until the agent was restarted,
+    // which nothing told the operator to do. In --client mode the refusal is a
+    // policy, not a probe result, so it is left alone.
+    .with_relaunch_probe({
+        let runner = Arc::clone(&runner);
+        let client_mode = args.client;
+        let initial = launchability_seed.clone();
+        Box::new(move || {
+            if client_mode {
+                return initial.clone();
+            }
+            match probe_can_launch(runner.as_ref()) {
+                Ok(()) => atlasctl_protocol::fleet::Launchability::yes(),
+                Err(why) => atlasctl_protocol::fleet::Launchability::no(why),
+            }
+        })
+    })
     .with_running(Box::new(atlasctl_agent::fleet::DockerRunning(Arc::clone(
         &runner,
     ))))

--- a/crates/atlasctl/src/commands/doctor.rs
+++ b/crates/atlasctl/src/commands/doctor.rs
@@ -3,6 +3,7 @@
 //! `doctor` — check this machine for problems.
 
 use anyhow::Result;
+use atlasctl_core::docker::DockerFault;
 use atlasctl_core::io::{ProcessRunner, StdProcessRunner};
 
 use super::doctor_checks::{self, ConfigDirState, Finding};
@@ -59,19 +60,26 @@ fn check_docker() -> usize {
             println!("docker:   ok (server {})", out.stdout.trim());
             0
         }
-        Ok(_) => {
-            println!(
-                "docker:   PROBLEM — the docker CLI is present but the daemon did not answer.\n\
-                 \x20         `atlasctl run` needs a working daemon; `recipe list` and\n\
-                 \x20         `run --print` work without one."
-            );
+        // Two buckets used to serve for four causes, and the commonest one —
+        // a user outside the `docker` group — was reported as a daemon that
+        // "did not answer". doctor exists to tell someone what to do next, so
+        // it now prints the classified diagnosis and its remedy.
+        Ok(out) => {
+            let fault = DockerFault::classify(&out.stderr);
+            println!("docker:   PROBLEM — {}", fault.summary());
+            for line in fault.advice().lines() {
+                println!("\x20         {line}");
+            }
             1
         }
-        Err(_) => {
+        Err(e) => {
             println!(
-                "docker:   PROBLEM — no docker on PATH. `atlasctl run` needs docker and the\n\
-                 \x20         NVIDIA container runtime; inspection commands work without them."
+                "docker:   PROBLEM — {} ({e})",
+                DockerFault::NotInstalled.summary()
             );
+            for line in DockerFault::NotInstalled.advice().lines() {
+                println!("\x20         {line}");
+            }
             1
         }
     }

--- a/crates/atlasctl/src/commands/run.rs
+++ b/crates/atlasctl/src/commands/run.rs
@@ -7,6 +7,7 @@ use crate::hostinfo;
 use crate::validate;
 use anyhow::{Result, bail};
 use atlasctl_core::chain::UserConfig;
+use atlasctl_core::docker::DockerFault;
 use atlasctl_core::docker::collective::NcclRoce;
 use atlasctl_core::docker::profile::{NvidiaDevices, ROOTLESS_V1};
 use atlasctl_core::docker::translate::{LaunchContext, translate};
@@ -167,8 +168,14 @@ pub fn run(args: &RunArgs) -> Result<()> {
     let argv = plan.docker.to_argv();
     let out = runner.run(&argv)?;
     if !out.success() {
+        // The raw stderr on its own is what a DGX Spark owner was left holding
+        // when the only thing wrong was their group membership. Lead with the
+        // diagnosis and the fix; keep the raw text underneath, because a
+        // message that hides what actually happened is its own kind of unhelpful.
+        let fault = DockerFault::classify(&out.stderr);
         bail!(
-            "`docker run` failed with status {}:\n{}",
+            "{}\n\n`docker run` exited {} with:\n{}",
+            fault.advice(),
             out.status,
             out.stderr.trim()
         );

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -331,6 +331,7 @@ check_sparkrun() {
 
 do_uninstall() {
     dir="${ATLASCTL_INSTALL_DIR:-$HOME/.local/bin}"
+    dir=${dir%/}   # so ATLASCTL_INSTALL_DIR=~/.local/bin/ cannot yield dir//atlasctl
     if [ -f "$dir/$BIN_NAME" ]; then
         # The service MUST come out before the binary does. `main` installs the
         # agent service by default, and its unit carries Restart=on-failure with
@@ -388,6 +389,25 @@ rc_file() {
 # and the comparison here silently stops matching, handing a fish user an
 # `export PATH=...` line that fails when pasted -- exactly the defect the
 # sentinel was added to prevent, reintroduced without a failing test.
+# Is a directory already on PATH, allowing for a trailing slash?
+#
+# `case ":$PATH:" in *":$dir:"*` looked exact and was not: a PATH entry of
+# `/home/u/.local/bin/` does not match `/home/u/.local/bin`, so an operator who
+# already had the directory on PATH was told to add it again. Following that
+# advice appends a second, duplicate entry -- and it is that duplicate,
+# trailing-slash entry that makes `which` print `/home/u/.local/bin//atlasctl`,
+# which is what someone reported and reasonably read as our bug.
+#
+# Both forms are compared, and $1 is normalised first so a caller-supplied
+# ATLASCTL_INSTALL_DIR with a trailing slash behaves the same as without.
+on_path() { # dir -> 0 if already on PATH
+    op_dir=${1%/}
+    case ":$PATH:" in
+        *":$op_dir:"* | *":$op_dir/:"*) return 0 ;;
+    esac
+    return 1
+}
+
 path_advice() { # dir  -- writes the two warn lines
     pa_rc=$(rc_file)
     warn "$1 is not on your PATH. Add it, e.g.:"
@@ -564,17 +584,15 @@ main() {
     tar -xf "$tmp/$archive_name" -C "$tmp"
 
     dir="${ATLASCTL_INSTALL_DIR:-$HOME/.local/bin}"
+    dir=${dir%/}   # so ATLASCTL_INSTALL_DIR=~/.local/bin/ cannot yield dir//atlasctl
     mkdir -p "$dir"
     [ -f "$tmp/$BIN_NAME" ] || die "the archive did not contain $BIN_NAME"
 
     same_version=$(place_binary "$dir" "$tmp")
 
-    case ":$PATH:" in
-        *":$dir:"*) ;;
-        *)
-            path_advice "$dir"
-            ;;
-    esac
+    if ! on_path "$dir"; then
+        path_advice "$dir"
+    fi
 
     check_docker
     check_sparkrun
@@ -584,10 +602,11 @@ main() {
     # `atlasctl` only resolves if its directory is on PATH. Printing the bare
     # name to someone we warned about PATH a few lines ago is a command that
     # fails the moment they paste it, which reads as a broken install.
-    case ":$PATH:" in
-        *":$dir:"*) try="$BIN_NAME" ;;
-        *) try="$dir/$BIN_NAME" ;;
-    esac
+    if on_path "$dir"; then
+        try="$BIN_NAME"
+    else
+        try="$dir/$BIN_NAME"
+    fi
 
     # Do not congratulate a failed run. The old code printed "done. Try:"
     # unconditionally, so an operator whose agent had NOT started read a

--- a/scripts/tests/install-sh.test.sh
+++ b/scripts/tests/install-sh.test.sh
@@ -440,6 +440,40 @@ contains "--join= with an empty value refuses" \
     "$parse_out" "--join= needs a value"
 check "and refusing is non-zero, so a wrapper notices" "1" "$parse_rc"
 
+# --- PATH membership, with and without a trailing slash -----------------------
+# A DGX Spark owner reported `which atlasctl` printing
+# `/home/user/.local/bin//atlasctl`. The doubled slash is not ours — `which`
+# joins the PATH ENTRY with `/name`, so the trailing slash was already in their
+# PATH. But `on_path` used to compare only the exact form, so that operator was
+# told to add a directory they already had; following the advice appends the
+# duplicate entry that produces exactly what they saw.
+( . "$WORK/lib.sh"
+  PATH="/usr/bin:/home/u/.local/bin:/bin" on_path "/home/u/.local/bin" ) \
+    && ok "an exact PATH entry is recognised" \
+    || { fail=$((fail+1)); printf '  FAIL %s\n' "an exact PATH entry is recognised"; }
+
+( . "$WORK/lib.sh"
+  PATH="/usr/bin:/home/u/.local/bin/:/bin" on_path "/home/u/.local/bin" ) \
+    && ok "a PATH entry with a trailing slash is recognised too" \
+    || { fail=$((fail+1)); printf '  FAIL %s\n' "a PATH entry with a trailing slash is recognised too"; }
+
+( . "$WORK/lib.sh"
+  PATH="/usr/bin:/home/u/.local/bin:/bin" on_path "/home/u/.local/bin/" ) \
+    && ok "a caller-supplied dir with a trailing slash is normalised" \
+    || { fail=$((fail+1)); printf '  FAIL %s\n' "a caller-supplied dir with a trailing slash is normalised"; }
+
+# The check must still be able to say no, or it is not a check.
+( . "$WORK/lib.sh"
+  PATH="/usr/bin:/bin" on_path "/home/u/.local/bin" ) \
+    && { fail=$((fail+1)); printf '  FAIL %s\n' "a directory genuinely absent from PATH is reported absent"; } \
+    || ok "a directory genuinely absent from PATH is reported absent"
+
+# And a near-miss must not count as a match, or every prefix would.
+( . "$WORK/lib.sh"
+  PATH="/usr/bin:/home/u/.local/binaries:/bin" on_path "/home/u/.local/bin" ) \
+    && { fail=$((fail+1)); printf '  FAIL %s\n' "a directory that merely shares a prefix is not a match"; } \
+    || ok "a directory that merely shares a prefix is not a match"
+
 printf '\n  %d passed, %d failed\n' "$pass" "$fail"
 # Explicit, not inherited. `[ "$fail" -eq 0 ]` as the last command happens to
 # be right here, but the PowerShell counterpart made exactly this mistake —


### PR DESCRIPTION
Two DGX Spark owners could not run a model. Both hit the same underlying problem — the user is not in the `docker` group — and neither was told so.

**User A** ran `atlasctl run <recipe>` and got the raw errno and nothing else:
```
permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock
```

**User B** never reached a terminal. The site told them *"This machine cannot run models, and no machine that can is paired yet"* and offered to pair a second machine. Their Spark was fine.

## Three defects

**1. The diagnosis was wrong.** `probe_can_launch` reported *any* non-zero `docker info` as `"the docker daemon did not answer"` — including permission-denied, where the daemon **answered and refused**. That string is exactly what the browser renders as a node's launchability reason, so a one-line group-membership fix was presented to User B as a fact about their hardware, with "pair another machine" as the suggested remedy.

`DockerFault::classify` now tells `NotInstalled` / `PermissionDenied` / `DaemonDown` / `Other` apart from the CLI's stderr. Pure function over `(stderr)`, 9 tests, no I/O.

**2. The remedy was missing.** `docker run` failures `bail!`'d raw stderr into the generic handler. They now lead with the diagnosis and the one-time fix, then still print the raw error underneath:

```
Docker is installed but this user cannot reach it.

You are not in the `docker` group. Fix it once:

    sudo usermod -aG docker $USER
    newgrp docker          # or log out and back in

Then re-run. Do NOT use `sudo atlasctl` — it runs the model as
root and leaves root-owned files in ~/.atlas that your normal
user cannot read afterwards.

https://docs.atlasinference.io/getting-started/troubleshooting.html
```

atlasctl never runs anything privileged itself. `doctor` gets the same treatment.

**3. The answer latched.** `can_launch` was probed once at agent startup and frozen into `launchability`. An operator who ran `usermod -aG docker` and logged back in **still** saw a machine that could not run models, until the agent was restarted — and nothing told them to restart it. `LocalFleet` now re-probes behind a 5 s TTL, so it heals on the next refresh without spawning `docker info` per node in a fleet listing. The TTL is a settable field, not a constant.

## And the `//` report

Someone reported `which atlasctl` printing `/home/user/.local/bin//atlasctl`. **The doubled slash is not ours** — `which` joins the PATH *entry* with `/name`, so the trailing slash was already in their PATH.

But the advice that produces it was ours. `on_path` compared PATH entries exactly, so an operator whose entry already ended in `/` was told to add a directory they already had; following that advice appends the duplicate entry that yields exactly what they saw. It now compares both forms and normalises `ATLASCTL_INSTALL_DIR`.

## Verification

| | |
|---|---|
| `cargo test --workspace` | 11 targets, **0 failures** |
| `cargo clippy --workspace --all-targets` | clean |
| `scripts/tests/install-sh.test.sh` | **71 passed, 0 failed** (5 new) |

Every guard was watched failing first:

| defect reintroduced | result |
|---|---|
| classify daemon-down before permission | `both_phrases_present_…` **FAILS** |
| revert `launchability` to the frozen field | **2 of 3 fail** |
| make the re-probe cache never expire | **1 of 3 fails** |
| revert `on_path` to exact-only comparison | **69 passed, 2 failed** |

One of those controls caught a defect in my own test: the first version asserted the classifier's ordering against a stderr containing only *one* of the two phrasings, so reversing the checks left it green. It now uses a string containing both, and the control fires.

The docs URL points at a troubleshooting page added in the companion `atlas` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01726abFdibR9YTp6URgzVh3
